### PR TITLE
fix: remove `JSONData` generic type arg from `CheerioCrawler`

### DIFF
--- a/test/core/crawlers/cheerio_crawler.test.ts
+++ b/test/core/crawlers/cheerio_crawler.test.ts
@@ -7,7 +7,6 @@ import bodyParser from 'body-parser';
 import type {
     CheerioRequestHandler,
     CheerioCrawlingContext,
-    PrepareRequestInputs,
     ProxyInfo,
     Source,
 } from '@crawlee/cheerio';
@@ -1089,9 +1088,9 @@ describe('CheerioCrawler', () => {
         });
 
         test('uses correct crawling context', async () => {
-            let prepareCrawlingContext: PrepareRequestInputs;
+            let prepareCrawlingContext: CheerioCrawlingContext;
 
-            const prepareRequestFunction = (crawlingContext: PrepareRequestInputs) => {
+            const prepareRequestFunction = (crawlingContext: CheerioCrawlingContext) => {
                 prepareCrawlingContext = crawlingContext;
                 expect(crawlingContext.request).toBeInstanceOf(Request);
                 expect(crawlingContext.crawler.autoscaledPool).toBeInstanceOf(AutoscaledPool);


### PR DESCRIPTION
The type arg is still available in the `CheerioCrawlingContext` but having one for the whole crawler does not make much sense and can be confusing.