### PR TITLE
fix: add `headless` option to `BrowserCrawlerOptions`

### DIFF
--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -248,6 +248,12 @@ export interface BrowserCrawlerOptions<
      * This can only be used when `useSessionPool` is set to `true`.
      */
     persistCookiesPerSession?: boolean;
+
+    /**
+     * Whether to run browser in headless mode. Defaults to `true`.
+     * Can be also set via {@link Configuration}.
+     */
+    headless?: boolean;
 }
 
 /**
@@ -306,7 +312,7 @@ export abstract class BrowserCrawler<
      */
     browserPool: BrowserPool<InternalBrowserPoolOptions>;
 
-    launchContext?: BrowserLaunchContext<LaunchOptions, unknown>;
+    launchContext: BrowserLaunchContext<LaunchOptions, unknown>;
 
     protected userProvidedRequestHandler!: BrowserCrawlerHandleRequest<Context>;
     protected navigationTimeoutMillis: number;
@@ -340,7 +346,7 @@ export abstract class BrowserCrawler<
             requestHandlerTimeoutSecs = 60,
             persistCookiesPerSession,
             proxyConfiguration,
-            launchContext,
+            launchContext = {},
             browserPoolOptions,
             preNavigationHooks = [],
             postNavigationHooks = [],
@@ -352,6 +358,7 @@ export abstract class BrowserCrawler<
 
             failedRequestHandler,
             handleFailedRequestFunction,
+            headless,
             ...basicCrawlerOptions
         } = options;
 
@@ -393,6 +400,11 @@ export abstract class BrowserCrawler<
         this.proxyConfiguration = proxyConfiguration;
         this.preNavigationHooks = preNavigationHooks;
         this.postNavigationHooks = postNavigationHooks;
+
+        if (headless != null) {
+            this.launchContext.launchOptions ??= {} as LaunchOptions;
+            (this.launchContext.launchOptions as Dictionary).headless = headless;
+        }
 
         if (this.useSessionPool) {
             this.persistCookiesPerSession = persistCookiesPerSession !== undefined ? persistCookiesPerSession : true;


### PR DESCRIPTION
It's just a shortcut for `launchContext: { launchOptions: { headless } }`.