### PR TITLE
feat: add support for middlewares to the `Router` via `use` method

### DIFF
--- a/test/core/router.test.ts
+++ b/test/core/router.test.ts
@@ -18,6 +18,9 @@ describe('Router', () => {
         router.addDefaultHandler(async (ctx) => {
             logs.push(`default handled with url ${ctx.request.loadedUrl}`);
         });
+        router.use(({ request }) => void logs.push(`middleware 1: ${request.loadedUrl}`));
+        router.use(({ request }) => void logs.push(`middleware 2: ${request.loadedUrl}`));
+        router.use(({ request }) => void logs.push(`middleware 3: ${request.loadedUrl}`));
 
         const log = { info: jest.fn(), warn: jest.fn(), debug: jest.fn() };
         await router({ request: { loadedUrl: 'https://example.com/A', label: 'A' }, log } as any);
@@ -34,17 +37,53 @@ describe('Router', () => {
         await router({ request: { loadedUrl: 'https://example.com/C', label: 'C' }, log } as any);
 
         expect(logs).toEqual([
+            'middleware 1: https://example.com/A',
+            'middleware 2: https://example.com/A',
+            'middleware 3: https://example.com/A',
             'label A handled with url https://example.com/A',
+            'middleware 1: https://example.com/A',
+            'middleware 2: https://example.com/A',
+            'middleware 3: https://example.com/A',
             'label A handled with url https://example.com/A',
+            'middleware 1: https://example.com/C',
+            'middleware 2: https://example.com/C',
+            'middleware 3: https://example.com/C',
             'label C handled with url https://example.com/C',
+            'middleware 1: https://example.com/A',
+            'middleware 2: https://example.com/A',
+            'middleware 3: https://example.com/A',
             'label A handled with url https://example.com/A',
+            'middleware 1: https://example.com/B',
+            'middleware 2: https://example.com/B',
+            'middleware 3: https://example.com/B',
             'label B handled with url https://example.com/B',
+            'middleware 1: https://example.com/B',
+            'middleware 2: https://example.com/B',
+            'middleware 3: https://example.com/B',
             'label B handled with url https://example.com/B',
+            'middleware 1: https://example.com/',
+            'middleware 2: https://example.com/',
+            'middleware 3: https://example.com/',
             'default handled with url https://example.com/',
+            'middleware 1: https://example.com/A',
+            'middleware 2: https://example.com/A',
+            'middleware 3: https://example.com/A',
             'label A handled with url https://example.com/A',
+            'middleware 1: https://example.com/C',
+            'middleware 2: https://example.com/C',
+            'middleware 3: https://example.com/C',
             'label C handled with url https://example.com/C',
+            'middleware 1: https://example.com/C',
+            'middleware 2: https://example.com/C',
+            'middleware 3: https://example.com/C',
             'label C handled with url https://example.com/C',
+            'middleware 1: https://example.com/D',
+            'middleware 2: https://example.com/D',
+            'middleware 3: https://example.com/D',
             'default handled with url https://example.com/D',
+            'middleware 1: https://example.com/C',
+            'middleware 2: https://example.com/C',
+            'middleware 3: https://example.com/C',
             'label C handled with url https://example.com/C',
         ]);
     });
@@ -54,7 +93,7 @@ describe('Router', () => {
         router.addHandler('A', async (ctx) => {});
         expect(() => router.addHandler('A', async (ctx) => {})).toThrow();
         const log = { info: jest.fn(), warn: jest.fn(), debug: jest.fn() };
-        expect(() => router({ request: { loadedUrl: 'https://example.com/C', label: 'C' }, log } as any)).toThrow(MissingRouteError);
+        await expect(router({ request: { loadedUrl: 'https://example.com/C', label: 'C' }, log } as any)).rejects.toThrow(MissingRouteError);
         router.addDefaultHandler(async (ctx) => {});
         expect(() => router.addDefaultHandler(async (ctx) => {})).toThrow();
     });


### PR DESCRIPTION
```ts
crawler.router.use((ctx) => { ... });
```