### PR TITLE
feat: add `RetryRequestError` + add error to the context for BC

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -1020,7 +1020,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
         Object.defineProperty(context, 'error', {
             get: () => {
                 // eslint-disable-next-line max-len
-                this.log.deprecated("The 'error' property of the crawling context is deprecated, and it is now passed as the second parameter in 'failedRequestHandler' or 'errorHandler'. Please update your code, as this property will be removed in a future version.");
+                this.log.deprecated("The 'error' property of the crawling context is deprecated, and it is now passed as the second parameter in 'errorHandler' and 'failedRequestHandler'. Please update your code, as this property will be removed in a future version.");
 
                 return error;
             },

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -1018,7 +1018,9 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
             return process.env.CRAWLEE_VERBOSE_LOG ? error.stack : error.message || error;
         }
 
-        return process.env.CRAWLEE_VERBOSE_LOG || forceStack ? error.stack ?? (error.message || error) : error.message || error;
+        return (process.env.CRAWLEE_VERBOSE_LOG || forceStack)
+            ? error.stack ?? (error.message || error)
+            : error.message || error;
     }
 
     protected _canRequestBeRetried(request: Request, error: Error) {

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -63,7 +63,7 @@ const SAFE_MIGRATION_WAIT_MILLIS = 20000;
 
 export type RequestHandler<Context extends CrawlingContext = BasicCrawlingContext> = (inputs: Context) => Awaitable<void>;
 
-export type ErrorHandler<Context extends CrawlingContext = BasicCrawlingContext> = (inputs: Context, error: unknown) => Awaitable<void>;
+export type ErrorHandler<Context extends CrawlingContext = BasicCrawlingContext> = (inputs: Context, error: Error) => Awaitable<void>;
 
 export interface BasicCrawlerOptions<Context extends CrawlingContext = BasicCrawlingContext> {
     /**
@@ -876,7 +876,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
         } catch (err) {
             try {
                 await addTimeoutToPromise(
-                    () => this._requestFunctionErrorHandler(err, crawlingContext, source),
+                    () => this._requestFunctionErrorHandler(err as Error, crawlingContext, source),
                     this.internalTimeoutMillis,
                     `Handling request failure of ${request.url} (${request.id}) timed out after ${this.internalTimeoutMillis / 1e3} seconds.`,
                 );
@@ -942,7 +942,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
      * Handles errors thrown by user provided requestHandler()
      */
     protected async _requestFunctionErrorHandler(
-        error: unknown,
+        error: Error,
         crawlingContext: Context,
         source: RequestList | RequestQueue,
     ): Promise<void> {

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -995,7 +995,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
     protected async _handleFailedRequestHandler(crawlingContext: Context, error: Error): Promise<void> {
         // Always log the last error regardless if the user provided a failedRequestHandler
         const { id, url, method, uniqueKey } = crawlingContext.request;
-        const message = this._getMessageFromError(error);
+        const message = this._getMessageFromError(error, true);
 
         this.log.error(
             `Request failed and reached maximum retries. ${message}`,
@@ -1012,8 +1012,8 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
      * @param error The error received
      * @returns The message to be logged
      */
-    protected _getMessageFromError(error: Error) {
-        return process.env.CRAWLEE_VERBOSE_LOG ? error.stack ?? error.message ?? error : error;
+    protected _getMessageFromError(error: Error, forceStack = false) {
+        return process.env.CRAWLEE_VERBOSE_LOG || forceStack ? error.stack ?? error.message ?? error : error;
     }
 
     protected _canRequestBeRetried(request: Request, error: Error) {

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -62,7 +62,7 @@ const SAFE_MIGRATION_WAIT_MILLIS = 20000;
 
 export type RequestHandler<Context extends CrawlingContext = BasicCrawlingContext> = (inputs: Context) => Awaitable<void>;
 
-export type ErrorHandler<Context extends CrawlingContext = BasicCrawlingContext> = (inputs: Context, error: Error) => Awaitable<void>;
+export type ErrorHandler<Context extends CrawlingContext = BasicCrawlingContext> = (inputs: Context, error: unknown) => Awaitable<void>;
 
 export interface BasicCrawlerOptions<Context extends CrawlingContext = BasicCrawlingContext> {
     /**
@@ -956,7 +956,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
         if (shouldRetryRequest) {
             request.retryCount++;
 
-            await this._tagUserHandlerError(() => this.errorHandler?.(crawlingContext, error));
+            await this._tagUserHandlerError(() => this.errorHandler?.({ ...crawlingContext, error }, error));
 
             const { url, retryCount, id } = request;
             // We don't want to see the stack trace in the logs by default, when we are going to retry the request.
@@ -991,7 +991,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
 
     protected async _handleFailedRequestHandler(crawlingContext: Context, error: Error): Promise<void> {
         if (this.failedRequestHandler) {
-            await this._tagUserHandlerError(() => this.failedRequestHandler?.(crawlingContext, error));
+            await this._tagUserHandlerError(() => this.failedRequestHandler?.({ ...crawlingContext, error }, error));
             return;
         }
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -12,3 +12,8 @@ export class CriticalError extends NonRetryableError {}
  * @ignore
  */
 export class MissingRouteError extends CriticalError {}
+
+/**
+ * Indicates that the request should be retried (while still respecting the maximum number of retries).
+ */
+export class RetryRequest extends Error {}

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -16,4 +16,8 @@ export class MissingRouteError extends CriticalError {}
 /**
  * Indicates that the request should be retried (while still respecting the maximum number of retries).
  */
-export class RetryRequest extends Error {}
+export class RetryRequestError extends Error {
+    public constructor(message?: string) {
+        super(message ?? "Request is being retried at the user's request");
+    }
+}

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -17,7 +17,7 @@ export class MissingRouteError extends CriticalError {}
  * Indicates that the request should be retried (while still respecting the maximum number of retries).
  */
 export class RetryRequestError extends Error {
-    public constructor(message?: string) {
+   constructor(message?: string) {
         super(message ?? "Request is being retried at the user's request");
     }
 }

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -17,7 +17,7 @@ export class MissingRouteError extends CriticalError {}
  * Indicates that the request should be retried (while still respecting the maximum number of retries).
  */
 export class RetryRequestError extends Error {
-   constructor(message?: string) {
+    constructor(message?: string) {
         super(message ?? "Request is being retried at the user's request");
     }
 }

--- a/test/core/crawlers/browser_crawler.test.ts
+++ b/test/core/crawlers/browser_crawler.test.ts
@@ -722,7 +722,7 @@ describe('BrowserCrawler', () => {
                 expect((crawlingContext.crawler as BrowserCrawler).browserPool).toBeInstanceOf(BrowserPool);
                 expect(crawlingContext.hasOwnProperty('response')).toBe(true);
 
-                expect(crawlingContext.error).toBeUndefined();
+                expect(crawlingContext.error).toBeInstanceOf(Error);
                 expect(error).toBeInstanceOf(Error);
                 expect(error.message).toEqual('some error');
             };

--- a/test/core/crawlers/cheerio_crawler.test.ts
+++ b/test/core/crawlers/cheerio_crawler.test.ts
@@ -1203,7 +1203,7 @@ describe('CheerioCrawler', () => {
                 expect(typeof crawlingContext.response).toBe('object');
                 expect(typeof crawlingContext.contentType).toBe('object');
 
-                expect(crawlingContext.error).toBeUndefined();
+                expect(crawlingContext.error).toBeInstanceOf(Error);
                 expect(error).toBeInstanceOf(Error);
                 expect(error.message).toEqual('some error');
             };

--- a/test/core/crawlers/puppeteer_crawler.test.ts
+++ b/test/core/crawlers/puppeteer_crawler.test.ts
@@ -246,15 +246,15 @@ describe('PuppeteerCrawler', () => {
         const warnings = logWarningSpy.mock.calls.map((call) => [call[0], call[1].retryCount]);
         expect(warnings).toEqual([
             [
-                'Reclaiming failed request back to the list or queue. Error: Navigation timed out after 0.005 seconds.',
+                'Reclaiming failed request back to the list or queue. Navigation timed out after 0.005 seconds.',
                 1,
             ],
             [
-                'Reclaiming failed request back to the list or queue. Error: Navigation timed out after 0.005 seconds.',
+                'Reclaiming failed request back to the list or queue. Navigation timed out after 0.005 seconds.',
                 2,
             ],
             [
-                'Reclaiming failed request back to the list or queue. Error: Navigation timed out after 0.005 seconds.',
+                'Reclaiming failed request back to the list or queue. Navigation timed out after 0.005 seconds.',
                 3,
             ],
         ]);
@@ -305,15 +305,15 @@ describe('PuppeteerCrawler', () => {
         const warnings = logWarningSpy.mock.calls.map((call) => [call[0], call[1].retryCount]);
         expect(warnings).toEqual([
             [
-                'Reclaiming failed request back to the list or queue. Error: Navigation timed out after 0.005 seconds.',
+                'Reclaiming failed request back to the list or queue. Navigation timed out after 0.005 seconds.',
                 1,
             ],
             [
-                'Reclaiming failed request back to the list or queue. Error: Navigation timed out after 0.005 seconds.',
+                'Reclaiming failed request back to the list or queue. Navigation timed out after 0.005 seconds.',
                 2,
             ],
             [
-                'Reclaiming failed request back to the list or queue. Error: Navigation timed out after 0.005 seconds.',
+                'Reclaiming failed request back to the list or queue. Navigation timed out after 0.005 seconds.',
                 3,
             ],
         ]);


### PR DESCRIPTION
The PR adds the error to the crawling context for the error handlers.

Since you can throw *anything*, the correct type for errors in the error handlers is unknown instead of `Error`, so this PR fixes that too.
