### PR TITLE
docs: Say "a X" instead of "the X" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
         </picture>
     </a>
     <br>
-    <small>The web scraping and browser automation library</small>
+    <small>A web scraping and browser automation library</small>
 </h1>
 
 <p align=center>


### PR DESCRIPTION
As mentioned in [the Hacker News announcement thread](https://news.ycombinator.com/item?id=32568318), several people dislike the definite article when referring to tech products. Would it be possible to change the README.md and the "About" section?

<img width="324" alt="the" src="https://user-images.githubusercontent.com/88276600/186341280-16e23ab2-f654-4fec-9cbe-3b527e6d7ce6.png">

Thanks!