### PR TITLE
fix: wait for persist state listeners to run when event manager closes

### DIFF
--- a/packages/core/src/events/event_manager.ts
+++ b/packages/core/src/events/event_manager.ts
@@ -58,6 +58,9 @@ export abstract class EventManager {
 
         // Emit final PERSIST_STATE event
         this.emit(EventType.PERSIST_STATE, { isMigrating: false });
+
+        // Wait for PERSIST_STATE to process
+        await this.waitForAllListenersToComplete();
     }
 
     on(event: EventTypeName, listener: (...args: any[]) => any): void {

--- a/test/e2e/automatic-persist-value/actor/.gitignore
+++ b/test/e2e/automatic-persist-value/actor/.gitignore
@@ -1,0 +1,7 @@
+.idea
+.DS_Store
+node_modules
+package-lock.json
+apify_storage
+crawlee_storage
+storage

--- a/test/e2e/automatic-persist-value/actor/Dockerfile
+++ b/test/e2e/automatic-persist-value/actor/Dockerfile
@@ -1,0 +1,15 @@
+FROM apify/actor-node:16
+
+COPY packages ./packages
+COPY package*.json ./
+
+RUN npm --quiet set progress=false \
+ && npm install --only=prod --no-optional \
+ && echo "Installed NPM packages:" \
+ && (npm list --only=prod --no-optional --all || true) \
+ && echo "Node.js version:" \
+ && node --version \
+ && echo "NPM version:" \
+ && npm --version
+
+COPY . ./

--- a/test/e2e/automatic-persist-value/actor/apify.json
+++ b/test/e2e/automatic-persist-value/actor/apify.json
@@ -1,0 +1,6 @@
+{
+	"name": "test-automatic-persist-value",
+	"version": "0.0",
+	"buildTag": "latest",
+	"env": null
+}

--- a/test/e2e/automatic-persist-value/actor/main.js
+++ b/test/e2e/automatic-persist-value/actor/main.js
@@ -1,0 +1,22 @@
+import { Actor, KeyValueStore } from 'apify';
+import { ApifyStorageLocal } from '@apify/storage-local';
+import { BasicCrawler } from '@crawlee/basic';
+
+const mainOptions = {
+    exit: Actor.isAtHome(),
+    storage: process.env.STORAGE_IMPLEMENTATION === 'LOCAL' ? new ApifyStorageLocal() : undefined,
+};
+
+await Actor.main(async () => {
+    const kv = await KeyValueStore.open('test');
+
+    const crawler = new BasicCrawler({
+        async requestHandler() {
+            const automaticValue = await kv.getAutoSavedValue('hello');
+
+            automaticValue.crawlee = 'awesome!';
+        },
+    });
+
+    await crawler.run(['https://example.com']);
+}, mainOptions);

--- a/test/e2e/automatic-persist-value/actor/package.json
+++ b/test/e2e/automatic-persist-value/actor/package.json
@@ -1,7 +1,7 @@
 {
-	"name": "test-autoscaling-max-tasks-per-minute",
+	"name": "test-automatic-persist-value",
 	"version": "0.0.1",
-	"description": "Autoscaling Pool Test - Max Tasks per Minute",
+	"description": "Key-Value Store - Automatic Persist Value Test",
 	"dependencies": {
         "apify": "^3.0.0-beta.75",
         "@apify/storage-local": "^2.1.0",

--- a/test/e2e/automatic-persist-value/test.mjs
+++ b/test/e2e/automatic-persist-value/test.mjs
@@ -1,0 +1,19 @@
+import { initialize, expect, getActorTestDir, runActor, getKeyValueStoreItems } from '../tools.mjs';
+
+const testActorDirname = getActorTestDir(import.meta.url);
+await initialize(testActorDirname);
+
+await runActor(testActorDirname);
+
+const kvsItems = await getKeyValueStoreItems(testActorDirname, 'test');
+
+expect(kvsItems.length === 1, 'Key-value store automatically saved the value expected to be auto-saved');
+
+const [{ name, raw }] = kvsItems;
+
+expect(name === 'crawlee', 'Key-value store auto-saved value is named "crawlee"');
+
+const parsed = JSON.parse(raw.toString());
+
+expect(typeof parsed === 'object' && parsed !== null, 'Key-value store auto-save value is a non-nullable object');
+expect(parsed.crawlee === 'awesome!', 'Key-value store auto-save value has a property "crawlee" that is set to "awesome!"');

--- a/test/e2e/tools.mjs
+++ b/test/e2e/tools.mjs
@@ -7,7 +7,8 @@ import { setTimeout } from 'node:timers/promises';
 import { execSync } from 'node:child_process';
 import fs from 'fs-extra';
 import { Actor } from 'apify';
-import { URL_NO_COMMAS_REGEX } from '@crawlee/utils';
+// eslint-disable-next-line import/no-relative-packages
+import { URL_NO_COMMAS_REGEX } from '../../packages/utils/dist/index.mjs';
 
 export const SKIPPED_TEST_CLOSE_CODE = 404;
 


### PR DESCRIPTION
Should resolve #1463 by ensuring the persist state listeners are executed when events.close is called

For the actor users, we also need https://github.com/apify/apify-sdk-js/pull/49