### PR TITLE
docs: add a variable in the example code

### DIFF
--- a/packages/playwright-crawler/src/internals/playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/playwright-crawler.ts
@@ -87,6 +87,7 @@ export interface PlaywrightCrawlerOptions extends BrowserCrawlerOptions<
      * ```
      * preNavigationHooks: [
      *     async (crawlingContext, gotoOptions) => {
+     *         const { page } = crawlingContext;
      *         await page.evaluate((attr) => { window.foo = attr; }, 'bar');
      *     },
      * ]


### PR DESCRIPTION
The `page` variable was missing, so I added it. 😉 