### PR TITLE
fix: handle redirect cookies

### DIFF
--- a/packages/http-crawler/src/internals/http-crawler.ts
+++ b/packages/http-crawler/src/internals/http-crawler.ts
@@ -23,7 +23,7 @@ import type { Awaitable, Dictionary } from '@crawlee/types';
 import type { RequestLike, ResponseLike } from 'content-type';
 import contentTypeParser from 'content-type';
 import mime from 'mime-types';
-import type { OptionsInit, Method, Request as GotRequest, Response as GotResponse, GotOptionsInit } from 'got-scraping';
+import type { OptionsInit, Method, Request as GotRequest, Response as GotResponse, GotOptionsInit, Options } from 'got-scraping';
 import { gotScraping, TimeoutError } from 'got-scraping';
 import type { JsonValue } from 'type-fest';
 import { extname } from 'node:path';
@@ -437,10 +437,6 @@ export class HttpCrawler<Context extends InternalHttpCrawlingContext<any, any, H
                 this._throwOnBlockedRequest(session!, response.statusCode!);
             }
 
-            if (this.persistCookiesPerSession) {
-                session!.setCookiesFromResponse(response);
-            }
-
             request.loadedUrl = response.url;
 
             Object.assign(crawlingContext, parsed);
@@ -551,7 +547,7 @@ export class HttpCrawler<Context extends InternalHttpCrawlingContext<any, any, H
         const opts = this._getRequestOptions(request, session, proxyUrl, gotOptions);
 
         try {
-            return await this._requestAsBrowser(opts);
+            return await this._requestAsBrowser(opts, session);
         } catch (e) {
             if (e instanceof TimeoutError) {
                 this._handleRequestTimeout(session);
@@ -725,9 +721,17 @@ export class HttpCrawler<Context extends InternalHttpCrawlingContext<any, any, H
     /**
      * @internal wraps public utility for mocking purposes
      */
-    private _requestAsBrowser = (options: OptionsInit & { isStream: true }) => {
+    private _requestAsBrowser = (options: OptionsInit & { isStream: true }, session?: Session) => {
         return new Promise<IncomingMessage>((resolve, reject) => {
             const stream = gotScraping(options);
+
+            stream.on('redirect', (updatedOptions: Options, redirectResponse: IncomingMessage) => {
+                if (this.persistCookiesPerSession) {
+                    session!.setCookiesFromResponse(redirectResponse);
+
+                    updatedOptions.headers.Cookie = session!.getCookieString(updatedOptions.url!.toString());
+                }
+            });
 
             stream.on('error', reject);
             stream.on('response', () => {

--- a/packages/http-crawler/src/internals/http-crawler.ts
+++ b/packages/http-crawler/src/internals/http-crawler.ts
@@ -437,6 +437,10 @@ export class HttpCrawler<Context extends InternalHttpCrawlingContext<any, any, H
                 this._throwOnBlockedRequest(session!, response.statusCode!);
             }
 
+            if (this.persistCookiesPerSession) {
+                session!.setCookiesFromResponse(response);
+            }
+
             request.loadedUrl = response.url;
 
             Object.assign(crawlingContext, parsed);

--- a/packages/http-crawler/src/internals/http-crawler.ts
+++ b/packages/http-crawler/src/internals/http-crawler.ts
@@ -733,7 +733,10 @@ export class HttpCrawler<Context extends InternalHttpCrawlingContext<any, any, H
                 if (this.persistCookiesPerSession) {
                     session!.setCookiesFromResponse(redirectResponse);
 
-                    updatedOptions.headers.Cookie = session!.getCookieString(updatedOptions.url!.toString());
+                    const cookieString = session!.getCookieString(updatedOptions.url!.toString());
+                    if (cookieString !== '') {
+                        updatedOptions.headers.Cookie = cookieString;
+                    }
                 }
             });
 

--- a/packages/http-crawler/src/internals/http-crawler.ts
+++ b/packages/http-crawler/src/internals/http-crawler.ts
@@ -539,7 +539,10 @@ export class HttpCrawler<Context extends InternalHttpCrawlingContext<any, any, H
         gotOptions.headers ??= {};
         Reflect.deleteProperty(gotOptions.headers, 'Cookie');
         Reflect.deleteProperty(gotOptions.headers, 'cookie');
-        gotOptions.headers.Cookie = mergedCookie;
+
+        if (mergedCookie !== '') {
+            gotOptions.headers.Cookie = mergedCookie;
+        }
     }
 
     /**

--- a/test/core/crawlers/http_crawler.test.ts
+++ b/test/core/crawlers/http_crawler.test.ts
@@ -22,6 +22,19 @@ router.set('/invalidContentType', (req, res) => {
     res.end(`<html><head><title>Example Domain</title></head></html>`);
 });
 
+router.set('/redirectAndCookies', (req, res) => {
+    res.setHeader('content-type', 'text/html');
+    res.setHeader('set-cookie', 'foo=bar');
+    res.setHeader('location', '/cookies');
+    res.statusCode = 302;
+    res.end();
+});
+
+router.set('/cookies', (req, res) => {
+    res.setHeader('content-type', 'text/html');
+    res.end(JSON.stringify(req.headers.cookie));
+});
+
 let server: http.Server;
 let url: string;
 
@@ -149,5 +162,24 @@ test('invalid content type defaults to octet-stream', async () => {
             type: 'application/octet-stream',
             encoding: 'utf-8',
         },
+    ]);
+});
+
+test('handles cookies from redirects', async () => {
+    const results: string[] = [];
+
+    const crawler = new HttpCrawler({
+        sessionPoolOptions: {
+            maxPoolSize: 1,
+        },
+        handlePageFunction: async ({ body }) => {
+            results.push(JSON.parse(body.toString()));
+        },
+    });
+
+    await crawler.run([`${url}/redirectAndCookies`]);
+
+    expect(results).toStrictEqual([
+        'foo=bar',
     ]);
 });

--- a/test/core/crawlers/http_crawler.test.ts
+++ b/test/core/crawlers/http_crawler.test.ts
@@ -35,6 +35,12 @@ router.set('/cookies', (req, res) => {
     res.end(JSON.stringify(req.headers.cookie));
 });
 
+router.set('/redirectWithoutCookies', (req, res) => {
+    res.setHeader('location', '/cookies');
+    res.statusCode = 302;
+    res.end();
+});
+
 let server: http.Server;
 let url: string;
 
@@ -182,4 +188,46 @@ test('handles cookies from redirects', async () => {
     expect(results).toStrictEqual([
         'foo=bar',
     ]);
+});
+
+test('handles cookies from redirects - no empty cookie header', async () => {
+    const results: string[] = [];
+
+    const crawler = new HttpCrawler({
+        sessionPoolOptions: {
+            maxPoolSize: 1,
+        },
+        handlePageFunction: async ({ body }) => {
+            const str = body.toString();
+
+            if (str !== '') {
+                results.push(JSON.parse(str));
+            }
+        },
+    });
+
+    await crawler.run([`${url}/redirectWithoutCookies`]);
+
+    expect(results).toStrictEqual([]);
+});
+
+test('no empty cookie header', async () => {
+    const results: string[] = [];
+
+    const crawler = new HttpCrawler({
+        sessionPoolOptions: {
+            maxPoolSize: 1,
+        },
+        handlePageFunction: async ({ body }) => {
+            const str = body.toString();
+
+            if (str !== '') {
+                results.push(JSON.parse(str));
+            }
+        },
+    });
+
+    await crawler.run([`${url}/cookies`]);
+
+    expect(results).toStrictEqual([]);
 });


### PR DESCRIPTION
Fixes https://github.com/apify/crawlee/issues/1267

~I'd prefer if we used `cookieJar` instead, because the headers should be treated case-insensitively (according to the spec) and as of now `options.headers` is just a plain object, meaning `cookie` and `Cookie` and `COOKIE` are treated as separate properties. Node.js will select the last header case-insensitively. Response headers are lowercased by default, it's just a matter of how to handle request cookie headers.~ rather unavoidable