### PR TITLE
fix: allow `label` in `enqueueLinksByClickingElements` options

### DIFF
--- a/packages/puppeteer-crawler/src/internals/enqueue-links/click-elements.ts
+++ b/packages/puppeteer-crawler/src/internals/enqueue-links/click-elements.ts
@@ -224,7 +224,7 @@ export async function enqueueLinksByClickingElements(options: EnqueueLinksByClic
         transformRequestFunction: ow.optional.function,
         waitForPageIdleSecs: ow.optional.number,
         maxWaitForPageIdleSecs: ow.optional.number,
-        label: ow.optional.string
+        label: ow.optional.string,
     }));
 
     const {

--- a/packages/puppeteer-crawler/src/internals/enqueue-links/click-elements.ts
+++ b/packages/puppeteer-crawler/src/internals/enqueue-links/click-elements.ts
@@ -224,6 +224,7 @@ export async function enqueueLinksByClickingElements(options: EnqueueLinksByClic
         transformRequestFunction: ow.optional.function,
         waitForPageIdleSecs: ow.optional.number,
         maxWaitForPageIdleSecs: ow.optional.number,
+        label: ow.optional.string
     }));
 
     const {


### PR DESCRIPTION
👋 Crawlee team!

I'm currently developing on top of Crawlee, and have been leveraging `enqueueLinksByClickingElements` to navigate links that require the preservation of session data. There are thousands of links, so moving these page contexts into the request queue under a new label is preferred. I am currently seeing an issue with enqueueing new work with custom labels. 

```
Reclaiming failed request back to the list or queue. Did not expect property `label` to exist
```

A fix below, which ensures the validation of `label` in `RequestOptions` enables `enqueueLinksByClickingElements` to queue up new links under a custom label. 