### PR TITLE
fix: correct some typing exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16644,6 +16644,7 @@
                 "@crawlee/types": "^3.0.4",
                 "@crawlee/utils": "^3.0.4",
                 "cheerio": "1.0.0-rc.12",
+                "devtools-protocol": "*",
                 "jquery": "^3.6.0",
                 "ow": "^0.28.1"
             },
@@ -16658,6 +16659,11 @@
                     "optional": true
                 }
             }
+        },
+        "packages/puppeteer-crawler/node_modules/devtools-protocol": {
+            "version": "0.0.1040073",
+            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1040073.tgz",
+            "integrity": "sha512-+iipnm2hvmlWs4MVNx7HwSTxhDxsXnQyK5F1OalZVXeUhdPgP/23T42NCyg0TK3wL/Yg92SVrSuGKqdg12o54w=="
         },
         "packages/templates": {
             "name": "@crawlee/templates",
@@ -17911,8 +17917,16 @@
                 "@crawlee/types": "^3.0.4",
                 "@crawlee/utils": "^3.0.4",
                 "cheerio": "1.0.0-rc.12",
+                "devtools-protocol": "*",
                 "jquery": "^3.6.0",
                 "ow": "^0.28.1"
+            },
+            "dependencies": {
+                "devtools-protocol": {
+                    "version": "0.0.1040073",
+                    "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1040073.tgz",
+                    "integrity": "sha512-+iipnm2hvmlWs4MVNx7HwSTxhDxsXnQyK5F1OalZVXeUhdPgP/23T42NCyg0TK3wL/Yg92SVrSuGKqdg12o54w=="
+                }
             }
         },
         "@crawlee/templates": {

--- a/packages/core/src/enqueue_links/shared.ts
+++ b/packages/core/src/enqueue_links/shared.ts
@@ -157,7 +157,7 @@ export function createRequests(requestOptions: (string | RequestOptions)[], urlP
     return requests;
 }
 
-export function filterRequestsByPatterns(requests: Request[], patterns?: UrlPatternObject[]) {
+export function filterRequestsByPatterns(requests: Request[], patterns?: UrlPatternObject[]): Request[] {
     if (!patterns?.length) {
         return requests;
     }

--- a/packages/puppeteer-crawler/package.json
+++ b/packages/puppeteer-crawler/package.json
@@ -60,6 +60,7 @@
         "@crawlee/types": "^3.0.4",
         "@crawlee/utils": "^3.0.4",
         "cheerio": "1.0.0-rc.12",
+        "devtools-protocol": "*",
         "jquery": "^3.6.0",
         "ow": "^0.28.1"
     },

--- a/scripts/typescript_fixes.mjs
+++ b/scripts/typescript_fixes.mjs
@@ -18,8 +18,6 @@ for (const filepath of files) {
         } else if (
             // playwright/puppeteer import
             line.match(/^([^']+)'(playwright|puppeteer)'/) ||
-            // type import for CDP protocol mappings
-            line.match(/^([^']+)'devtools-protocol\/types\/protocol-mapping\.js'/) ||
             // proxy-per-page reexport of puppeteer
             line.match(/: Puppeteer\.\w+/) ||
             // don't ask me why, but this one is needed too ¯\_(ツ)_/¯

--- a/scripts/typescript_fixes.mjs
+++ b/scripts/typescript_fixes.mjs
@@ -18,6 +18,8 @@ for (const filepath of files) {
         } else if (
             // playwright/puppeteer import
             line.match(/^([^']+)'(playwright|puppeteer)'/) ||
+            // type import for CDP protocol mappings
+            line.match(/^([^']+)'devtools-protocol\/types\/protocol-mapping\.js'/) ||
             // proxy-per-page reexport of puppeteer
             line.match(/: Puppeteer\.\w+/) ||
             // don't ask me why, but this one is needed too ¯\_(ツ)_/¯


### PR DESCRIPTION
Fixes the devtools-protocol typing issue (should we be setting it as a dependency or letting it come from puppeteer? I think the latter is fine), as well as the broken type in /core for filteringRequestsWithPatterns (typescript inlined it to import from our mapped paths)