### PR TITLE
refactor: error analysis message

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -595,10 +595,12 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
         this.log.info('Crawl finished. Final request statistics:', stats);
 
         if (this.stats.errorTracker.total !== 0) {
+            const prettify = ([count, info]: [number, string[]]) => `${count}x: ${info.at(-1)!.trim()} (${info[0]})`;
+
             this.log.info(`Error analysis:`, {
                 totalErrors: this.stats.errorTracker.total,
                 uniqueErrors: this.stats.errorTracker.getUniqueErrorCount(),
-                mostCommonErrors: Object.fromEntries(this.stats.errorTracker.getMostPopularErrors(3)),
+                mostCommonErrors: this.stats.errorTracker.getMostPopularErrors(3).map(prettify),
             });
         }
 

--- a/packages/utils/src/internals/error_tracker.ts
+++ b/packages/utils/src/internals/error_tracker.ts
@@ -353,7 +353,7 @@ export class ErrorTracker {
 
         goDeeper(this.result, []);
 
-        return result.sort((a, b) => a[0] - b[0]).slice(0, count);
+        return result.sort((a, b) => b[0] - a[0]).slice(0, count);
     }
 
     reset() {


### PR DESCRIPTION
It now prints something like this:

```
INFO  CheerioCrawler: Error analysis: {"totalErrors":1,"uniqueErrors":1,"mostCommonErrors":["1x: 502 - Internal Server Error: (/home/szm/Desktop/crawlee/packages/http-crawler/dist/internals/http-crawler.js:412:19)"]}
```

Also fixed the order so it prints actually most common errors first.