### PR TITLE
fix(basic-crawler): handle `request.noRetry` after `errorHandler`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17815,7 +17815,7 @@
                 "@types/tough-cookie": "^4.0.2",
                 "@vladfrangu/async_event_emitter": "^2.0.0",
                 "fs-extra": "^10.1.0",
-                "json5": "*",
+                "json5": "^2.2.1",
                 "minimatch": "^5.1.0",
                 "ow": "^0.28.1",
                 "stream-chain": "^2.2.5",

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -1014,7 +1014,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
         } else {
             this.stats.errorTracker.add(error);
 
-            // If we get here, the request is either not retryable
+            // If we get here, the request is either not retry-able
             // or failed more than retryCount times and will not be retried anymore.
             // Mark the request as failed and do not retry.
             this.handledRequestsCount++;


### PR DESCRIPTION
See this Discord post to fully understand the use case: https://discord.com/channels/801163717915574323/1019936393235017769

Didn't want to make big changes to existing code so kept the else statement and, therefore,the code repeats itself a little.  If a refactor is in order, I can easily fix.