### PR TITLE
feat(Request): add `requestHandlerTimeoutSecs` and `requestTimeoutSecs` options

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -821,6 +821,8 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
 
         tryCancel();
 
+        // A request can have some request-specific timeouts defined. We check if they have been defined, and if so,
+        // use those timeouts instead. However; if they aren't present, the defaults will be used.
         const requestTimeoutMillis = request?.requestTimeoutMillis ?? this.internalTimeoutMillis;
         const requestHandlerTimeoutMillis = request?.requestHandlerTimeoutMillis ?? this.requestHandlerTimeoutMillis;
 

--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -483,10 +483,12 @@ export abstract class BrowserCrawler<
             }
         }
 
+        request.requestHandlerTimeoutSecs ??= this.requestHandlerTimeoutMillis / 1e3;
+
         await addTimeoutToPromise(
             () => Promise.resolve(this.userProvidedRequestHandler(crawlingContext)),
-            this.requestHandlerTimeoutMillis,
-            `requestHandler timed out after ${this.requestHandlerTimeoutMillis / 1000} seconds.`,
+            request.requestHandlerTimeoutSecs * 1e3,
+            `requestHandler timed out after ${request.requestHandlerTimeoutSecs} seconds.`,
         );
         tryCancel();
 
@@ -523,10 +525,9 @@ export abstract class BrowserCrawler<
     }
 
     protected async _handleNavigation(crawlingContext: Context) {
-        const gotoOptions = {
-            timeout: (crawlingContext.request as Request & {
-                requestHandlerTimeoutMillis?: number;
-                requestTimeoutMillis?: number; }).requestTimeoutMillis ?? this.navigationTimeoutMillis } as unknown as GoToOptions;
+        crawlingContext.request.requestTimeoutSecs ??= this.navigationTimeoutMillis / 1e3;
+
+        const gotoOptions = { timeout: crawlingContext.request.requestTimeoutSecs * 1e3 } as unknown as GoToOptions;
 
         const preNavigationHooksCookies = this._getCookieHeaderFromRequest(crawlingContext.request);
 

--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -11,6 +11,7 @@ import type {
     RequestHandler,
     ErrorHandler,
     EnqueueLinksOptions,
+    Request,
 } from '@crawlee/basic';
 import {
     cookieStringToToughCookie,
@@ -522,7 +523,10 @@ export abstract class BrowserCrawler<
     }
 
     protected async _handleNavigation(crawlingContext: Context) {
-        const gotoOptions = { timeout: this.navigationTimeoutMillis } as unknown as GoToOptions;
+        const gotoOptions = {
+            timeout: (crawlingContext.request as Request & {
+                requestHandlerTimeoutMillis?: number;
+                requestTimeoutMillis?: number; }).requestTimeoutMillis ?? this.navigationTimeoutMillis } as unknown as GoToOptions;
 
         const preNavigationHooksCookies = this._getCookieHeaderFromRequest(crawlingContext.request);
 

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -28,6 +28,8 @@ const requestOptionalPredicates = {
     keepUrlFragment: ow.optional.boolean,
     useExtendedUniqueKey: ow.optional.boolean,
     skipNavigation: ow.optional.boolean,
+    requestHandlerTimeoutSecs: ow.optional.number,
+    requestTimeoutSecs: ow.optional.number,
 };
 
 /**

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -185,22 +185,8 @@ export class Request<UserData extends Dictionary = Dictionary> {
         this.errorMessages = [...errorMessages];
         this.headers = { ...headers };
         this.handledAt = handledAt as unknown instanceof Date ? (handledAt as Date).toISOString() : handledAt!;
-
         this.requestHandlerTimeoutSecs = requestHandlerTimeoutSecs;
         this.requestTimeoutSecs = requestTimeoutSecs;
-
-        Object.defineProperty(
-            this,
-            'requestHandlerTimeoutMillis',
-            // If zero was provided, this will still return null.
-            { enumerable: false, value: requestHandlerTimeoutSecs ? requestHandlerTimeoutSecs * 1e3 : null },
-        );
-
-        Object.defineProperty(
-            this,
-            'requestTimeoutMillis',
-            { enumerable: false, value: requestTimeoutSecs ? requestTimeoutSecs * 1e3 : null },
-        );
 
         if (label) {
             userData.label = label;

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -112,6 +112,16 @@ export class Request<UserData extends Dictionary = Dictionary> {
     handledAt?: string;
 
     /**
+     * The number of seconds to timeout after if the request hasn't succeeded yet.
+     */
+    requestTimeoutSecs?: number;
+
+    /**
+     * The number of seconds to timeout after if the `requestHandler` function runs for too long.
+     */
+    requestHandlerTimeoutSecs?: number;
+
+    /**
      * `Request` parameters including the URL, HTTP method and headers, and others.
      */
     constructor(options: RequestOptions) {
@@ -150,6 +160,8 @@ export class Request<UserData extends Dictionary = Dictionary> {
             keepUrlFragment = false,
             useExtendedUniqueKey = false,
             skipNavigation,
+            requestHandlerTimeoutSecs,
+            requestTimeoutSecs,
         } = options as RequestOptions & { loadedUrl?: string; retryCount?: number; errorMessages?: string[]; handledAt?: string | Date };
 
         let {
@@ -171,6 +183,21 @@ export class Request<UserData extends Dictionary = Dictionary> {
         this.errorMessages = [...errorMessages];
         this.headers = { ...headers };
         this.handledAt = handledAt as unknown instanceof Date ? (handledAt as Date).toISOString() : handledAt!;
+
+        this.requestHandlerTimeoutSecs = requestHandlerTimeoutSecs;
+        this.requestTimeoutSecs = requestTimeoutSecs;
+
+        Object.defineProperty(
+            this,
+            'requestHandlerTimeoutMillis',
+            { enumerable: false, value: requestHandlerTimeoutSecs ? requestHandlerTimeoutSecs * 1e3 : null },
+        );
+
+        Object.defineProperty(
+            this,
+            'requestTimeoutMillis',
+            { enumerable: false, value: requestTimeoutSecs ? requestTimeoutSecs * 1e3 : null },
+        );
 
         if (label) {
             userData.label = label;
@@ -399,12 +426,23 @@ export interface RequestOptions<UserData extends Dictionary = Dictionary> {
      */
     skipNavigation?: boolean;
 
+    /**
+     * Determines a request-specific number of seconds before the request times out.
+     * Overrides the default `navigationTimeoutSecs` provided to the crawler.
+     */
+    requestTimeoutSecs?: number;
+
+    /**
+     * Determines a request-specific number of seconds before the request handler times out.
+     * Overrides the default `requestHandlerTimeoutSecs` provided to the crawler.
+     */
+    requestHandlerTimeoutSecs?: number;
+
     /** @internal */
     id?: string;
 
     /** @internal */
     handledAt?: string;
-
 }
 
 export interface PushErrorMessageOptions {

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -190,6 +190,7 @@ export class Request<UserData extends Dictionary = Dictionary> {
         Object.defineProperty(
             this,
             'requestHandlerTimeoutMillis',
+            // If zero was provided, this will still return null.
             { enumerable: false, value: requestHandlerTimeoutSecs ? requestHandlerTimeoutSecs * 1e3 : null },
         );
 

--- a/packages/http-crawler/src/internals/http-crawler.ts
+++ b/packages/http-crawler/src/internals/http-crawler.ts
@@ -452,10 +452,12 @@ export class HttpCrawler<Context extends InternalHttpCrawlingContext<any, any, H
             });
         }
 
+        crawlingContext.request.requestTimeoutSecs ??= this.userRequestHandlerTimeoutMillis / 1e3;
+
         return addTimeoutToPromise(
             () => Promise.resolve(this.requestHandler(crawlingContext)),
-            this.userRequestHandlerTimeoutMillis,
-            `requestHandler timed out after ${this.userRequestHandlerTimeoutMillis / 1000} seconds.`,
+            crawlingContext.request.requestTimeoutSecs * 1e3,
+            `requestHandler timed out after ${crawlingContext.request.requestTimeoutSecs} seconds.`,
         );
     }
 
@@ -475,10 +477,12 @@ export class HttpCrawler<Context extends InternalHttpCrawlingContext<any, any, H
 
         const proxyUrl = crawlingContext.proxyInfo?.url;
 
+        crawlingContext.request.requestTimeoutSecs ??= this.navigationTimeoutMillis / 1e3;
+
         crawlingContext.response = await addTimeoutToPromise(
             () => this._requestFunction({ request, session, proxyUrl, gotOptions }),
-            this.navigationTimeoutMillis,
-            `request timed out after ${this.navigationTimeoutMillis / 1000} seconds.`,
+            crawlingContext.request.requestTimeoutSecs * 1e3,
+            `request timed out after ${crawlingContext.request.requestTimeoutSecs} seconds.`,
         );
         tryCancel();
 

--- a/test/core/crawlers/basic_crawler.test.ts
+++ b/test/core/crawlers/basic_crawler.test.ts
@@ -1235,7 +1235,5 @@ describe('BasicCrawler', () => {
 
         // The run should most definitely take less than 10 seconds with the 2 second timeout.
         expect(performance.now() - timeStart).toBeLessThan(1e4);
-
-        await crawler.teardown();
     });
 });

--- a/test/core/crawlers/cheerio_crawler.test.ts
+++ b/test/core/crawlers/cheerio_crawler.test.ts
@@ -1340,8 +1340,6 @@ describe('CheerioCrawler', () => {
 
         // The run should most definitely take less than 10 seconds with the 2 second timeout.
         expect(performance.now() - timeStart).toBeLessThan(1e4);
-
-        await crawler.teardown();
     });
 
     it('Should use the requestTimeoutSecs provided within the request instead of the crawler one', async () => {
@@ -1365,8 +1363,6 @@ describe('CheerioCrawler', () => {
 
         // The run should most definitely take less than 10 seconds with the 0.00001 second timeout.
         expect(performance.now() - timeStart).toBeLessThan(1e4);
-
-        await crawler.teardown();
     });
 });
 

--- a/test/core/crawlers/cheerio_crawler.test.ts
+++ b/test/core/crawlers/cheerio_crawler.test.ts
@@ -1318,6 +1318,56 @@ describe('CheerioCrawler', () => {
             expect(cheerioCrawler.requestHandler).toBeUndefined();
         });
     });
+
+    it('Should use the requestHandlerTimeoutSecs provided within the request instead of the crawler one', async () => {
+        const timeStart = performance.now();
+
+        const crawler = new CheerioCrawler({
+            requestHandlerTimeoutSecs: 99999,
+            maxRequestRetries: 1,
+            requestHandler: async () => {
+                await new Promise((resolve) => setTimeout(resolve, 5e4));
+            },
+            errorHandler: (_, error) => {
+                expect(error.message.includes('timed out after 2 seconds')).toBeTruthy();
+            },
+        });
+
+        await crawler.run([{
+            url: 'https://google.com',
+            requestHandlerTimeoutSecs: 2,
+        }]);
+
+        // The run should most definitely take less than 10 seconds with the 2 second timeout.
+        expect(performance.now() - timeStart).toBeLessThan(1e4);
+
+        await crawler.teardown();
+    });
+
+    it('Should use the requestTimeoutSecs provided within the request instead of the crawler one', async () => {
+        const timeStart = performance.now();
+
+        const crawler = new CheerioCrawler({
+            navigationTimeoutSecs: 99999,
+            maxRequestRetries: 1,
+            requestHandler: async () => {
+                log.info('Hey');
+            },
+            errorHandler: (_, error) => {
+                expect(error.message.includes('timed out after 2 seconds')).toBeTruthy();
+            },
+        });
+
+        await crawler.run([{
+            url: 'https://google.com',
+            requestTimeoutSecs: 0.00001,
+        }]);
+
+        // The run should most definitely take less than 10 seconds with the 0.00001 second timeout.
+        expect(performance.now() - timeStart).toBeLessThan(1e4);
+
+        await crawler.teardown();
+    });
 });
 
 async function getRequestListForMock(port: number, mockData: Dictionary, pathName = 'mock') {

--- a/test/core/crawlers/cheerio_crawler.test.ts
+++ b/test/core/crawlers/cheerio_crawler.test.ts
@@ -1319,7 +1319,7 @@ describe('CheerioCrawler', () => {
         });
     });
 
-    it('Should use the requestHandlerTimeoutSecs provided within the request instead of the crawler one', async () => {
+    test('Should use the requestHandlerTimeoutSecs provided within the request instead of the crawler one', async () => {
         const timeStart = performance.now();
 
         const crawler = new CheerioCrawler({
@@ -1342,7 +1342,7 @@ describe('CheerioCrawler', () => {
         expect(performance.now() - timeStart).toBeLessThan(1e4);
     });
 
-    it('Should use the requestTimeoutSecs provided within the request instead of the crawler one', async () => {
+    test('Should use the requestTimeoutSecs provided within the request instead of the crawler one', async () => {
         const timeStart = performance.now();
 
         const crawler = new CheerioCrawler({
@@ -1352,17 +1352,19 @@ describe('CheerioCrawler', () => {
                 log.info('Hey');
             },
             errorHandler: (_, error) => {
-                expect(error.message.includes('timed out after 2 seconds')).toBeTruthy();
+                expect(error.message.includes('timed out after 1 seconds')).toBeTruthy();
             },
         });
 
         await crawler.run([{
-            url: 'https://google.com',
-            requestTimeoutSecs: 0.00001,
+            // https://deelay.me/
+            // Google with a huge delay
+            url: 'https://deelay.me/200000/https://google.com',
+            requestTimeoutSecs: 1,
         }]);
 
-        // The run should most definitely take less than 10 seconds with the 0.00001 second timeout.
-        expect(performance.now() - timeStart).toBeLessThan(1e4);
+        // The run should most definitely take less than 15 seconds with the 0.00001 second timeout.
+        expect(performance.now() - timeStart).toBeLessThan(15e3);
     });
 });
 


### PR DESCRIPTION
closes #1485

Adds `requestHandlerTimeoutSecs` and `requestTimeoutSecs` options to a request to allow for request-specific timeouts.

If these optional parameters aren't provided in `RequestOptions`, the crawler will fallback to the timeouts provided in its configuration.