### PR TITLE
feat: enable migration testing

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -598,6 +598,12 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
         await this._init();
         await this.stats.startCapturing();
 
+        process.once('SIGINT', async () => {
+            this.log.warning('Pausing... Press CTRL+C again to force exit. To resume, do: CRAWLEE_PURGE_ON_START=0 npm run start');
+            await this._pauseOnMigration();
+            await this.autoscaledPool!.abort();
+        });
+
         try {
             this.log.info('Starting the crawl');
             await this.autoscaledPool!.run();

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -598,11 +598,13 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
         await this._init();
         await this.stats.startCapturing();
 
-        process.once('SIGINT', async () => {
-            this.log.warning('Pausing... Press CTRL+C again to force exit. To resume, do: CRAWLEE_PURGE_ON_START=0 npm run start');
-            await this._pauseOnMigration();
-            await this.autoscaledPool!.abort();
-        });
+        if (!this.config.get('purgeOnStart')) {
+            process.once('SIGINT', async () => {
+                this.log.warning('Pausing... Press CTRL+C again to force exit. To resume, do: CRAWLEE_PURGE_ON_START=0 npm run start');
+                await this._pauseOnMigration();
+                await this.autoscaledPool!.abort();
+            });
+        }
 
         try {
             this.log.info('Starting the crawl');

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -598,13 +598,11 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
         await this._init();
         await this.stats.startCapturing();
 
-        if (!this.config.get('purgeOnStart')) {
-            process.once('SIGINT', async () => {
-                this.log.warning('Pausing... Press CTRL+C again to force exit. To resume, do: CRAWLEE_PURGE_ON_START=0 npm run start');
-                await this._pauseOnMigration();
-                await this.autoscaledPool!.abort();
-            });
-        }
+        process.once('SIGINT', async () => {
+            this.log.warning('Pausing... Press CTRL+C again to force exit. To resume, do: CRAWLEE_PURGE_ON_START=0 npm run start');
+            await this._pauseOnMigration();
+            await this.autoscaledPool!.abort();
+        });
 
         try {
             this.log.info('Starting the crawl');

--- a/test/e2e/migration/actor/.gitignore
+++ b/test/e2e/migration/actor/.gitignore
@@ -1,0 +1,7 @@
+.idea
+.DS_Store
+node_modules
+package-lock.json
+apify_storage
+crawlee_storage
+storage

--- a/test/e2e/migration/actor/Dockerfile
+++ b/test/e2e/migration/actor/Dockerfile
@@ -1,0 +1,16 @@
+FROM apify/actor-node:16-beta
+
+COPY packages ./packages
+COPY package*.json ./
+
+RUN npm --quiet set progress=false \
+ && npm install --only=prod --no-optional \
+ && npm update \
+ && echo "Installed NPM packages:" \
+ && (npm list --only=prod --no-optional --all || true) \
+ && echo "Node.js version:" \
+ && node --version \
+ && echo "NPM version:" \
+ && npm --version
+
+COPY . ./

--- a/test/e2e/migration/actor/apify.json
+++ b/test/e2e/migration/actor/apify.json
@@ -1,0 +1,6 @@
+{
+	"name": "test-migration",
+	"version": "0.0",
+	"buildTag": "latest",
+	"env": null
+}

--- a/test/e2e/migration/actor/main.js
+++ b/test/e2e/migration/actor/main.js
@@ -1,0 +1,35 @@
+import { Actor } from 'apify';
+import { CheerioCrawler, Configuration, Dataset } from '@crawlee/cheerio';
+import { ApifyStorageLocal } from '@apify/storage-local';
+
+process.env.CRAWLEE_PURGE_ON_START = '0';
+
+const mainOptions = {
+    exit: Actor.isAtHome(),
+    storage: process.env.STORAGE_IMPLEMENTATION === 'LOCAL' ? new ApifyStorageLocal() : undefined,
+};
+
+const run = async () => {
+    await Actor.main(async () => {
+        const crawler = new CheerioCrawler({
+            maxConcurrency: 1,
+            maxRequestsPerCrawl: 5,
+            async requestHandler({ enqueueLinks, request }) {
+                const { url } = request;
+                await enqueueLinks({ pseudoUrls: ['https://apify.com[(/[\\w-]+)?]'] });
+
+                await Dataset.pushData({ url });
+
+                process.emit('SIGINT');
+            },
+        });
+
+        // eslint-disable-next-line no-underscore-dangle
+        Configuration.getGlobalConfig().getStorageClient().__purged = false;
+
+        await crawler.run(['https://apify.com']);
+    }, mainOptions);
+};
+
+await run();
+await run();

--- a/test/e2e/migration/actor/package.json
+++ b/test/e2e/migration/actor/package.json
@@ -1,0 +1,28 @@
+{
+    "name": "test-migration",
+    "version": "0.0.1",
+    "description": "Migration Test",
+    "dependencies": {
+        "apify": "next",
+        "@apify/storage-local": "^2.1.0",
+        "@crawlee/basic": "file:./packages/basic-crawler",
+        "@crawlee/browser-pool": "file:./packages/browser-pool",
+        "@crawlee/http": "file:./packages/http-crawler",
+        "@crawlee/cheerio": "file:./packages/cheerio-crawler",
+        "@crawlee/core": "file:./packages/core",
+        "@crawlee/memory-storage": "file:./packages/memory-storage",
+        "@crawlee/types": "file:./packages/types",
+        "@crawlee/utils": "file:./packages/utils"
+    },
+    "overrides": {
+        "apify": {
+            "@crawlee/core": "file:./packages/core",
+            "@crawlee/utils": "file:./packages/utils"
+        }
+    },
+    "scripts": {
+        "start": "node main.js"
+    },
+    "type": "module",
+    "license": "ISC"
+}

--- a/test/e2e/migration/test.mjs
+++ b/test/e2e/migration/test.mjs
@@ -1,0 +1,10 @@
+import { initialize, getActorTestDir, runActor, expect, validateDataset } from '../tools.mjs';
+
+const testActorDirname = getActorTestDir(import.meta.url);
+await initialize(testActorDirname);
+
+const { datasetItems } = await runActor(testActorDirname);
+
+await expect(datasetItems.length === 2, 'Number of dataset items');
+await expect(validateDataset(datasetItems, ['url']), 'Dataset items validation');
+await expect(datasetItems[0].url !== datasetItems[1].url, 'Dataset items unique');


### PR DESCRIPTION
1. I noticed that `_pauseOnMigration` does not stop the autoscaled pool, keeping the event loop alive. Is this expected?
    Google Meet summary: probably, let's consult with Ondra
    Resolution: it should probably not block the event loop, but there's bunch of other things that are blocking the event loop, such as snapshotter so probably not worth the change
3. Do we want to E2E test this? Done ✅ 

Flaky tests encountered (should be a separate issue?):

```
https://github.com/apify/crawlee/actions/runs/3218900877/jobs/5263614933#step:9:70

FAIL test/core/session_pool/session_pool.test.ts (8.869 s)
  ● SessionPool - testing session pool › should initialize with default values for first time

    ENOENT: no such file or directory, stat '/home/runner/work/crawlee/crawlee/storage/datasets/default/000000001.json.lock'

https://github.com/apify/crawlee/actions/runs/3218900877/jobs/5263615026#step:9:70

FAIL test/core/crawlers/puppeteer_crawler.test.ts (40.046 s)
  ● PuppeteerCrawler › should work

    ENOENT: no such file or directory, stat '/home/runner/work/crawlee/crawlee/storage/datasets/default/000000001.json.lock'

https://github.com/apify/crawlee/actions/runs/3263113405/jobs/5361354845#step:9:82

FAIL test/core/autoscaling/snapshotter.test.ts (8.556 s)
  ● Snapshotter › correctly marks CPU overloaded using OS metrics

    expect(jest.fn()).toBeCalledTimes(expected)

    Expected number of calls: 5
    Received number of calls: 6

      168 |         expect(loopSnapshots[3].isOverloaded).toBe(false);
      169 |         expect(loopSnapshots[4].isOverloaded).toBe(true);
    > 170 |         expect(cpusMock).toBeCalledTimes(5);
          |                          ^
      171 |
      172 |         cpusMock.mockRestore();
      173 |         spy.mockRestore();

      at Object.<anonymous> (test/core/autoscaling/snapshotter.test.ts:170:26)
```

Closes #1531