### PR TITLE
test: fix flakyness of some test that used default storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "postbuild": "node ./scripts/typescript_fixes.mjs",
         "ci:build": "turbo run build --cache-dir=\".turbo\"",
         "postci:build": "node ./scripts/typescript_fixes.mjs",
-        "test": "jest --silent --runInBand",
+        "test": "jest --silent",
         "test:e2e": "node test/e2e/run.mjs",
         "coverage": "jest --coverage",
         "publish:next": "lerna publish from-package --contents dist --dist-tag next --force-publish",

--- a/packages/basic-crawler/test/migration.test.ts
+++ b/packages/basic-crawler/test/migration.test.ts
@@ -1,6 +1,17 @@
 import type { Log } from '@apify/log';
 import log from '@apify/log';
+import { MemoryStorageEmulator } from 'test/shared/MemoryStorageEmulator';
 import { BasicCrawler, RequestList } from '../src/index';
+
+const localStorageEmulator = new MemoryStorageEmulator();
+
+beforeEach(async () => {
+    await localStorageEmulator.init();
+});
+
+afterAll(async () => {
+    await localStorageEmulator.destroy();
+});
 
 describe('Moving from handleRequest* to requestHandler*', () => {
     let requestList: RequestList;

--- a/packages/browser-crawler/test/migration.test.ts
+++ b/packages/browser-crawler/test/migration.test.ts
@@ -2,7 +2,18 @@ import type { Log } from '@apify/log';
 import log from '@apify/log';
 import { PuppeteerPlugin } from '@crawlee/browser-pool';
 import puppeteer from 'puppeteer';
+import { MemoryStorageEmulator } from 'test/shared/MemoryStorageEmulator';
 import { BrowserCrawler, RequestList } from '../src/index';
+
+const localStorageEmulator = new MemoryStorageEmulator();
+
+beforeEach(async () => {
+    await localStorageEmulator.init();
+});
+
+afterAll(async () => {
+    await localStorageEmulator.destroy();
+});
 
 const plugin = new PuppeteerPlugin(puppeteer);
 

--- a/packages/cheerio-crawler/test/migration.test.ts
+++ b/packages/cheerio-crawler/test/migration.test.ts
@@ -1,6 +1,17 @@
 import type { Log } from '@apify/log';
 import log from '@apify/log';
+import { MemoryStorageEmulator } from 'test/shared/MemoryStorageEmulator';
 import { CheerioCrawler, RequestList } from '../src/index';
+
+const localStorageEmulator = new MemoryStorageEmulator();
+
+beforeEach(async () => {
+    await localStorageEmulator.init();
+});
+
+afterAll(async () => {
+    await localStorageEmulator.destroy();
+});
 
 describe('Moving from handleRequest* to requestHandler*', () => {
     let requestList: RequestList;

--- a/test/core/storages/key_value_store.test.ts
+++ b/test/core/storages/key_value_store.test.ts
@@ -1,7 +1,17 @@
-import { ENV_VARS } from '@apify/consts';
 import { maybeStringify, Configuration, KeyValueStore } from '@crawlee/core';
 import type { Dictionary } from '@crawlee/utils';
 import { PassThrough } from 'stream';
+import { MemoryStorageEmulator } from 'test/shared/MemoryStorageEmulator';
+
+const localStorageEmulator = new MemoryStorageEmulator();
+
+beforeEach(async () => {
+    await localStorageEmulator.init();
+});
+
+afterAll(async () => {
+    await localStorageEmulator.destroy();
+});
 
 describe('KeyValueStore', () => {
     const client = Configuration.getStorageClient();


### PR DESCRIPTION
Possible explanation: sme tests were not using the storage emulator, and the automatic purge of default storage sometimes collided with another test.

We might want to consider disabling the file system persistence in the storage emulator, could result in perf improvements of the tests. 