### PR TITLE
docs: add launcher description

### DIFF
--- a/packages/browser-crawler/src/internals/browser-launcher.ts
+++ b/packages/browser-crawler/src/internals/browser-launcher.ts
@@ -58,6 +58,10 @@ export interface BrowserLaunchContext<TOptions, Launcher> extends BrowserPluginO
      */
     userAgent?: string;
 
+    /**
+     * The type of browser to be launched.
+     * By default, `chromium` is used. Other browsers like `webkit` or `firefox` can be used.
+     */
     launcher?: Launcher;
 }
 

--- a/packages/browser-crawler/src/internals/browser-launcher.ts
+++ b/packages/browser-crawler/src/internals/browser-launcher.ts
@@ -61,6 +61,14 @@ export interface BrowserLaunchContext<TOptions, Launcher> extends BrowserPluginO
     /**
      * The type of browser to be launched.
      * By default, `chromium` is used. Other browsers like `webkit` or `firefox` can be used.
+     *
+     * @example
+     * ```ts
+     * // import the browser from the library first
+     * import { firefox } from 'playwright';
+     * ```
+     *
+     * For more details, check out the [example](https://crawlee.dev/docs/examples/playwright-crawler-firefox).
      */
     launcher?: Launcher;
 }


### PR DESCRIPTION
The launcher property should have a description to make it more understandable in the documentation.