### PR TITLE
fix: build storage classes by using `this` instead of the class

### DIFF
--- a/packages/core/src/storages/dataset.ts
+++ b/packages/core/src/storages/dataset.ts
@@ -527,7 +527,7 @@ export class Dataset<Data extends Dictionary = Dictionary> {
         }));
         options.config ??= Configuration.getGlobalConfig();
         await purgeDefaultStorages();
-        const manager = StorageManager.getManager<Dataset<Data>>(Dataset, options.config);
+        const manager = StorageManager.getManager<Dataset<Data>>(this, options.config);
 
         return manager.openStorage(datasetIdOrName, options.config.getStorageClient());
     }

--- a/packages/core/src/storages/key_value_store.ts
+++ b/packages/core/src/storages/key_value_store.ts
@@ -411,7 +411,7 @@ export class KeyValueStore {
             config: ow.optional.object.instanceOf(Configuration),
         }));
         await purgeDefaultStorages();
-        const manager = StorageManager.getManager(KeyValueStore, options.config);
+        const manager = StorageManager.getManager(this, options.config);
 
         return manager.openStorage(storeIdOrName);
     }

--- a/packages/core/src/storages/request_queue.ts
+++ b/packages/core/src/storages/request_queue.ts
@@ -785,7 +785,7 @@ export class RequestQueue {
         }));
 
         await purgeDefaultStorages();
-        const manager = StorageManager.getManager(RequestQueue, options.config);
+        const manager = StorageManager.getManager(this, options.config);
 
         return manager.openStorage(queueIdOrName);
     }


### PR DESCRIPTION
This allows us to extend the classes (like we do in SDK) while not requireing us to extend the static `open` method