### PR TITLE
fix: mark session as bad on failed requests

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -951,6 +951,8 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
                 }
                 throw secondaryError;
             }
+            // decrease the session score if the request fails (but the error handler did not throw)
+            session?.markBad();
         } finally {
             await this._cleanupContext(crawlingContext);
 


### PR DESCRIPTION
The session used in a request handler that throws an error is now **marked bad**. 
This is in line with no-error behavior marking the session as good - but might cause (unwanted) faster session rotation.

closes #1635 
closes #1648