### PR TITLE
fix: increment usage count on handler error

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -951,6 +951,8 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
                 }
                 throw secondaryError;
             }
+            // eslint-disable-next-line dot-notation
+            if (session) session['usageCount']++;
         } finally {
             await this._cleanupContext(crawlingContext);
 


### PR DESCRIPTION
When `requestHandler` throws an error, the session usage count is incremented.

This PR does not mark the failed session as bad, but accesses a private property `usageCount` - which might break some invariants - the `usageCount` is updated, but the `errorScore` stays the same.

closes #1635
closes #1647 