### PR TITLE
fix: handle non-error objects thrown gracefully

### DIFF
--- a/packages/utils/src/internals/error_tracker.ts
+++ b/packages/utils/src/internals/error_tracker.ts
@@ -219,6 +219,10 @@ const mergeMessages = (a: string, b: string, storage: Record<string, unknown>) =
 const getErrorMessageGroup = (error: ErrnoException, storage: Record<string, unknown>, showFullMessage: boolean) => {
     let { message } = error;
 
+    if (!message) {
+        message = typeof error === 'string' ? error : `Unknown error message. Received non-error object: ${JSON.stringify(error)}`;
+    }
+
     if (!showFullMessage) {
         const newLineIndex = message.indexOf('\n');
         message = message.slice(0, newLineIndex === -1 ? undefined : newLineIndex);

--- a/packages/utils/test/non-error-objects-working.test.ts
+++ b/packages/utils/test/non-error-objects-working.test.ts
@@ -1,0 +1,9 @@
+import { ErrorTracker } from '../src/internals/error_tracker';
+
+describe('ErrorTracker', () => {
+    test('processing a non-error error should not crash', () => {
+        const errorTracker = new ErrorTracker();
+        // @ts-expect-error tracking non-error errors
+        expect(() => errorTracker.add('foo')).not.toThrow();
+    });
+});


### PR DESCRIPTION
Closes #1636 