### PR TITLE
chore: re-export package.json from the core module

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,8 @@
             "import": "./dist/index.mjs",
             "require": "./dist/index.js",
             "types": "./dist/index.d.ts"
-        }
+        },
+        "./package.json": "./package.json"
     },
     "keywords": [
         "apify",


### PR DESCRIPTION
Needed for https://github.com/apify/apify-sdk-js/pull/122 (and somehow the only one missing)