### PR TITLE
feat(jsdom-crawler): add runScripts option

### DIFF
--- a/docs/examples/jsdom_crawler.mdx
+++ b/docs/examples/jsdom_crawler.mdx
@@ -7,8 +7,9 @@ import CodeBlock from '@theme/CodeBlock';
 import ApiLink from '@site/src/components/ApiLink';
 import JSDOMCrawlerSource from '!!raw-loader!./jsdom_crawler.ts';
 
-This example demonstrates how to use <ApiLink to="jsdom-crawler/class/JSDOMCrawler">`JSDOMCrawler`</ApiLink> to crawl a list of URLs from an external file, load each URL using a plain HTTP request, parse the HTML using the [jsdom](https://www.npmjs.com/package/jsdom) DOM implementation and extract some data from it: the page title and all `h1` tags.
+This example demonstrates how to use <ApiLink to="jsdom-crawler/class/JSDOMCrawler">`JSDOMCrawler`</ApiLink> to interact with a website using [jsdom](https://www.npmjs.com/package/jsdom) DOM implementation.
+Here the script will open a calculator app from the [React examples](https://reactjs.org/community/examples.html), click `1` `+` `1` `=` and extract the result.
 
-<CodeBlock className="language-js">
+<CodeBlock className="language-ts">
 	{JSDOMCrawlerSource}
 </CodeBlock>

--- a/package-lock.json
+++ b/package-lock.json
@@ -16797,7 +16797,8 @@
                 "@crawlee/http": "^3.1.1",
                 "@crawlee/types": "^3.1.1",
                 "@types/jsdom": "^20.0.0",
-                "jsdom": "^20.0.0"
+                "jsdom": "^20.0.0",
+                "ow": "^0.28.2"
             },
             "engines": {
                 "node": ">=16.0.0"

--- a/packages/browser-pool/src/abstract-classes/browser-plugin.ts
+++ b/packages/browser-pool/src/abstract-classes/browser-plugin.ts
@@ -13,6 +13,8 @@ import type { UnwrapPromise } from '../utils';
  *  - without using a fingerprint,
  *  - without specifying a user agent.
  * Last updated on 2022-05-05.
+ *
+ * After you update it here, please update it also in jsdom-crawler.ts
  */
 export const DEFAULT_USER_AGENT = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.54 Safari/537.36';
 

--- a/packages/jsdom-crawler/package.json
+++ b/packages/jsdom-crawler/package.json
@@ -57,6 +57,7 @@
         "@crawlee/http": "^3.1.1",
         "@crawlee/types": "^3.1.1",
         "@types/jsdom": "^20.0.0",
-        "jsdom": "^20.0.0"
+        "jsdom": "^20.0.0",
+        "ow": "^0.28.2"
     }
 }

--- a/packages/jsdom-crawler/src/internals/jsdom-crawler.ts
+++ b/packages/jsdom-crawler/src/internals/jsdom-crawler.ts
@@ -140,7 +140,7 @@ export class JSDOMCrawler extends HttpCrawler<JSDOMCrawlingContext> {
     }
 
     protected override async _cleanupContext(context: JSDOMCrawlingContext) {
-        context.window.close();
+        context.window?.close();
     }
 
     protected override async _parseHTML(response: IncomingMessage, isXml: boolean, crawlingContext: JSDOMCrawlingContext) {

--- a/test/e2e/jsdom-react-ts/actor/.gitignore
+++ b/test/e2e/jsdom-react-ts/actor/.gitignore
@@ -1,0 +1,11 @@
+.idea
+.DS_Store
+node_modules
+package-lock.json
+apify_storage
+crawlee_storage
+storage
+main.d.ts
+main.d.ts.map
+main.js
+main.js.map

--- a/test/e2e/jsdom-react-ts/actor/Dockerfile
+++ b/test/e2e/jsdom-react-ts/actor/Dockerfile
@@ -1,0 +1,28 @@
+# using multistage build, as we need dev deps to build the TS source code
+FROM apify/actor-node:16-beta AS builder
+
+# copy all files, install all dependencies (including dev deps) and build the project
+COPY . ./
+RUN npm install --include=dev \
+    && npm run build
+
+# create final image
+FROM apify/actor-node:16-beta
+# copy only necessary files
+COPY --from=builder /usr/src/app/packages ./packages
+COPY --from=builder /usr/src/app/package.json ./
+COPY --from=builder /usr/src/app/main.js ./
+
+# install only prod deps
+RUN npm --quiet set progress=false \
+    && npm install --only=prod --no-optional \
+    && npm update \
+    && echo "Installed NPM packages:" \
+    && (npm list --only=prod --no-optional --all || true) \
+    && echo "Node.js version:" \
+    && node --version \
+    && echo "NPM version:" \
+    && npm --version
+
+# run compiled code
+CMD npm run start:prod

--- a/test/e2e/jsdom-react-ts/actor/apify.json
+++ b/test/e2e/jsdom-react-ts/actor/apify.json
@@ -1,0 +1,6 @@
+{
+	"name": "test-jsdom-default-ts",
+	"version": "0.0",
+	"buildTag": "latest",
+	"env": null
+}

--- a/test/e2e/jsdom-react-ts/actor/apify.json
+++ b/test/e2e/jsdom-react-ts/actor/apify.json
@@ -1,5 +1,5 @@
 {
-	"name": "test-jsdom-default-ts",
+	"name": "test-jsdom-react-ts",
 	"version": "0.0",
 	"buildTag": "latest",
 	"env": null

--- a/test/e2e/jsdom-react-ts/actor/main.ts
+++ b/test/e2e/jsdom-react-ts/actor/main.ts
@@ -1,0 +1,27 @@
+import { Actor } from 'apify';
+import { JSDOMCrawler, Dataset } from '@crawlee/jsdom';
+import { ApifyStorageLocal } from '@apify/storage-local';
+
+if (process.env.STORAGE_IMPLEMENTATION === 'LOCAL') {
+    await Actor.init({ storage: new ApifyStorageLocal() });
+} else {
+    await Actor.init();
+}
+
+const crawler = new JSDOMCrawler();
+
+crawler.router.addDefaultHandler(async ({ window, enqueueLinks, request, log }) => {
+    const { url } = request;
+    await enqueueLinks({
+        globs: ['https://crawlee.dev/docs/**'],
+    });
+
+    const pageTitle = window.document.title;
+    log.info(`URL: ${url} TITLE: ${pageTitle}`);
+
+    await Dataset.pushData({ url, pageTitle });
+});
+
+await crawler.run(['https://crawlee.dev/docs/quick-start']);
+
+await Actor.exit({ exit: Actor.isAtHome() });

--- a/test/e2e/jsdom-react-ts/actor/main.ts
+++ b/test/e2e/jsdom-react-ts/actor/main.ts
@@ -8,20 +8,24 @@ if (process.env.STORAGE_IMPLEMENTATION === 'LOCAL') {
     await Actor.init();
 }
 
-const crawler = new JSDOMCrawler();
+const crawler = new JSDOMCrawler({
+    runScripts: true,
+    requestHandler: async ({ window }) => {
+        const { document } = window;
+        document.querySelectorAll('button')[12].click(); // 1
+        document.querySelectorAll('button')[15].click(); // +
+        document.querySelectorAll('button')[12].click(); // 1
+        document.querySelectorAll('button')[18].click(); // =
 
-crawler.router.addDefaultHandler(async ({ window, enqueueLinks, request, log }) => {
-    const { url } = request;
-    await enqueueLinks({
-        globs: ['https://crawlee.dev/docs/**'],
-    });
+        // 2
+        const { innerHTML } = document.querySelectorAll('.component-display')[0].childNodes[0] as Element;
 
-    const pageTitle = window.document.title;
-    log.info(`URL: ${url} TITLE: ${pageTitle}`);
-
-    await Dataset.pushData({ url, pageTitle });
+        await Dataset.pushData({ result: innerHTML });
+    },
 });
 
-await crawler.run(['https://crawlee.dev/docs/quick-start']);
+await crawler.run([
+    'https://ahfarmer.github.io/calculator/',
+]);
 
 await Actor.exit({ exit: Actor.isAtHome() });

--- a/test/e2e/jsdom-react-ts/actor/package.json
+++ b/test/e2e/jsdom-react-ts/actor/package.json
@@ -1,0 +1,35 @@
+{
+    "name": "test-jsdom-default-ts",
+    "version": "0.0.1",
+    "description": "JSDOM Crawler Test - TypeScript",
+    "dependencies": {
+        "apify": "next",
+        "@apify/storage-local": "^2.1.0",
+        "@crawlee/basic": "file:./packages/basic-crawler",
+        "@crawlee/browser-pool": "file:./packages/browser-pool",
+        "@crawlee/http": "file:./packages/http-crawler",
+        "@crawlee/jsdom": "file:./packages/jsdom-crawler",
+        "@crawlee/core": "file:./packages/core",
+        "@crawlee/memory-storage": "file:./packages/memory-storage",
+        "@crawlee/types": "file:./packages/types",
+        "@crawlee/utils": "file:./packages/utils"
+    },
+    "overrides": {
+        "apify": {
+            "@crawlee/core": "file:./packages/core",
+            "@crawlee/types": "file:./packages/types",
+            "@crawlee/utils": "file:./packages/utils"
+        }
+    },
+    "devDependencies": {
+        "@apify/tsconfig": "^0.1.0",
+        "typescript": "4.7.4"
+    },
+    "scripts": {
+        "start": "tsc && node main.js",
+        "start:prod": "node main.js",
+        "build": "tsc"
+    },
+    "type": "module",
+    "license": "ISC"
+}

--- a/test/e2e/jsdom-react-ts/actor/package.json
+++ b/test/e2e/jsdom-react-ts/actor/package.json
@@ -1,7 +1,7 @@
 {
-    "name": "test-jsdom-default-ts",
+    "name": "test-jsdom-react-ts",
     "version": "0.0.1",
-    "description": "JSDOM Crawler Test - TypeScript",
+    "description": "JSDOM Crawler Test - React - TypeScript",
     "dependencies": {
         "apify": "next",
         "@apify/storage-local": "^2.1.0",

--- a/test/e2e/jsdom-react-ts/actor/tsconfig.json
+++ b/test/e2e/jsdom-react-ts/actor/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "@apify/tsconfig",
+    "compilerOptions": {
+        "module": "ES2022",
+        "target": "ES2022",
+        "lib": ["DOM"]
+    },
+    "include": [
+        "./**/*.ts"
+    ]
+}

--- a/test/e2e/jsdom-react-ts/test.mjs
+++ b/test/e2e/jsdom-react-ts/test.mjs
@@ -1,0 +1,10 @@
+import { initialize, getActorTestDir, runActor, expect, validateDataset } from '../tools.mjs';
+
+const testActorDirname = getActorTestDir(import.meta.url);
+await initialize(testActorDirname);
+
+const { stats, datasetItems } = await runActor(testActorDirname);
+
+await expect(stats.requestsFinished > 40, 'All requests finished');
+await expect(datasetItems.length > 40, 'Number of dataset items');
+await expect(validateDataset(datasetItems, ['url', 'pageTitle']), 'Dataset items validation');

--- a/test/e2e/jsdom-react-ts/test.mjs
+++ b/test/e2e/jsdom-react-ts/test.mjs
@@ -5,6 +5,7 @@ await initialize(testActorDirname);
 
 const { stats, datasetItems } = await runActor(testActorDirname);
 
-await expect(stats.requestsFinished > 40, 'All requests finished');
-await expect(datasetItems.length > 40, 'Number of dataset items');
-await expect(validateDataset(datasetItems, ['url', 'pageTitle']), 'Dataset items validation');
+await expect(stats.requestsFinished === 1, 'All requests finished');
+await expect(datasetItems.length === 1, 'Number of dataset items');
+await expect(validateDataset(datasetItems, ['result']), 'Dataset items validation');
+await expect(datasetItems[0].result, 'Dataset items');


### PR DESCRIPTION
What's missing here is session integration. For now every page load has a different `cookieJar`.

https://github.com/jsdom/jsdom#advanced-configuration Resources such as CSS / JS can be downloaded via a proxy (this should be optional, as downloading several megabytes through a proxy sometimes takes too long). Also the user-agent is `jsdom/xxx` for downloading resources, which should be changed.

The proposals above probably require a bigger change in Session API (should be a separate PR), e.g. the generated headers should be stored in the session, not in `got-scraping`, otherwise we don't know what user agent we should pass to JSDOM. Also I don't see any reason why the Session API does not expose `cookieJar` directly.