### PR TITLE
fix: make router error message more helpful for undefined routes

### DIFF
--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -115,12 +115,11 @@ export class Router<Context extends CrawlingContext> {
             return this.routes.get(defaultRoute)!;
         }
 
-        if (!label) {
-            // eslint-disable-next-line max-len
-            throw new MissingRouteError(`No default route set up. Please specify 'requestHandler' option or provide default route via 'crawler.router.addDefaultRoute()'.`);
-        }
-
-        throw new MissingRouteError(`Route not found for label '${String(label)}' and no default route set up!`);
+        throw new MissingRouteError(
+            `Route not found for label '${String(label)}'.`
+            + ' You must set up a route for this label or a default route.'
+            + ' Use `requestHandler`, `router.addHandler` or `router.addDefaultHandler`.',
+        );
     }
 
     /**

--- a/test/core/crawlers/cheerio_crawler.test.ts
+++ b/test/core/crawlers/cheerio_crawler.test.ts
@@ -190,7 +190,7 @@ describe('CheerioCrawler', () => {
         });
 
         // eslint-disable-next-line max-len
-        await expect(cheerioCrawler.run()).rejects.toThrow(`No default route set up. Please specify 'requestHandler' option or provide default route via 'crawler.router.addDefaultRoute()'.`);
+        await expect(cheerioCrawler.run()).rejects.toThrow("Route not found for label 'undefined'. You must set up a route for this label or a default route. Use `requestHandler`, `router.addHandler` or `router.addDefaultHandler`.");
     });
 
     test('should ignore ssl by default', async () => {


### PR DESCRIPTION
Trying to improve the error message a bit. I had a situation where I forgot to add a label to `enqueueLinks`. The original message told me that I needed to add a default route, but it did not mention that it's telling me this, because the label was undefined. The issue wasn't a missing default route, but a missing label. Hopefully this one is a bit more clear, but happy to hear other suggestions.