### PR TITLE
fix: lock lib versions in templates with the docker image versions

### DIFF
--- a/docs/guides/docker_images.mdx
+++ b/docs/guides/docker_images.mdx
@@ -71,19 +71,19 @@ FROM apify/actor-node-playwright-chrome:16-1.10.0-beta
 
 - Node.js version tag should **always** be used.
 - The automation library version tag should be used for **added security**.
-- Asterisk `*` should be used as the automation library version in our `package.json` files.
+- The automation library version should always match the image tag to avoid **compatibility issues**.
 
-It makes sure the pre-installed version of Puppeteer or Playwright is not re-installed on build. This is important, because those libraries are only guaranteed to work with specific versions of browsers, and those browsers come pre-installed in the image.
+This is important, because those libraries are only guaranteed to work with specific versions of browsers, and those browsers come pre-installed in the image. If not specified, package managers (`yarn`, `npm`) can resolve the package versions differently, which can lead to compatibility issues. 
 
 ```dockerfile
-FROM apify/actor-node-playwright-chrome:16
+FROM apify/actor-node-playwright-chrome:16-1.25.0
 ```
 
 ```json
 {
     "dependencies": {
         "crawlee": "^3.0.0",
-        "playwright": "*"
+        "playwright": "1.25.0"
     }
 }
 ```

--- a/packages/templates/templates/getting-started-js/Dockerfile
+++ b/packages/templates/templates/getting-started-js/Dockerfile
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://crawlee.dev/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node-playwright-chrome:16
+FROM apify/actor-node-playwright-chrome:16-1.25.0
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.

--- a/packages/templates/templates/getting-started-js/package.json
+++ b/packages/templates/templates/getting-started-js/package.json
@@ -5,7 +5,7 @@
     "description": "This is an example of a Crawlee project.",
     "dependencies": {
         "crawlee": "^3.0.0",
-        "playwright": "*"
+        "playwright": "1.25.0"
     },
     "scripts": {
         "start": "node src/main.js",

--- a/packages/templates/templates/getting-started-ts/Dockerfile
+++ b/packages/templates/templates/getting-started-ts/Dockerfile
@@ -19,7 +19,7 @@ COPY --chown=myuser . ./
 RUN npm run build
 
 # Create final image
-FROM apify/actor-node-playwright-chrome:16
+FROM apify/actor-node-playwright-chrome:16-1.25.0
 
 # Copy only built JS files from builder image
 COPY --from=builder --chown=myuser /home/myuser/dist ./dist

--- a/packages/templates/templates/getting-started-ts/package.json
+++ b/packages/templates/templates/getting-started-ts/package.json
@@ -5,7 +5,7 @@
     "description": "This is an example of a Crawlee project.",
     "dependencies": {
         "crawlee": "^3.0.0",
-        "playwright": "*"
+        "playwright": "1.25.0"
     },
     "devDependencies": {
         "@apify/tsconfig": "^0.1.0",

--- a/packages/templates/templates/playwright-js/Dockerfile
+++ b/packages/templates/templates/playwright-js/Dockerfile
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://crawlee.dev/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node-playwright-chrome:16
+FROM apify/actor-node-playwright-chrome:16-1.25.0
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.

--- a/packages/templates/templates/playwright-js/package.json
+++ b/packages/templates/templates/playwright-js/package.json
@@ -5,7 +5,7 @@
     "description": "This is an example of a Crawlee project.",
     "dependencies": {
         "crawlee": "^3.0.0",
-        "playwright": "*"
+        "playwright": "1.25.0"
     },
     "scripts": {
         "start": "node src/main.js",

--- a/packages/templates/templates/playwright-ts/Dockerfile
+++ b/packages/templates/templates/playwright-ts/Dockerfile
@@ -19,7 +19,7 @@ COPY --chown=myuser . ./
 RUN npm run build
 
 # Create final image
-FROM apify/actor-node-playwright-chrome:16
+FROM apify/actor-node-playwright-chrome:16-1.25.0
 
 # Copy only built JS files from builder image
 COPY --from=builder --chown=myuser /home/myuser/dist ./dist

--- a/packages/templates/templates/playwright-ts/package.json
+++ b/packages/templates/templates/playwright-ts/package.json
@@ -5,7 +5,7 @@
     "description": "This is an example of a Crawlee project.",
     "dependencies": {
         "crawlee": "^3.0.0",
-        "playwright": "*"
+        "playwright": "1.25.0"
     },
     "devDependencies": {
         "@apify/tsconfig": "^0.1.0",

--- a/packages/templates/templates/puppeteer-js/Dockerfile
+++ b/packages/templates/templates/puppeteer-js/Dockerfile
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://crawlee.dev/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node-puppeteer-chrome:16
+FROM apify/actor-node-puppeteer-chrome:16-15.1.1
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.

--- a/packages/templates/templates/puppeteer-js/package.json
+++ b/packages/templates/templates/puppeteer-js/package.json
@@ -5,7 +5,7 @@
     "description": "This is an example of a Crawlee project.",
     "dependencies": {
         "crawlee": "^3.0.0",
-        "puppeteer": "*"
+        "puppeteer": "15.1.1"
     },
     "scripts": {
         "start": "node src/main.js",

--- a/packages/templates/templates/puppeteer-ts/Dockerfile
+++ b/packages/templates/templates/puppeteer-ts/Dockerfile
@@ -19,7 +19,7 @@ COPY --chown=myuser . ./
 RUN npm run build
 
 # Create final image
-FROM apify/actor-node-puppeteer-chrome:16
+FROM apify/actor-node-puppeteer-chrome:16-15.1.1
 
 # Copy only built JS files from builder image
 COPY --from=builder --chown=myuser /home/myuser/dist ./dist

--- a/packages/templates/templates/puppeteer-ts/package.json
+++ b/packages/templates/templates/puppeteer-ts/package.json
@@ -5,7 +5,7 @@
     "description": "This is an example of a Crawlee project.",
     "dependencies": {
         "crawlee": "^3.0.0",
-        "puppeteer": "*"
+        "puppeteer": "15.1.1"
     },
     "devDependencies": {
         "@apify/tsconfig": "^0.1.0",


### PR DESCRIPTION
Perhaps adds a bit more hassle to the release pipeline, but is imho crucial to keep the templates ready for the future.

Templates should be imho dumb-proof - and we can do that only by having a total control over what is happening.

fixes #1685 