### PR TITLE
chore(ci): fix lerna issues with publishing releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Use Node.js 18
         uses: actions/setup-node@v3


### PR DESCRIPTION
We might not need to remove the changelog file at all, we'd need to test it out first 👀. If the next release has a broken changelog, we just nuke it for the next release, otherwise we celebrate