### PR TITLE
feat: hideInternalConsole in JSDOMCrawler

### DIFF
--- a/packages/jsdom-crawler/src/internals/jsdom-crawler.ts
+++ b/packages/jsdom-crawler/src/internals/jsdom-crawler.ts
@@ -165,13 +165,11 @@ export class JSDOMCrawler extends HttpCrawler<JSDOMCrawlingContext> {
      *
      * **Example usage:**
      * ```javascript
-     *   const console = crawler.getVirtualConsole();
-     *   console.on('error', (e) => {
-     *       log.error(e);
-     *   });
-     *
+     * const console = crawler.getVirtualConsole();
+     * console.on('error', (e) => {
+     *     log.error(e);
+     * });
      * ```
-     *
      */
     getVirtualConsole() {
         if (!this.virtualConsole) {

--- a/packages/jsdom-crawler/src/internals/jsdom-crawler.ts
+++ b/packages/jsdom-crawler/src/internals/jsdom-crawler.ts
@@ -157,7 +157,23 @@ export class JSDOMCrawler extends HttpCrawler<JSDOMCrawlingContext> {
         this.hideInternalConsole = hideInternalConsole;
     }
 
-    private getVirtualConsole() {
+    /**
+     * Returns the currently used `VirtualConsole` instance. Can be used to listen for the JSDOM's internal console messages.
+     *
+     * If the `hideInternalConsole` option is set to `true`, the messages aren't logged to the console by default,
+     * but the virtual console can still be listened to.
+     *
+     * **Example usage:**
+     * ```javascript
+     *   const console = crawler.getVirtualConsole();
+     *   console.on('error', (e) => {
+     *       log.error(e);
+     *   });
+     *
+     * ```
+     *
+     */
+    getVirtualConsole() {
         if (!this.virtualConsole) {
             this.virtualConsole = new VirtualConsole();
             if (!this.hideInternalConsole) {


### PR DESCRIPTION
Brings `JSDOMCrawler`'s logs closer to `Playwright`/`PuppeteerCrawler` - when set to `true`, the `hideInternalConsole` toggle turns off the JSDOM's calls to `console.log`, hiding the "page" script execution from the user. 