### PR TITLE
fix: allow `userData` option in `enqueueLinksByClickingElements`

### DIFF
--- a/packages/playwright-crawler/src/internals/enqueue-links/click-elements.ts
+++ b/packages/playwright-crawler/src/internals/enqueue-links/click-elements.ts
@@ -203,6 +203,7 @@ export async function enqueueLinksByClickingElements(options: EnqueueLinksByClic
         page: ow.object.hasKeys('goto', 'evaluate'),
         requestQueue: ow.object.hasKeys('fetchNextRequest', 'addRequest'),
         selector: ow.string,
+        userData: ow.optional.object,
         clickOptions: ow.optional.object.hasKeys('clickCount', 'delay'),
         pseudoUrls: ow.optional.array.ofType(ow.any(
             ow.string,

--- a/packages/puppeteer-crawler/src/internals/enqueue-links/click-elements.ts
+++ b/packages/puppeteer-crawler/src/internals/enqueue-links/click-elements.ts
@@ -208,6 +208,7 @@ export async function enqueueLinksByClickingElements(options: EnqueueLinksByClic
         page: ow.object.hasKeys('goto', 'evaluate'),
         requestQueue: ow.object.hasKeys('fetchNextRequest', 'addRequest'),
         selector: ow.string,
+        userData: ow.optional.object,
         clickOptions: ow.optional.object.hasKeys('clickCount', 'delay'),
         pseudoUrls: ow.optional.array.ofType(ow.any(
             ow.string,


### PR DESCRIPTION
It is included in the Options type, but was missing in the ow validation.

Does this need tests @B4nan ?

Fixes #1617 