### PR TITLE
chore: pin node and yarn for volta users

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,5 +100,9 @@
         "turbo": "1.7.0",
         "typescript": "^4.9.4"
     },
-    "packageManager": "yarn@3.3.1"
+    "packageManager": "yarn@3.3.1",
+    "volta": {
+        "node": "18.13.0",
+        "yarn": "3.3.1"
+    }
 }


### PR DESCRIPTION
This will help volta users get the correct yarn version (till volta supports `packageManager`)