### PR TITLE
feat: add forefront option to all enqueueLinks variants

### DIFF
--- a/packages/playwright-crawler/src/internals/enqueue-links/click-elements.ts
+++ b/packages/playwright-crawler/src/internals/enqueue-links/click-elements.ts
@@ -155,6 +155,16 @@ export interface EnqueueLinksByClickingElementsOptions {
      * @default 5
      */
     maxWaitForPageIdleSecs?: number;
+
+    /**
+     * If set to `true`:
+     *   - while adding the request to the queue: the request will be added to the foremost position in the queue.
+     *   - while reclaiming the request: the request will be placed to the beginning of the queue, so that it's returned
+     *   in the next call to {@apilink RequestQueue.fetchNextRequest}.
+     * By default, it's put to the end of the queue.
+     * @default false
+     */
+    forefront?: boolean;
 }
 
 /**
@@ -221,6 +231,7 @@ export async function enqueueLinksByClickingElements(options: EnqueueLinksByClic
         waitForPageIdleSecs: ow.optional.number,
         maxWaitForPageIdleSecs: ow.optional.number,
         label: ow.optional.string,
+        forefront: ow.optional.boolean,
     }));
 
     const {
@@ -234,6 +245,7 @@ export async function enqueueLinksByClickingElements(options: EnqueueLinksByClic
         transformRequestFunction,
         waitForPageIdleSecs = 1,
         maxWaitForPageIdleSecs = 5,
+        forefront,
     } = options;
 
     const waitForPageIdleMillis = waitForPageIdleSecs * 1000;
@@ -266,7 +278,7 @@ export async function enqueueLinksByClickingElements(options: EnqueueLinksByClic
         requestOptions = requestOptions.map(transformRequestFunction).filter((r) => !!r) as RequestOptions[];
     }
     const requests = createRequests(requestOptions, urlPatternObjects);
-    return requestQueue.addRequests(requests);
+    return requestQueue.addRequests(requests, { forefront });
 }
 
 interface WaitForPageIdleOptions {

--- a/packages/puppeteer-crawler/src/internals/enqueue-links/click-elements.ts
+++ b/packages/puppeteer-crawler/src/internals/enqueue-links/click-elements.ts
@@ -160,6 +160,16 @@ export interface EnqueueLinksByClickingElementsOptions {
      * @default 5
      */
     maxWaitForPageIdleSecs?: number;
+
+    /**
+     * If set to `true`:
+     *   - while adding the request to the queue: the request will be added to the foremost position in the queue.
+     *   - while reclaiming the request: the request will be placed to the beginning of the queue, so that it's returned
+     *   in the next call to {@apilink RequestQueue.fetchNextRequest}.
+     * By default, it's put to the end of the queue.
+     * @default false
+     */
+    forefront?: boolean;
 }
 
 /**
@@ -226,6 +236,7 @@ export async function enqueueLinksByClickingElements(options: EnqueueLinksByClic
         waitForPageIdleSecs: ow.optional.number,
         maxWaitForPageIdleSecs: ow.optional.number,
         label: ow.optional.string,
+        forefront: ow.optional.boolean,
     }));
 
     const {
@@ -239,6 +250,7 @@ export async function enqueueLinksByClickingElements(options: EnqueueLinksByClic
         transformRequestFunction,
         waitForPageIdleSecs = 1,
         maxWaitForPageIdleSecs = 5,
+        forefront,
     } = options;
 
     const waitForPageIdleMillis = waitForPageIdleSecs * 1000;
@@ -271,7 +283,7 @@ export async function enqueueLinksByClickingElements(options: EnqueueLinksByClic
         requestOptions = requestOptions.map(transformRequestFunction).filter((r) => !!r) as RequestOptions[];
     }
     const requests = createRequests(requestOptions, urlPatternObjects);
-    return requestQueue.addRequests(requests);
+    return requestQueue.addRequests(requests, { forefront });
 }
 
 interface WaitForPageIdleOptions {


### PR DESCRIPTION
Fixes #1483 (it actually already was there for enqueueLinks, but was missing in clickingElements variants and wasn't covered by tests