### PR TITLE
feat(MemoryStorage): read from fs if persistStorage is enabled, ram only otherwise

### DIFF
--- a/packages/memory-storage/src/fs/common.ts
+++ b/packages/memory-storage/src/fs/common.ts
@@ -1,0 +1,5 @@
+export interface StorageImplementation<T> {
+    get(): Promise<T>;
+    update(data: T): void | Promise<void>;
+    delete(): void | Promise<void>;
+}

--- a/packages/memory-storage/src/fs/dataset/fs.ts
+++ b/packages/memory-storage/src/fs/dataset/fs.ts
@@ -1,0 +1,27 @@
+import { readFile, rm } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { ensureDir } from 'fs-extra';
+import type { CreateStorageImplementationOptions } from './index';
+import type { StorageImplementation } from '../common';
+import { lockAndWrite } from '../../workers/worker-utils';
+
+export class DatasetFileSystemEntry<Data> implements StorageImplementation<Data> {
+    private filePath: string;
+
+    constructor(options: CreateStorageImplementationOptions) {
+        this.filePath = resolve(options.storeDirectory, `${options.entityId}.json`);
+    }
+
+    async get() {
+        return JSON.parse(await readFile(this.filePath, 'utf-8'));
+    }
+
+    async update(data: Data) {
+        await ensureDir(dirname(this.filePath));
+        await lockAndWrite(this.filePath, data);
+    }
+
+    async delete() {
+        await rm(this.filePath, { force: true });
+    }
+}

--- a/packages/memory-storage/src/fs/dataset/index.ts
+++ b/packages/memory-storage/src/fs/dataset/index.ts
@@ -1,0 +1,19 @@
+import type { Dictionary } from '@crawlee/types';
+import type { StorageImplementation } from '../common';
+import { DatasetFileSystemEntry } from './fs';
+import { DatasetMemoryEntry } from './memory';
+
+export function createDatasetStorageImplementation<Data extends Dictionary>(options: CreateStorageImplementationOptions): StorageImplementation<Data> {
+    if (options.persistStorage) {
+        return new DatasetFileSystemEntry<Data>(options);
+    }
+
+    return new DatasetMemoryEntry<Data>();
+}
+
+export interface CreateStorageImplementationOptions {
+    persistStorage: boolean;
+    storeDirectory: string;
+    /** The actual id of the file to save */
+    entityId: string;
+}

--- a/packages/memory-storage/src/fs/dataset/memory.ts
+++ b/packages/memory-storage/src/fs/dataset/memory.ts
@@ -1,0 +1,17 @@
+import type { StorageImplementation } from '../common';
+
+export class DatasetMemoryEntry<Data> implements StorageImplementation<Data> {
+    private data!: Data;
+
+    async get() {
+        return this.data;
+    }
+
+    update(data: Data) {
+        this.data = data;
+    }
+
+    delete() {
+        // No-op
+    }
+}

--- a/packages/memory-storage/src/fs/key-value-store/fs.ts
+++ b/packages/memory-storage/src/fs/key-value-store/fs.ts
@@ -1,0 +1,68 @@
+import { ensureDir } from 'fs-extra';
+import { readFile, rm } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { basename } from 'node:path/win32';
+import type { CreateStorageImplementationOptions } from '.';
+import type { InternalKeyRecord } from '../../resource-clients/key-value-store';
+import { memoryStorageLog } from '../../utils';
+import { lockAndWrite } from '../../workers/worker-utils';
+import type { StorageImplementation } from '../common';
+
+export class KeyValueFileSystemEntry implements StorageImplementation<InternalKeyRecord> {
+    private storeDirectory: string;
+    private writeMetadata: boolean;
+
+    private filePath!: string;
+    private fileMetadataPath!: string;
+    private rawRecord!: Omit<InternalKeyRecord, 'value'>;
+
+    constructor(options: CreateStorageImplementationOptions) {
+        this.storeDirectory = options.storeDirectory;
+        this.writeMetadata = options.writeMetadata;
+    }
+
+    async get(): Promise<InternalKeyRecord> {
+        let file: Buffer;
+
+        try {
+            file = await readFile(this.filePath);
+        } catch {
+            try {
+                // Try without extension
+                file = await readFile(resolve(this.storeDirectory, this.rawRecord.key));
+                memoryStorageLog.warning([
+                    `Key-value entry "${this.rawRecord.key}" for store ${basename(this.storeDirectory)} does not have a file extension, assuming it as text.`,
+                    'If you want to have correct interpretation of the file, you should add a file extension to the entry.',
+                ].join('\n'));
+            } catch {
+                // This is impossible to happen, but just in case
+                throw new Error(`Could not find file at ${this.filePath}`);
+            }
+        }
+
+        return {
+            ...this.rawRecord,
+            value: file,
+        };
+    }
+
+    async update(data: InternalKeyRecord) {
+        this.filePath ??= resolve(this.storeDirectory, `${data.key}.${data.extension}`);
+        this.fileMetadataPath ??= resolve(this.storeDirectory, `${data.key}.__metadata__.json`);
+
+        const { value, ...rest } = data;
+        this.rawRecord = rest;
+
+        await ensureDir(dirname(this.filePath));
+        await lockAndWrite(this.filePath, value, false);
+
+        if (this.writeMetadata) {
+            await lockAndWrite(this.fileMetadataPath, JSON.stringify(rest), true);
+        }
+    }
+
+    async delete() {
+        await rm(this.filePath, { force: true });
+        await rm(this.fileMetadataPath, { force: true });
+    }
+}

--- a/packages/memory-storage/src/fs/key-value-store/fs.ts
+++ b/packages/memory-storage/src/fs/key-value-store/fs.ts
@@ -22,7 +22,7 @@ export class KeyValueFileSystemEntry implements StorageImplementation<InternalKe
     }
 
     async get(): Promise<InternalKeyRecord> {
-        let file: Buffer;
+        let file: Buffer | string;
 
         try {
             file = await readFile(this.filePath);
@@ -34,6 +34,7 @@ export class KeyValueFileSystemEntry implements StorageImplementation<InternalKe
                     `Key-value entry "${this.rawRecord.key}" for store ${basename(this.storeDirectory)} does not have a file extension, assuming it as text.`,
                     'If you want to have correct interpretation of the file, you should add a file extension to the entry.',
                 ].join('\n'));
+                file = file.toString('utf-8');
             } catch {
                 // This is impossible to happen, but just in case
                 throw new Error(`Could not find file at ${this.filePath}`);

--- a/packages/memory-storage/src/fs/key-value-store/index.ts
+++ b/packages/memory-storage/src/fs/key-value-store/index.ts
@@ -1,0 +1,18 @@
+import type { InternalKeyRecord } from '../../resource-clients/key-value-store';
+import type { StorageImplementation } from '../common';
+import { KeyValueFileSystemEntry } from './fs';
+import { KeyValueMemoryEntry } from './memory';
+
+export function createKeyValueStorageImplementation(options: CreateStorageImplementationOptions): StorageImplementation<InternalKeyRecord> {
+    if (options.persistStorage) {
+        return new KeyValueFileSystemEntry(options);
+    }
+
+    return new KeyValueMemoryEntry();
+}
+
+export interface CreateStorageImplementationOptions {
+    persistStorage: boolean;
+    storeDirectory: string;
+    writeMetadata: boolean;
+}

--- a/packages/memory-storage/src/fs/key-value-store/memory.ts
+++ b/packages/memory-storage/src/fs/key-value-store/memory.ts
@@ -1,0 +1,18 @@
+import type { InternalKeyRecord } from '../../resource-clients/key-value-store';
+import type { StorageImplementation } from '../common';
+
+export class KeyValueMemoryEntry implements StorageImplementation<InternalKeyRecord> {
+    private data!: InternalKeyRecord;
+
+    async get() {
+        return this.data;
+    }
+
+    update(data: InternalKeyRecord) {
+        this.data = data;
+    }
+
+    delete() {
+        // No-op
+    }
+}

--- a/packages/memory-storage/src/fs/request-queue/fs.ts
+++ b/packages/memory-storage/src/fs/request-queue/fs.ts
@@ -1,0 +1,28 @@
+import { ensureDir } from 'fs-extra';
+import { readFile, rm } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import type { CreateStorageImplementationOptions } from '.';
+import type { InternalRequest } from '../../resource-clients/request-queue';
+import { lockAndWrite } from '../../workers/worker-utils';
+import type { StorageImplementation } from '../common';
+
+export class RequestQueueFileSystemEntry implements StorageImplementation<InternalRequest> {
+    private filePath: string;
+
+    constructor(options: CreateStorageImplementationOptions) {
+        this.filePath = resolve(options.storeDirectory, `${options.requestId}.json`);
+    }
+
+    async get() {
+        return JSON.parse(await readFile(this.filePath, 'utf-8'));
+    }
+
+    async update(data: InternalRequest) {
+        await ensureDir(dirname(this.filePath));
+        await lockAndWrite(this.filePath, data);
+    }
+
+    async delete() {
+        await rm(this.filePath, { force: true });
+    }
+}

--- a/packages/memory-storage/src/fs/request-queue/index.ts
+++ b/packages/memory-storage/src/fs/request-queue/index.ts
@@ -1,0 +1,18 @@
+import type { InternalRequest } from '../../resource-clients/request-queue';
+import type { StorageImplementation } from '../common';
+import { RequestQueueFileSystemEntry } from './fs';
+import { RequestQueueMemoryEntry } from './memory';
+
+export function createRequestQueueStorageImplementation(options: CreateStorageImplementationOptions): StorageImplementation<InternalRequest> {
+    if (options.persistStorage) {
+        return new RequestQueueFileSystemEntry(options);
+    }
+
+    return new RequestQueueMemoryEntry();
+}
+
+export interface CreateStorageImplementationOptions {
+    persistStorage: boolean;
+    storeDirectory: string;
+    requestId: string;
+}

--- a/packages/memory-storage/src/fs/request-queue/memory.ts
+++ b/packages/memory-storage/src/fs/request-queue/memory.ts
@@ -1,0 +1,18 @@
+import type { InternalRequest } from '../../resource-clients/request-queue';
+import type { StorageImplementation } from '../common';
+
+export class RequestQueueMemoryEntry implements StorageImplementation<InternalRequest> {
+    private data!: InternalRequest;
+
+    async get() {
+        return this.data;
+    }
+
+    update(data: InternalRequest) {
+        this.data = data;
+    }
+
+    delete() {
+        // No-op
+    }
+}

--- a/packages/memory-storage/src/resource-clients/request-queue.ts
+++ b/packages/memory-storage/src/resource-clients/request-queue.ts
@@ -10,6 +10,8 @@ import { purgeNullsFromObject, uniqueKeyToRequestId } from '../utils';
 import { BaseClient } from './common/base-client';
 import { sendWorkerMessage } from '../workers/instance';
 import { findRequestQueueByPossibleId } from '../cache-helpers';
+import type { StorageImplementation } from '../fs/common';
+import { createRequestQueueStorageImplementation } from '../fs/request-queue';
 
 const requestShape = s.object({
     id: s.string,
@@ -54,7 +56,7 @@ export class RequestQueueClient extends BaseClient implements storage.RequestQue
     pendingRequestCount = 0;
     requestQueueDirectory: string;
 
-    private readonly requests = new Map<string, InternalRequest>();
+    private readonly requests = new Map<string, StorageImplementation<InternalRequest>>();
     private readonly client: MemoryStorage;
 
     constructor(options: RequestQueueClientOptions) {
@@ -141,10 +143,12 @@ export class RequestQueueClient extends BaseClient implements storage.RequestQue
 
         const items = [];
 
-        for (const request of existingQueueById.requests.values()) {
+        for (const storageEntry of existingQueueById.requests.values()) {
             if (items.length === limit) {
                 break;
             }
+
+            const request = await storageEntry.get();
 
             if (request.orderNo) {
                 items.push(request);
@@ -171,10 +175,11 @@ export class RequestQueueClient extends BaseClient implements storage.RequestQue
 
         const requestModel = this._createInternalRequest(request, options.forefront);
 
-        const existingRequestWithId = existingQueueById.requests.get(requestModel.id);
+        const existingRequestWithIdEntry = existingQueueById.requests.get(requestModel.id);
 
         // We already have the request present, so we return information about it
-        if (existingRequestWithId) {
+        if (existingRequestWithIdEntry) {
+            const existingRequestWithId = await existingRequestWithIdEntry.get();
             existingQueueById.updateTimestamps(false);
 
             return {
@@ -184,10 +189,17 @@ export class RequestQueueClient extends BaseClient implements storage.RequestQue
             };
         }
 
-        existingQueueById.requests.set(requestModel.id, requestModel);
+        const newEntry = createRequestQueueStorageImplementation({
+            persistStorage: existingQueueById.client.persistStorage,
+            requestId: requestModel.id,
+            storeDirectory: existingQueueById.client.requestQueuesDirectory,
+        });
+
+        await newEntry.update(requestModel);
+
+        existingQueueById.requests.set(requestModel.id, newEntry);
         existingQueueById.pendingRequestCount += requestModel.orderNo === null ? 1 : 0;
         existingQueueById.updateTimestamps(true);
-        existingQueueById.updateItem(requestModel);
 
         return {
             requestId: requestModel.id,
@@ -216,9 +228,11 @@ export class RequestQueueClient extends BaseClient implements storage.RequestQue
         for (const model of requests) {
             const requestModel = this._createInternalRequest(model, options.forefront);
 
-            const existingRequestWithId = existingQueueById.requests.get(requestModel.id);
+            const existingRequestWithIdEntry = existingQueueById.requests.get(requestModel.id);
 
-            if (existingRequestWithId) {
+            if (existingRequestWithIdEntry) {
+                const existingRequestWithId = await existingRequestWithIdEntry.get();
+
                 result.processedRequests.push({
                     requestId: existingRequestWithId.id,
                     uniqueKey: existingRequestWithId.uniqueKey,
@@ -229,7 +243,15 @@ export class RequestQueueClient extends BaseClient implements storage.RequestQue
                 continue;
             }
 
-            existingQueueById.requests.set(requestModel.id, requestModel);
+            const newEntry = createRequestQueueStorageImplementation({
+                persistStorage: existingQueueById.client.persistStorage,
+                requestId: requestModel.id,
+                storeDirectory: existingQueueById.client.requestQueuesDirectory,
+            });
+
+            await newEntry.update(requestModel);
+
+            existingQueueById.requests.set(requestModel.id, newEntry);
             existingQueueById.pendingRequestCount += requestModel.orderNo === null ? 1 : 0;
             result.processedRequests.push({
                 requestId: requestModel.id,
@@ -239,7 +261,6 @@ export class RequestQueueClient extends BaseClient implements storage.RequestQue
                 wasAlreadyHandled: false,
                 wasAlreadyPresent: false,
             });
-            existingQueueById.updateItem(requestModel);
         }
 
         existingQueueById.updateTimestamps(true);
@@ -257,7 +278,7 @@ export class RequestQueueClient extends BaseClient implements storage.RequestQue
 
         existingQueueById.updateTimestamps(false);
 
-        const json = existingQueueById.requests.get(id)?.json;
+        const json = (await existingQueueById.requests.get(id)?.get())?.json;
         return this._jsonToRequest(json);
     }
 
@@ -276,17 +297,27 @@ export class RequestQueueClient extends BaseClient implements storage.RequestQue
         // First we need to check the existing request to be
         // able to return information about its handled state.
 
-        const existingRequest = existingQueueById.requests.get(requestModel.id);
+        const existingRequestEntry = existingQueueById.requests.get(requestModel.id);
 
         // Undefined means that the request is not present in the queue.
         // We need to insert it, to behave the same as API.
-        if (!existingRequest) {
+        if (!existingRequestEntry) {
             return this.addRequest(request, options);
         }
 
+        const existingRequest = await existingRequestEntry.get();
+
+        const newEntry = createRequestQueueStorageImplementation({
+            persistStorage: existingQueueById.client.persistStorage,
+            requestId: requestModel.id,
+            storeDirectory: existingQueueById.client.requestQueuesDirectory,
+        });
+
+        await newEntry.update(requestModel);
+
         // When updating the request, we need to make sure that
         // the handled counts are updated correctly in all cases.
-        existingQueueById.requests.set(requestModel.id, requestModel);
+        existingQueueById.requests.set(requestModel.id, newEntry);
 
         let handledCountAdjustment = 0;
         const isRequestHandledStateChanging = typeof existingRequest.orderNo !== typeof requestModel.orderNo;
@@ -297,7 +328,6 @@ export class RequestQueueClient extends BaseClient implements storage.RequestQue
 
         existingQueueById.pendingRequestCount += handledCountAdjustment;
         existingQueueById.updateTimestamps(true);
-        existingQueueById.updateItem(requestModel);
 
         return {
             requestId: requestModel.id,
@@ -313,21 +343,15 @@ export class RequestQueueClient extends BaseClient implements storage.RequestQue
             this.throwOnNonExisting(StorageTypes.RequestQueue);
         }
 
-        const request = existingQueueById.requests.get(id);
+        const entry = existingQueueById.requests.get(id);
 
-        if (request) {
+        if (entry) {
+            const request = await entry.get();
+
             existingQueueById.requests.delete(id);
             existingQueueById.pendingRequestCount -= request.orderNo ? 1 : 0;
             existingQueueById.updateTimestamps(true);
-            sendWorkerMessage({
-                action: 'delete-entry',
-                data: { id },
-                entityType: 'requestQueues',
-                entityDirectory: existingQueueById.requestQueueDirectory,
-                id: existingQueueById.name ?? existingQueueById.id,
-                writeMetadata: existingQueueById.client.writeMetadata,
-                persistStorage: existingQueueById.client.persistStorage,
-            });
+            await entry.delete();
         }
     }
 
@@ -358,18 +382,6 @@ export class RequestQueueClient extends BaseClient implements storage.RequestQue
         sendWorkerMessage({
             action: 'update-metadata',
             data,
-            entityType: 'requestQueues',
-            entityDirectory: this.requestQueueDirectory,
-            id: this.name ?? this.id,
-            writeMetadata: this.client.writeMetadata,
-            persistStorage: this.client.persistStorage,
-        });
-    }
-
-    private updateItem(item: InternalRequest) {
-        sendWorkerMessage({
-            action: 'update-entries',
-            data: item,
             entityType: 'requestQueues',
             entityDirectory: this.requestQueueDirectory,
             id: this.name ?? this.id,

--- a/packages/memory-storage/src/utils.ts
+++ b/packages/memory-storage/src/utils.ts
@@ -3,8 +3,6 @@ import type * as storage from '@crawlee/types';
 import { s } from '@sapphire/shapeshift';
 import { createHash } from 'node:crypto';
 import { REQUEST_ID_LENGTH } from './consts';
-import type { InternalKeyRecord } from './resource-clients/key-value-store';
-import type { InternalRequest } from './resource-clients/request-queue';
 
 /**
  * Removes all properties with a null value
@@ -67,19 +65,12 @@ export interface WorkerData {
     requestQueuesDirectory: string;
 }
 
-export type WorkerReceivedMessage = WorkerUpdateMetadataMessage | WorkerUpdateEntriesMessage | WorkerDeleteEntryMessage;
+export type WorkerReceivedMessage = WorkerUpdateMetadataMessage;
 
 export type WorkerUpdateMetadataMessage =
     | MetadataUpdate<'datasets', storage.DatasetInfo>
     | MetadataUpdate<'keyValueStores', storage.KeyValueStoreInfo>
     | MetadataUpdate<'requestQueues', storage.RequestQueueInfo>;
-
-export type WorkerUpdateEntriesMessage =
-    | EntriesUpdate<'datasets', [string, storage.Dictionary][]>
-    | EntriesUpdate<'keyValueStores', KeyValueStoreItemData>
-    | EntriesUpdate<'requestQueues', InternalRequest>;
-
-export type WorkerDeleteEntryMessage = EntryDelete<'requestQueues'>;
 
 type EntityType = 'datasets' | 'keyValueStores' | 'requestQueues';
 
@@ -91,31 +82,4 @@ interface MetadataUpdate<Type extends EntityType, DataType> {
     data: DataType;
     writeMetadata: boolean;
     persistStorage: boolean;
-}
-
-interface EntriesUpdate<Type extends EntityType, DataType> {
-    entityType: Type;
-    id: string;
-    action: 'update-entries';
-    entityDirectory: string;
-    data: DataType;
-    writeMetadata: boolean;
-    persistStorage: boolean;
-}
-
-interface EntryDelete<Type extends EntityType> {
-    entityType: Type;
-    id: string;
-    action: 'delete-entry';
-    entityDirectory: string;
-    writeMetadata: boolean;
-    persistStorage: boolean;
-    data: {
-        id: string;
-    };
-}
-
-interface KeyValueStoreItemData {
-    action: 'set' | 'delete';
-    record: InternalKeyRecord;
 }

--- a/packages/types/src/storages.ts
+++ b/packages/types/src/storages.ts
@@ -34,7 +34,7 @@ export interface DatasetCollectionData {
  */
 export interface DatasetCollectionClient {
     list(): Promise<PaginatedList<Dataset>>;
-    getOrCreate(name: string): Promise<DatasetCollectionData>;
+    getOrCreate(name?: string): Promise<DatasetCollectionData>;
 }
 
 export interface Dataset extends DatasetCollectionData {


### PR DESCRIPTION
This *should* just work and have no issues. Effectively
- if `persistStorage` is enabled, we don't store the data in memory as well as on disk anymore, but rather fetch it on demand from disk
- otherwise, it is kept in memory

This does come with a caveat: when a store of any kind gets loaded and interpreted from disk, even if persistStorage is set to false, the existing entries will act as file system entries. This means a KVS with an INPUT.json will still load from fs when requested and will not be available in RAM.