### PR TITLE
fix: Correctly compute `pendingRequestCount` in request queue

### DIFF
--- a/packages/memory-storage/src/resource-clients/request-queue.ts
+++ b/packages/memory-storage/src/resource-clients/request-queue.ts
@@ -185,7 +185,8 @@ export class RequestQueueClient extends BaseClient implements storage.RequestQue
         }
 
         existingQueueById.requests.set(requestModel.id, requestModel);
-        existingQueueById.pendingRequestCount += requestModel.orderNo === null ? 1 : 0;
+        // We add 1 to pending requests if the request was not handled yet
+        existingQueueById.pendingRequestCount += requestModel.orderNo !== null ? 1 : 0;
         existingQueueById.updateTimestamps(true);
         existingQueueById.updateItem(requestModel);
 
@@ -230,7 +231,8 @@ export class RequestQueueClient extends BaseClient implements storage.RequestQue
             }
 
             existingQueueById.requests.set(requestModel.id, requestModel);
-            existingQueueById.pendingRequestCount += requestModel.orderNo === null ? 1 : 0;
+            // We add 1 to pending requests if the request was not handled yet
+            existingQueueById.pendingRequestCount += requestModel.orderNo !== null ? 1 : 0;
             result.processedRequests.push({
                 requestId: requestModel.id,
                 uniqueKey: requestModel.uniqueKey,
@@ -288,14 +290,12 @@ export class RequestQueueClient extends BaseClient implements storage.RequestQue
         // the handled counts are updated correctly in all cases.
         existingQueueById.requests.set(requestModel.id, requestModel);
 
-        let handledCountAdjustment = 0;
         const isRequestHandledStateChanging = typeof existingRequest.orderNo !== typeof requestModel.orderNo;
         const requestWasHandledBeforeUpdate = existingRequest.orderNo === null;
 
-        if (isRequestHandledStateChanging) handledCountAdjustment += 1;
-        if (requestWasHandledBeforeUpdate) handledCountAdjustment = -handledCountAdjustment;
-
-        existingQueueById.pendingRequestCount += handledCountAdjustment;
+        if (isRequestHandledStateChanging) {
+            existingQueueById.pendingRequestCount += requestWasHandledBeforeUpdate ? 1 : -1;
+        }
         existingQueueById.updateTimestamps(true);
         existingQueueById.updateItem(requestModel);
 


### PR DESCRIPTION
Logic in https://github.com/apify/crawlee/blob/master/packages/memory-storage/src/resource-clients/request-queue.ts#L291-L298 is wrong. You can even see that `pendingRequestCount` is being changed by `handledCountAdjustment`. There are a few more cases...

I fixed them and also simplified the code to be actually readable