### PR TITLE
docs: add missing dependency to typescript guide package.json

### DIFF
--- a/docs/guides/typescript_project.mdx
+++ b/docs/guides/typescript_project.mdx
@@ -140,6 +140,7 @@ Let's wrap it up to. In addition to the scripts we described above, we also need
     },
     "devDependencies": {
         "@apify/tsconfig": "^0.1.0",
+        "@types/node": "^18.14.0",
         "ts-node": "^10.8.0",
         "typescript": "^4.7.4"
     },


### PR DESCRIPTION
Typescript project setup guide includes installing `@types/node` package as a step but the dependency was missing in final `package.json`