### PR TITLE
fix: ignore invalid URLs in `enqueueLinks` in browser crawlers

### DIFF
--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -23,6 +23,7 @@ import {
     BASIC_CRAWLER_TIMEOUT_BUFFER_SECS,
     BasicCrawler,
     RequestState,
+    tryAbsoluteURL,
 } from '@crawlee/basic';
 import type {
     BrowserController,
@@ -723,14 +724,10 @@ async function extractUrlsFromPage(page: { $$eval: Function }, selector: string,
             throw new Error(`An extracted URL: ${href} is relative and options.baseUrl is not set. `
                     + 'Use options.baseUrl in enqueueLinks() to automatically resolve relative URLs.');
         }
-        if (baseUrl) {
-            try {
-                return new URL(href, baseUrl).href;
-            } catch {
-                // Ignore invalid URLs
-            }
-        }
 
-        return href;
-    });
+        return baseUrl
+            ? tryAbsoluteURL(href, baseUrl)
+            : href;
+    })
+        .filter((href: string | undefined) => !!href);
 }

--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -723,8 +723,14 @@ async function extractUrlsFromPage(page: { $$eval: Function }, selector: string,
             throw new Error(`An extracted URL: ${href} is relative and options.baseUrl is not set. `
                     + 'Use options.baseUrl in enqueueLinks() to automatically resolve relative URLs.');
         }
-        return baseUrl
-            ? (new URL(href, baseUrl)).href
-            : href;
+        if (baseUrl) {
+            try {
+                return new URL(href, baseUrl).href;
+            } catch {
+                // Ignore invalid URLs
+            }
+        }
+
+        return href;
     });
 }

--- a/packages/cheerio-crawler/src/internals/cheerio-crawler.ts
+++ b/packages/cheerio-crawler/src/internals/cheerio-crawler.ts
@@ -8,7 +8,7 @@ import type {
     RequestQueue,
     Configuration,
 } from '@crawlee/http';
-import { HttpCrawler, enqueueLinks, Router, resolveBaseUrlForEnqueueLinksFiltering } from '@crawlee/http';
+import { HttpCrawler, enqueueLinks, Router, resolveBaseUrlForEnqueueLinksFiltering, tryAbsoluteURL } from '@crawlee/http';
 import type { Dictionary } from '@crawlee/types';
 import type { CheerioOptions } from 'cheerio';
 import * as cheerio from 'cheerio';
@@ -224,15 +224,8 @@ function extractUrlsFromCheerio($: cheerio.CheerioAPI, selector: string, baseUrl
                 throw new Error(`An extracted URL: ${href} is relative and options.baseUrl is not set. `
                     + 'Use options.baseUrl in enqueueLinks() to automatically resolve relative URLs.');
             }
-            const tryAbsolute = () => {
-                try {
-                    return (new URL(href, baseUrl)).href;
-                } catch {
-                    return undefined;
-                }
-            };
             return baseUrl
-                ? tryAbsolute()
+                ? tryAbsoluteURL(href, baseUrl)
                 : href;
         })
         .filter((href) => !!href) as string[];

--- a/packages/core/src/enqueue_links/shared.ts
+++ b/packages/core/src/enqueue_links/shared.ts
@@ -1,9 +1,9 @@
 import { URL } from 'url';
 import { purlToRegExp } from '@apify/pseudo_url';
 import minimatch from 'minimatch';
-import type { EnqueueLinksOptions } from '@crawlee/core';
 import type { RequestOptions } from '../request';
 import { Request } from '../request';
+import type { EnqueueLinksOptions } from './enqueue_links';
 
 const MAX_ENQUEUE_LINKS_CACHE_SIZE = 1000;
 

--- a/packages/core/src/enqueue_links/shared.ts
+++ b/packages/core/src/enqueue_links/shared.ts
@@ -1,9 +1,9 @@
 import { URL } from 'url';
 import { purlToRegExp } from '@apify/pseudo_url';
 import minimatch from 'minimatch';
+import type { EnqueueLinksOptions } from '@crawlee/core';
 import type { RequestOptions } from '../request';
 import { Request } from '../request';
-import type { EnqueueLinksOptions } from './enqueue_links';
 
 const MAX_ENQUEUE_LINKS_CACHE_SIZE = 1000;
 
@@ -209,6 +209,17 @@ export function createRequestOptions(
 
             return requestOptions;
         });
+}
+
+/**
+ * Helper function used to validate URLs used when extracting URLs from a page
+ */
+export function tryAbsoluteURL(href: string, baseUrl: string): string | undefined {
+    try {
+        return (new URL(href, baseUrl)).href;
+    } catch {
+        return undefined;
+    }
 }
 
 /**

--- a/packages/jsdom-crawler/src/internals/jsdom-crawler.ts
+++ b/packages/jsdom-crawler/src/internals/jsdom-crawler.ts
@@ -9,7 +9,7 @@ import type {
     RequestQueue,
     Configuration,
 } from '@crawlee/http';
-import { HttpCrawler, enqueueLinks, Router, resolveBaseUrlForEnqueueLinksFiltering } from '@crawlee/http';
+import { HttpCrawler, enqueueLinks, Router, resolveBaseUrlForEnqueueLinksFiltering, tryAbsoluteURL } from '@crawlee/http';
 import type { BatchAddRequestsResult, Dictionary } from '@crawlee/types';
 import { concatStreamToBuffer } from '@apify/utilities';
 import type { DOMWindow } from 'jsdom';
@@ -265,12 +265,7 @@ function extractUrlsFromWindow(window: DOMWindow, selector: string, baseUrl: str
             if (href === undefined) {
                 return undefined;
             }
-
-            try {
-                return (new URL(href, baseUrl)).href;
-            } catch {
-                return undefined;
-            }
+            return tryAbsoluteURL(href, baseUrl);
         })
         .filter((href) => href !== undefined && href !== '') as string[];
 }

--- a/test/core/enqueue_links/enqueue_links.test.ts
+++ b/test/core/enqueue_links/enqueue_links.test.ts
@@ -38,6 +38,7 @@ const HTML = `
         <a href="/x/absolutepath">This is a relative link.</a>
         <a href="y/relativepath">This is a relative link.</a>
         <a href="//example.absolute.com/hello">This is a link to a different subdomain</a>
+        <a href="http://">Invalid URL link, this needs to be ignored</a>
     </body>
 </html>
 `;


### PR DESCRIPTION
Fixes: https://github.com/apify/crawlee/issues/1802