### PR TITLE
chore(MemoryStorage): remove extra `@crawlee/utils` dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Please note we have a code of conduct, please follow it in all your interactions
 
 ### Yarn
 
-This project now uses yarn v3 to manage dependencies. You will need to install it, the easies way is by using `corepack`:
+This project now uses yarn v3 to manage dependencies. You will need to install it, the easiest way is by using `corepack`:
 
 ```shell
 corepack enable

--- a/packages/memory-storage/package.json
+++ b/packages/memory-storage/package.json
@@ -50,7 +50,6 @@
     "dependencies": {
         "@apify/log": "^2.0.0",
         "@crawlee/types": "^3.2.2",
-        "@crawlee/utils": "^3.2.2",
         "@sapphire/async-queue": "^1.5.0",
         "@sapphire/shapeshift": "^3.0.0",
         "content-type": "^1.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -893,7 +893,6 @@ __metadata:
   dependencies:
     "@apify/log": ^2.0.0
     "@crawlee/types": ^3.2.2
-    "@crawlee/utils": ^3.2.2
     "@sapphire/async-queue": ^1.5.0
     "@sapphire/shapeshift": ^3.0.0
     content-type: ^1.0.4


### PR DESCRIPTION
As far as I can tell, `@crawlee/memory-storage` does not use `@crawlee/utils` anywhere, so the dependency was extra.

This will help us a lot with the dependency size in the Apify CLI, which depends on `@crawlee/memory-storage` - this change will remove ~10 MB of dependencies.