### PR TITLE
docs: fix main-wrapper alignment on desktop

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -228,8 +228,16 @@ nav.navbar .dropdown__menu {
     height: 3rem;
 }
 
+.main-wrapper {
+    align-items: center;
+}
+
 .main-wrapper a[class*='sidebarLogo'] img {
     height: 3rem;
+}
+
+.main-wrapper a[class*='sidebarLogo'] b {
+    display: none;
 }
 
 html.plugin-pages {


### PR DESCRIPTION
Realigns all the docs pages back to the center. Also hides the title next to the logo on scroll.

![obrazek](https://user-images.githubusercontent.com/61918049/225057816-3871fbc2-51c5-4a3f-b6fc-e158dee24b98.png)
