### PR TITLE
chore(deps): bump to got-scraping for type fixes

### DIFF
--- a/packages/basic-crawler/package.json
+++ b/packages/basic-crawler/package.json
@@ -51,7 +51,7 @@
         "@crawlee/core": "^3.3.0",
         "@crawlee/types": "^3.3.0",
         "@crawlee/utils": "^3.3.0",
-        "got-scraping": "^3.2.9",
+        "got-scraping": "^3.2.13-beta.0",
         "ow": "^0.28.1",
         "tslib": "^2.4.0",
         "type-fest": "^3.0.0"

--- a/packages/http-crawler/package.json
+++ b/packages/http-crawler/package.json
@@ -59,7 +59,7 @@
         "@crawlee/types": "^3.3.0",
         "@types/content-type": "^1.1.5",
         "content-type": "^1.0.4",
-        "got-scraping": "^3.2.9",
+        "got-scraping": "^3.2.13-beta.0",
         "iconv-lite": "^0.6.3",
         "mime-types": "^2.1.35",
         "ow": "^0.28.1",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -51,7 +51,7 @@
         "@apify/ps-tree": "^1.1.4",
         "@crawlee/types": "^3.3.0",
         "cheerio": "1.0.0-rc.12",
-        "got-scraping": "^3.2.9",
+        "got-scraping": "^3.2.13-beta.0",
         "ow": "^0.28.1",
         "tslib": "^2.4.0"
     }

--- a/packages/utils/src/internals/extract-urls.ts
+++ b/packages/utils/src/internals/extract-urls.ts
@@ -46,7 +46,6 @@ export async function downloadListOfUrls(options: DownloadListOfUrlsOptions): Pr
         fixedUrl = `${match[1]}/gviz/tq?tqx=out:csv`;
     }
 
-    // @ts-expect-error https://github.com/apify/got-scraping/issues/66
     const { body: string } = await gotScraping({ url: fixedUrl, encoding, proxyUrl });
 
     return extractUrls({ string, urlRegExp });

--- a/yarn.lock
+++ b/yarn.lock
@@ -749,7 +749,7 @@ __metadata:
     "@crawlee/core": ^3.3.0
     "@crawlee/types": ^3.3.0
     "@crawlee/utils": ^3.3.0
-    got-scraping: ^3.2.9
+    got-scraping: ^3.2.13-beta.0
     ow: ^0.28.1
     tslib: ^2.4.0
     type-fest: ^3.0.0
@@ -865,7 +865,7 @@ __metadata:
     "@crawlee/types": ^3.3.0
     "@types/content-type": ^1.1.5
     content-type: ^1.0.4
-    got-scraping: ^3.2.9
+    got-scraping: ^3.2.13-beta.0
     iconv-lite: ^0.6.3
     mime-types: ^2.1.35
     ow: ^0.28.1
@@ -1034,7 +1034,7 @@ __metadata:
     "@apify/ps-tree": ^1.1.4
     "@crawlee/types": ^3.3.0
     cheerio: 1.0.0-rc.12
-    got-scraping: ^3.2.9
+    got-scraping: ^3.2.13-beta.0
     ow: ^0.28.1
     tslib: ^2.4.0
   languageName: unknown
@@ -6293,9 +6293,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"got-scraping@npm:^3.2.9":
-  version: 3.2.12
-  resolution: "got-scraping@npm:3.2.12"
+"got-scraping@npm:^3.2.13-beta.0":
+  version: 3.2.13-beta.0
+  resolution: "got-scraping@npm:3.2.13-beta.0"
   dependencies:
     got-cjs: 12.5.4
     header-generator: ^2.1.3
@@ -6304,7 +6304,7 @@ __metadata:
     ow: ^0.28.1
     quick-lru: ^5.1.1
     tslib: ^2.4.0
-  checksum: 94fdd7251ed29636528c24d33ac6f82b16321956ed7732d92ed4b093f39c6970bb87749045cae481ac9e0078ac6148805245f49fead833be864302ef04e2ecb8
+  checksum: 868c696897f357bda22b3a86b248166bc164382fd96ddb28aaf3f38e969a875882ad887bfd14d18a4ee14e09c18883238f0b122d33c693a48b37ba8278af1d71
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Seems like we don't need to change...anything, both in tests and in e2e. We can just drop a `ts-expect-error`!