### PR TITLE
docs: use enums in the fingerprint examples

### DIFF
--- a/docs/guides/avoid_blocking_playwright.ts
+++ b/docs/guides/avoid_blocking_playwright.ts
@@ -1,4 +1,5 @@
 import { PlaywrightCrawler } from 'crawlee';
+import { BrowserName, DeviceCategory, OperatingSystemsName } from '@crawlee/browser-pool';
 
 const crawler = new PlaywrightCrawler({
     browserPoolOptions: {
@@ -6,14 +7,14 @@ const crawler = new PlaywrightCrawler({
         fingerprintOptions: {
             fingerprintGeneratorOptions: {
                 browsers: [{
-                    name: 'edge',
+                    name: BrowserName.edge,
                     minVersion: 96,
                 }],
                 devices: [
-                    'desktop',
+                    DeviceCategory.desktop,
                 ],
                 operatingSystems: [
-                    'windows',
+                    OperatingSystemsName.windows,
                 ],
             },
         },

--- a/docs/guides/avoid_blocking_puppeteer.ts
+++ b/docs/guides/avoid_blocking_puppeteer.ts
@@ -1,4 +1,5 @@
 import { PuppeteerCrawler } from 'crawlee';
+import { BrowserName, DeviceCategory } from '@crawlee/browser-pool';
 
 const crawler = new PuppeteerCrawler({
     browserPoolOptions: {
@@ -6,11 +7,11 @@ const crawler = new PuppeteerCrawler({
         fingerprintOptions: {
             fingerprintGeneratorOptions: {
                 browsers: [
-                    'chrome',
-                    'firefox',
+                    BrowserName.chrome,
+                    BrowserName.firefox,
                 ],
                 devices: [
-                    'mobile',
+                    DeviceCategory.mobile,
                 ],
                 locales: [
                     'en-US',

--- a/website/versioned_docs/version-3.0/guides/avoid_blocking_playwright.ts
+++ b/website/versioned_docs/version-3.0/guides/avoid_blocking_playwright.ts
@@ -1,4 +1,5 @@
 import { PlaywrightCrawler } from 'crawlee';
+import { BrowserName, DeviceCategory, OperatingSystemsName } from '@crawlee/browser-pool';
 
 const crawler = new PlaywrightCrawler({
     browserPoolOptions: {
@@ -6,14 +7,14 @@ const crawler = new PlaywrightCrawler({
         fingerprintOptions: {
             fingerprintGeneratorOptions: {
                 browsers: [{
-                    name: 'edge',
+                    name: BrowserName.edge,
                     minVersion: 96,
                 }],
                 devices: [
-                    'desktop',
+                    DeviceCategory.desktop,
                 ],
                 operatingSystems: [
-                    'windows',
+                    OperatingSystemsName.windows,
                 ],
             },
         },

--- a/website/versioned_docs/version-3.0/guides/avoid_blocking_puppeteer.ts
+++ b/website/versioned_docs/version-3.0/guides/avoid_blocking_puppeteer.ts
@@ -1,4 +1,5 @@
 import { PuppeteerCrawler } from 'crawlee';
+import { BrowserName, DeviceCategory } from '@crawlee/browser-pool';
 
 const crawler = new PuppeteerCrawler({
     browserPoolOptions: {
@@ -6,11 +7,11 @@ const crawler = new PuppeteerCrawler({
         fingerprintOptions: {
             fingerprintGeneratorOptions: {
                 browsers: [
-                    'chrome',
-                    'firefox',
+                    BrowserName.chrome,
+                    BrowserName.firefox,
                 ],
                 devices: [
-                    'mobile',
+                    DeviceCategory.mobile,
                 ],
                 locales: [
                     'en-US',

--- a/website/versioned_docs/version-3.1/guides/avoid_blocking_playwright.ts
+++ b/website/versioned_docs/version-3.1/guides/avoid_blocking_playwright.ts
@@ -1,4 +1,5 @@
 import { PlaywrightCrawler } from 'crawlee';
+import { BrowserName, DeviceCategory, OperatingSystemsName } from '@crawlee/browser-pool';
 
 const crawler = new PlaywrightCrawler({
     browserPoolOptions: {
@@ -6,14 +7,14 @@ const crawler = new PlaywrightCrawler({
         fingerprintOptions: {
             fingerprintGeneratorOptions: {
                 browsers: [{
-                    name: 'edge',
+                    name: BrowserName.edge,
                     minVersion: 96,
                 }],
                 devices: [
-                    'desktop',
+                    DeviceCategory.desktop,
                 ],
                 operatingSystems: [
-                    'windows',
+                    OperatingSystemsName.windows,
                 ],
             },
         },

--- a/website/versioned_docs/version-3.1/guides/avoid_blocking_puppeteer.ts
+++ b/website/versioned_docs/version-3.1/guides/avoid_blocking_puppeteer.ts
@@ -1,4 +1,5 @@
 import { PuppeteerCrawler } from 'crawlee';
+import { BrowserName, DeviceCategory } from '@crawlee/browser-pool';
 
 const crawler = new PuppeteerCrawler({
     browserPoolOptions: {
@@ -6,11 +7,11 @@ const crawler = new PuppeteerCrawler({
         fingerprintOptions: {
             fingerprintGeneratorOptions: {
                 browsers: [
-                    'chrome',
-                    'firefox',
+                    BrowserName.chrome,
+                    BrowserName.firefox,
                 ],
                 devices: [
-                    'mobile',
+                    DeviceCategory.mobile,
                 ],
                 locales: [
                     'en-US',

--- a/website/versioned_docs/version-3.2/guides/avoid_blocking_playwright.ts
+++ b/website/versioned_docs/version-3.2/guides/avoid_blocking_playwright.ts
@@ -1,4 +1,5 @@
 import { PlaywrightCrawler } from 'crawlee';
+import { BrowserName, DeviceCategory, OperatingSystemsName } from '@crawlee/browser-pool';
 
 const crawler = new PlaywrightCrawler({
     browserPoolOptions: {
@@ -6,14 +7,14 @@ const crawler = new PlaywrightCrawler({
         fingerprintOptions: {
             fingerprintGeneratorOptions: {
                 browsers: [{
-                    name: 'edge',
+                    name: BrowserName.edge,
                     minVersion: 96,
                 }],
                 devices: [
-                    'desktop',
+                    DeviceCategory.desktop,
                 ],
                 operatingSystems: [
-                    'windows',
+                    OperatingSystemsName.windows,
                 ],
             },
         },

--- a/website/versioned_docs/version-3.2/guides/avoid_blocking_puppeteer.ts
+++ b/website/versioned_docs/version-3.2/guides/avoid_blocking_puppeteer.ts
@@ -1,4 +1,5 @@
 import { PuppeteerCrawler } from 'crawlee';
+import { BrowserName, DeviceCategory } from '@crawlee/browser-pool';
 
 const crawler = new PuppeteerCrawler({
     browserPoolOptions: {
@@ -6,11 +7,11 @@ const crawler = new PuppeteerCrawler({
         fingerprintOptions: {
             fingerprintGeneratorOptions: {
                 browsers: [
-                    'chrome',
-                    'firefox',
+                    BrowserName.chrome,
+                    BrowserName.firefox,
                 ],
                 devices: [
-                    'mobile',
+                    DeviceCategory.mobile,
                 ],
                 locales: [
                     'en-US',

--- a/website/versioned_docs/version-3.3/guides/avoid_blocking_playwright.ts
+++ b/website/versioned_docs/version-3.3/guides/avoid_blocking_playwright.ts
@@ -1,4 +1,5 @@
 import { PlaywrightCrawler } from 'crawlee';
+import { BrowserName, DeviceCategory, OperatingSystemsName } from '@crawlee/browser-pool';
 
 const crawler = new PlaywrightCrawler({
     browserPoolOptions: {
@@ -6,14 +7,14 @@ const crawler = new PlaywrightCrawler({
         fingerprintOptions: {
             fingerprintGeneratorOptions: {
                 browsers: [{
-                    name: 'edge',
+                    name: BrowserName.edge,
                     minVersion: 96,
                 }],
                 devices: [
-                    'desktop',
+                    DeviceCategory.desktop,
                 ],
                 operatingSystems: [
-                    'windows',
+                    OperatingSystemsName.windows,
                 ],
             },
         },

--- a/website/versioned_docs/version-3.3/guides/avoid_blocking_puppeteer.ts
+++ b/website/versioned_docs/version-3.3/guides/avoid_blocking_puppeteer.ts
@@ -1,4 +1,5 @@
 import { PuppeteerCrawler } from 'crawlee';
+import { BrowserName, DeviceCategory } from '@crawlee/browser-pool';
 
 const crawler = new PuppeteerCrawler({
     browserPoolOptions: {
@@ -6,11 +7,11 @@ const crawler = new PuppeteerCrawler({
         fingerprintOptions: {
             fingerprintGeneratorOptions: {
                 browsers: [
-                    'chrome',
-                    'firefox',
+                    BrowserName.chrome,
+                    BrowserName.firefox,
                 ],
                 devices: [
-                    'mobile',
+                    DeviceCategory.mobile,
                 ],
                 locales: [
                     'en-US',


### PR DESCRIPTION
Using string literals in the `FingerprintGeneratorOptions` causes TS errors. This PR updates the docs so the examples are in line with the best practices.

Fixes #1813 