### PR TITLE
fix: try to detect stuck request queue and fix its state

### DIFF
--- a/packages/core/src/storages/request_queue.ts
+++ b/packages/core/src/storages/request_queue.ts
@@ -571,7 +571,7 @@ export class RequestQueue {
      * but it will never return a false positive.
      */
     async isFinished(): Promise<boolean> {
-        if (this.inProgressCount() > 0 && (Date.now() - +this.lastActivity) > this.internalTimeoutMillis) {
+        if ((Date.now() - +this.lastActivity) > this.internalTimeoutMillis) {
             const message = `The request queue seems to be stuck for ${this.internalTimeoutMillis / 1e3}s, resetting internal state.`;
             this.log.warning(message, { inProgress: [...this.inProgress] });
             this._reset();


### PR DESCRIPTION
When we were facing the RQ stuck issues, the solution was to automatically unstuck it in case we detect nothing was happening for ~5 minutes and there are some requests in progress.

This PR removes the condition for in-progress requests, as the queue could get stuck without any in-progress requests too apparently.

https://apifier.slack.com/archives/C0L33UM7Z/p1679262267148309