### PR TITLE
fix: status message - total requests

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -633,8 +633,9 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
                     { level: LogLevel.WARNING },
                 );
             } else {
+                const total = this.requestQueue?.assumedTotalCount || this.requestList?.length();
                 // eslint-disable-next-line max-len
-                await this.setStatusMessage(`Crawled ${this.stats.state.requestsFinished}/${this.requestQueue?.assumedTotalCount || this.requestList?.length() || this.stats.state.requestsFinished} pages, ${this.stats.state.requestsFailed} errors.`);
+                await this.setStatusMessage(`Crawled ${this.stats.state.requestsFinished}${total ? `/${total}` : ''} pages, ${this.stats.state.requestsFailed} errors.`);
             }
         };
 

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -634,7 +634,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
                 );
             } else {
                 // eslint-disable-next-line max-len
-                await this.setStatusMessage(`Crawled ${this.stats.state.requestsFinished}/${this.requestQueue?.assumedTotalCount || this.requestList?.length()} pages, ${this.stats.state.requestsFailed} errors.`);
+                await this.setStatusMessage(`Crawled ${this.stats.state.requestsFinished}/${this.requestQueue?.assumedTotalCount || this.requestList?.length() || this.stats.state.requestsFinished} pages, ${this.stats.state.requestsFailed} errors.`);
             }
         };
 


### PR DESCRIPTION
If `requestQueue` / `requestList` are uninitialized, the status message contains `undefined` - this PR removes this, no total is shown in this case.