### PR TITLE
feat: crawler Statistics contain number of enqueued requests

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -720,7 +720,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
 
         periodicLogger.stop();
         // eslint-disable-next-line max-len
-        await this.setStatusMessage(`Finished! Total ${this.stats.state.requestsFinished + this.stats.state.requestsFailed} requests: ${this.stats.state.requestsFinished} succeeded, ${this.stats.state.requestsFailed} failed.`, { isStatusMessageTerminal: true });
+        await this.setStatusMessage(`Finished! Total ${stats.requestsTotal} requests: ${stats.requestsFinished} succeeded, ${stats.requestsFailed} failed.`, { isStatusMessageTerminal: true });
         return stats;
     }
 

--- a/packages/core/src/crawlers/statistics.ts
+++ b/packages/core/src/crawlers/statistics.ts
@@ -126,6 +126,7 @@ export class Statistics {
             requestsFinished: 0,
             requestsFailed: 0,
             requestsRetries: 0,
+            requestsEnqueued: 0,
             requestsFailedPerMinute: 0,
             requestsFinishedPerMinute: 0,
             requestMinDurationMillis: Infinity,
@@ -411,4 +412,5 @@ export interface StatisticState {
     errors: Record<string, unknown>;
     retryErrors: Record<string, unknown>;
     requestsWithStatusCode: Record<string, number>;
+    requestsEnqueued: number;
 }


### PR DESCRIPTION
As per the discussion under #1855 , this PR adds the `requestsEnqueued` statistic, which is then used in the status message. This should help with the inconsistencies in the request counts in the status message, as the stats object should endure migrations.

fixes #1855 