### PR TITLE
feat(router): option to define routes when creating router

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -39,7 +39,15 @@ import {
 } from '@crawlee/core';
 import type { Method, OptionsInit } from 'got-scraping';
 import { gotScraping } from 'got-scraping';
-import type { ProcessedRequest, Dictionary, Awaitable, BatchAddRequestsResult, SetStatusMessageOptions } from '@crawlee/types';
+import type {
+    ProcessedRequest,
+    Dictionary,
+    Awaitable,
+    BatchAddRequestsResult,
+    SetStatusMessageOptions,
+    GetUserDataFromRequest,
+    RouterRoutes,
+} from '@crawlee/types';
 import { chunk, sleep } from '@crawlee/utils';
 import ow, { ArgumentError } from 'ow';
 
@@ -1367,6 +1375,11 @@ interface HandlePropertyNameChangeData<New, Old> {
  * await crawler.run();
  * ```
  */
-export function createBasicRouter<Context extends BasicCrawlingContext = BasicCrawlingContext>() {
-    return Router.create<Context>();
+export function createBasicRouter<
+    Context extends BasicCrawlingContext = BasicCrawlingContext,
+    UserData extends Dictionary = GetUserDataFromRequest<Context['request']>
+>(
+    routes?: RouterRoutes<Context, UserData>,
+) {
+    return Router.create<Context>(routes);
 }

--- a/packages/cheerio-crawler/src/internals/cheerio-crawler.ts
+++ b/packages/cheerio-crawler/src/internals/cheerio-crawler.ts
@@ -9,7 +9,7 @@ import type {
     Configuration,
 } from '@crawlee/http';
 import { HttpCrawler, enqueueLinks, Router, resolveBaseUrlForEnqueueLinksFiltering, tryAbsoluteURL } from '@crawlee/http';
-import type { Dictionary } from '@crawlee/types';
+import type { Dictionary, GetUserDataFromRequest, RouterRoutes } from '@crawlee/types';
 import type { CheerioOptions } from 'cheerio';
 import * as cheerio from 'cheerio';
 import { DomHandler } from 'htmlparser2';
@@ -275,6 +275,11 @@ function extractUrlsFromCheerio($: cheerio.CheerioAPI, selector: string, baseUrl
  * await crawler.run();
  * ```
  */
-export function createCheerioRouter<Context extends CheerioCrawlingContext = CheerioCrawlingContext>() {
-    return Router.create<Context>();
+export function createCheerioRouter<
+    Context extends CheerioCrawlingContext = CheerioCrawlingContext,
+    UserData extends Dictionary = GetUserDataFromRequest<Context['request']>
+>(
+    routes?: RouterRoutes<Context, UserData>,
+) {
+    return Router.create<Context>(routes);
 }

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -1,4 +1,4 @@
-import type { Dictionary } from '@crawlee/types';
+import type { Dictionary, RouterRoutes } from '@crawlee/types';
 import type { CrawlingContext } from './crawlers/crawler_commons';
 import type { Awaitable } from './typedefs';
 import type { Request } from './request';
@@ -153,7 +153,12 @@ export class Router<Context extends CrawlingContext> {
      * await crawler.run();
      * ```
      */
-    static create<Context extends CrawlingContext = CrawlingContext>(): RouterHandler<Context> {
+    static create<
+        Context extends CrawlingContext = CrawlingContext,
+        UserData extends Dictionary = GetUserDataFromRequest<Context['request']>
+    >(
+        routes?: RouterRoutes<Context, UserData>,
+    ): RouterHandler<Context> {
         const router = new Router<Context>();
         const obj = Object.create(Function.prototype);
 
@@ -161,6 +166,10 @@ export class Router<Context extends CrawlingContext> {
         obj.addDefaultHandler = router.addDefaultHandler.bind(router);
         obj.getHandler = router.getHandler.bind(router);
         obj.use = router.use.bind(router);
+
+        for (const [label, handler] of Object.entries(routes ?? {})) {
+            router.addHandler(label, handler);
+        }
 
         const func = async function (context: Context) {
             const { url, loadedUrl, label } = context.request;

--- a/packages/http-crawler/src/internals/http-crawler.ts
+++ b/packages/http-crawler/src/internals/http-crawler.ts
@@ -20,7 +20,7 @@ import {
     Configuration,
     RequestState,
 } from '@crawlee/basic';
-import type { Awaitable, Dictionary } from '@crawlee/types';
+import type { Awaitable, Dictionary, GetUserDataFromRequest, RouterRoutes } from '@crawlee/types';
 import type { RequestLike, ResponseLike } from 'content-type';
 import contentTypeParser from 'content-type';
 import mime from 'mime-types';
@@ -870,6 +870,11 @@ function parseContentTypeFromResponse(response: IncomingMessage): { type: string
  * await crawler.run();
  * ```
  */
-export function createHttpRouter<Context extends HttpCrawlingContext = HttpCrawlingContext>() {
-    return Router.create<Context>();
+export function createHttpRouter<
+    Context extends HttpCrawlingContext = HttpCrawlingContext,
+    UserData extends Dictionary = GetUserDataFromRequest<Context['request']> // quick&dirty copy-paste
+>(
+    routes?: RouterRoutes<Context, UserData>,
+) {
+    return Router.create<Context>(routes);
 }

--- a/packages/jsdom-crawler/src/internals/jsdom-crawler.ts
+++ b/packages/jsdom-crawler/src/internals/jsdom-crawler.ts
@@ -11,7 +11,7 @@ import type {
     Configuration,
 } from '@crawlee/http';
 import { HttpCrawler, enqueueLinks, Router, resolveBaseUrlForEnqueueLinksFiltering, tryAbsoluteURL } from '@crawlee/http';
-import type { Dictionary } from '@crawlee/types';
+import type { Dictionary, GetUserDataFromRequest, RouterRoutes } from '@crawlee/types';
 import { concatStreamToBuffer } from '@apify/utilities';
 import type { DOMWindow } from 'jsdom';
 import { JSDOM, ResourceLoader, VirtualConsole } from 'jsdom';
@@ -351,6 +351,11 @@ function extractUrlsFromWindow(window: DOMWindow, selector: string, baseUrl: str
  * await crawler.run();
  * ```
  */
-export function createJSDOMRouter<Context extends JSDOMCrawlingContext = JSDOMCrawlingContext>() {
-    return Router.create<Context>();
+export function createJSDOMRouter<
+    Context extends JSDOMCrawlingContext = JSDOMCrawlingContext,
+    UserData extends Dictionary = GetUserDataFromRequest<Context['request']>
+>(
+    routes?: RouterRoutes<Context, UserData>,
+) {
+    return Router.create<Context>(routes);
 }

--- a/packages/playwright-crawler/src/internals/playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/playwright-crawler.ts
@@ -3,7 +3,7 @@ import type { LaunchOptions, Page, Response } from 'playwright';
 import type { BrowserPoolOptions, PlaywrightController, PlaywrightPlugin } from '@crawlee/browser-pool';
 import type { BrowserCrawlerOptions, BrowserCrawlingContext, BrowserRequestHandler, BrowserHook } from '@crawlee/browser';
 import { BrowserCrawler, Configuration, Router } from '@crawlee/browser';
-import type { Dictionary } from '@crawlee/types';
+import type { Dictionary, GetUserDataFromRequest, RouterRoutes } from '@crawlee/types';
 import type { PlaywrightLaunchContext } from './playwright-launcher';
 import { PlaywrightLauncher } from './playwright-launcher';
 import type { DirectNavigationOptions, PlaywrightContextUtils } from './utils/playwright-utils';
@@ -262,6 +262,11 @@ export class PlaywrightCrawler extends BrowserCrawler<{ browserPlugins: [Playwri
  * await crawler.run();
  * ```
  */
-export function createPlaywrightRouter<Context extends PlaywrightCrawlingContext = PlaywrightCrawlingContext>() {
-    return Router.create<Context>();
+export function createPlaywrightRouter<
+    Context extends PlaywrightCrawlingContext = PlaywrightCrawlingContext,
+    UserData extends Dictionary = GetUserDataFromRequest<Context['request']>
+>(
+    routes?: RouterRoutes<Context, UserData>,
+) {
+    return Router.create<Context>(routes);
 }

--- a/packages/puppeteer-crawler/src/internals/puppeteer-crawler.ts
+++ b/packages/puppeteer-crawler/src/internals/puppeteer-crawler.ts
@@ -6,7 +6,7 @@ import type {
 } from '@crawlee/browser';
 import { BrowserCrawler, Configuration, Router } from '@crawlee/browser';
 import type { BrowserPoolOptions, PuppeteerController, PuppeteerPlugin } from '@crawlee/browser-pool';
-import type { Dictionary } from '@crawlee/types';
+import type { Dictionary, GetUserDataFromRequest, RouterRoutes } from '@crawlee/types';
 import ow from 'ow';
 import type { HTTPResponse, LaunchOptions, Page } from 'puppeteer';
 import type { PuppeteerLaunchContext } from './puppeteer-launcher';
@@ -212,6 +212,11 @@ export class PuppeteerCrawler extends BrowserCrawler<{ browserPlugins: [Puppetee
  * await crawler.run();
  * ```
  */
-export function createPuppeteerRouter<Context extends PuppeteerCrawlingContext = PuppeteerCrawlingContext>() {
-    return Router.create<Context>();
+export function createPuppeteerRouter<
+    Context extends PuppeteerCrawlingContext = PuppeteerCrawlingContext,
+    UserData extends Dictionary = GetUserDataFromRequest<Context['request']>
+>(
+    routes?: RouterRoutes<Context, UserData>,
+) {
+    return Router.create<Context>(routes);
 }

--- a/packages/types/src/utility-types.ts
+++ b/packages/types/src/utility-types.ts
@@ -1,3 +1,5 @@
+import type { Request } from '@crawlee/core';
+
 /** @ignore */
 export type Dictionary<T = any> = Record<PropertyKey, T>;
 
@@ -8,3 +10,9 @@ export type Constructor<T = unknown> = new (...args: any[]) => T;
 export type Awaitable<T> = T | PromiseLike<T>;
 
 export type AllowedHttpMethods = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'TRACE' | 'OPTIONS' | 'CONNECT' | 'PATCH';
+
+export type RouterRoutes<Context, UserData extends Dictionary> = {
+    [label in string | symbol]: (ctx: Omit<Context, 'request'> & { request: Request<UserData> }) => Awaitable<void>;
+}
+
+export type GetUserDataFromRequest<T> = T extends Request<infer Y> ? Y : never;


### PR DESCRIPTION
As mentioned in discussion https://github.com/apify/crawlee/discussions/1873

Crawlee is so good that router definition often can be straightforward, so it would be nice to have the option to define it "inline".
It also could be great for tutorials and snippets in docs.

```js
const crawler = new CheerioCrawler({
  requestHandler: createCheerioRouter({
    [LABEL.INDEX]: async ({ enqueueLinks }) => {
      await enqueueLinks({
        selector: `#sitemap a`,
        label: LABEL.PRODUCTS,
      })
    },
    [LABEL.PRODUCTS]: async ({ $ }) => {
      await Actor.pushData({ title: $(`title`).text() })
    },
  }),
})
await crawler.run([{ url: `https://example.com`, label: LABEL.INDEX }])
```

I will add tests after agreeing that the "signature" is ok :) 