### PR TITLE
docs: fix code examples for Adding more URLs - Finding new links and Filtering links to same domain

### DIFF
--- a/docs/introduction/03-filter-el.ts
+++ b/docs/introduction/03-filter-el.ts
@@ -5,6 +5,9 @@ const crawler = new CheerioCrawler({
     async requestHandler({ $, request, enqueueLinks }) {
         const title = $('title').text();
         console.log(`The title of "${request.url}" is: ${title}.`);
+        // The default behavior of enqueueLinks is to stay on the same hostname,
+        // so it does not require any parameters.
+        // This does not include subdomains.
         await enqueueLinks();
     },
 });

--- a/docs/introduction/03-filter-without-el.ts
+++ b/docs/introduction/03-filter-without-el.ts
@@ -7,19 +7,25 @@ const crawler = new CheerioCrawler({
         const title = $('title').text();
         console.log(`The title of "${request.url}" is: ${title}.`);
 
-        // Without enqueueLinks, we first have to extract all
-        // the URLs from the page with Cheerio.
         const links = $('a[href]')
             .map((_, el) => $(el).attr('href'))
             .get();
 
-        // Then we need to resolve relative URLs,
-        // otherwise they would be unusable for crawling.
-        const absoluteUrls = links
-            .map((link) => new URL(link, request.loadedUrl).href);
+        // Besides resolving the URLs, we now also need to
+        // grab their hostname for filtering.
+        const { hostname } = new URL(request.loadedUrl);
+        const absoluteUrls = links.map(
+            (link) => new URL(link, request.loadedUrl)
+        );
+
+        // We use the hostname to filter links that point
+        // to a different domain, even subdomain.
+        const sameHostnameLinks = absoluteUrls
+            .filter((url) => url.hostname === hostname)
+            .map((url) => ({ url: url.href }));
 
         // Finally, we have to add the URLs to the queue
-        await crawler.addRequests(absoluteUrls);
+        await crawler.addRequests(sameHostnameLinks);
     },
 });
 

--- a/docs/introduction/03-find-without-el.ts
+++ b/docs/introduction/03-find-without-el.ts
@@ -9,24 +9,20 @@ const crawler = new CheerioCrawler({
         const title = $('title').text();
         console.log(`The title of "${request.url}" is: ${title}.`);
 
+        // Without enqueueLinks, we first have to extract all
+        // the URLs from the page with Cheerio.
         const links = $('a[href]')
             .map((_, el) => $(el).attr('href'))
             .get();
 
-        // Besides resolving the URLs, we now also need to
-        // grab their hostname for filtering.
-        const { hostname } = new URL(request.loadedUrl);
-        const absoluteUrls = links
-            .map((link) => new URL(link, request.loadedUrl));
-
-        // We use the hostname to filter links that point
-        // to a different domain, even subdomain.
-        const sameHostnameLinks = absoluteUrls
-            .filter((url) => url.hostname === hostname)
-            .map((url) => ({ url: url.href }));
+        // Then we need to resolve relative URLs,
+        // otherwise they would be unusable for crawling.
+        const absoluteUrls = links.map(
+            (link) => new URL(link, request.loadedUrl).href
+        );
 
         // Finally, we have to add the URLs to the queue
-        await crawler.addRequests(sameHostnameLinks);
+        await crawler.addRequests(absoluteUrls);
     },
 });
 


### PR DESCRIPTION
I believe the code examples for https://crawlee.dev/docs/introduction/adding-urls#finding-new-links and https://crawlee.dev/docs/introduction/adding-urls#filtering-links-to-same-domain without enqueueLinks were mixed up.

Additionally I added a comment to why there are no params for filtering with enqueueLinks.
