### PR TITLE
fix(MemoryStorage): cache requests in `RequestQueue`

### DIFF
--- a/packages/memory-storage/src/fs/request-queue/fs.ts
+++ b/packages/memory-storage/src/fs/request-queue/fs.ts
@@ -11,6 +11,11 @@ export class RequestQueueFileSystemEntry implements StorageImplementation<Intern
     private filePath: string;
     private fsQueue = new AsyncQueue();
     private data?: InternalRequest;
+
+    /**
+     * A "sweep" timeout that is created/refreshed whenever this entry is accessed/updated.
+     * It exists to ensure that the entry is not kept in memory indefinitely, by sweeping it after 60 seconds of inactivity (in order to keep memory usage low)
+     */
     private sweepTimeout?: NodeJS.Timeout;
 
     constructor(options: CreateStorageImplementationOptions) {

--- a/packages/memory-storage/src/fs/request-queue/fs.ts
+++ b/packages/memory-storage/src/fs/request-queue/fs.ts
@@ -10,6 +10,8 @@ import type { StorageImplementation } from '../common';
 export class RequestQueueFileSystemEntry implements StorageImplementation<InternalRequest> {
     private filePath: string;
     private fsQueue = new AsyncQueue();
+    private data?: InternalRequest;
+    private sweepTimeout?: NodeJS.Timeout;
 
     constructor(options: CreateStorageImplementationOptions) {
         this.filePath = resolve(options.storeDirectory, `${options.requestId}.json`);
@@ -17,8 +19,17 @@ export class RequestQueueFileSystemEntry implements StorageImplementation<Intern
 
     async get() {
         await this.fsQueue.wait();
+        this.setOrRefreshSweepTimeout();
+
+        if (this.data) {
+            return this.data;
+        }
+
         try {
-            return JSON.parse(await readFile(this.filePath, 'utf-8'));
+            const req = JSON.parse(await readFile(this.filePath, 'utf-8'));
+            this.data = req;
+
+            return req;
         } finally {
             this.fsQueue.shift();
         }
@@ -26,10 +37,13 @@ export class RequestQueueFileSystemEntry implements StorageImplementation<Intern
 
     async update(data: InternalRequest) {
         await this.fsQueue.wait();
+        this.data = data;
+
         try {
             await ensureDir(dirname(this.filePath));
             await lockAndWrite(this.filePath, data);
         } finally {
+            this.setOrRefreshSweepTimeout();
             this.fsQueue.shift();
         }
     }
@@ -38,5 +52,16 @@ export class RequestQueueFileSystemEntry implements StorageImplementation<Intern
         await this.fsQueue.wait();
         await rm(this.filePath, { force: true });
         this.fsQueue.shift();
+    }
+
+    private setOrRefreshSweepTimeout() {
+        if (this.sweepTimeout) {
+            this.sweepTimeout.refresh();
+        } else {
+            this.sweepTimeout = setTimeout(() => {
+                this.sweepTimeout = undefined;
+                this.data = undefined;
+            }, 60_000);
+        }
     }
 }

--- a/packages/memory-storage/src/fs/request-queue/fs.ts
+++ b/packages/memory-storage/src/fs/request-queue/fs.ts
@@ -27,6 +27,7 @@ export class RequestQueueFileSystemEntry implements StorageImplementation<Intern
         this.setOrRefreshSweepTimeout();
 
         if (this.data) {
+            this.fsQueue.shift();
             return this.data;
         }
 

--- a/packages/memory-storage/src/fs/request-queue/fs.ts
+++ b/packages/memory-storage/src/fs/request-queue/fs.ts
@@ -67,7 +67,7 @@ export class RequestQueueFileSystemEntry implements StorageImplementation<Intern
             this.sweepTimeout = setTimeout(() => {
                 this.sweepTimeout = undefined;
                 this.data = undefined;
-            }, 60_000);
+            }, 60_000).unref();
         }
     }
 }

--- a/packages/memory-storage/src/resource-clients/request-queue.ts
+++ b/packages/memory-storage/src/resource-clients/request-queue.ts
@@ -230,7 +230,7 @@ export class RequestQueueClient extends BaseClient implements storage.RequestQue
         }).parse(options);
 
         const queue = await this.getQueue();
-        const request = await queue.requests.get(id);
+        const request = queue.requests.get(id);
 
         const internalRequest = await request?.get();
 
@@ -262,7 +262,7 @@ export class RequestQueueClient extends BaseClient implements storage.RequestQue
         }).parse(options);
 
         const queue = await this.getQueue();
-        const request = await queue.requests.get(id);
+        const request = queue.requests.get(id);
 
         const internalRequest = await request?.get();
 


### PR DESCRIPTION
This is added because request queues tend to have a _lot_ of activity on one entry, until the request is finished. This should ensure that no more invalid JSON errors are thrown, while also keeping the memory footprint low once a request entry is no longer accessed (+re-loading from fs if that happens)