### PR TITLE
feat(puppeteer): enable `new` headless mode

### DIFF
--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -249,7 +249,7 @@ export interface BrowserCrawlerOptions<
      * Whether to run browser in headless mode. Defaults to `true`.
      * Can be also set via {@apilink Configuration}.
      */
-    headless?: boolean;
+    headless?: boolean | 'new' | 'old'; // `new`/`old` are for puppeteer only
 }
 
 /**
@@ -326,7 +326,7 @@ export abstract class BrowserCrawler<
         postNavigationHooks: ow.optional.array,
 
         launchContext: ow.optional.object,
-        headless: ow.optional.boolean,
+        headless: ow.optional.any(ow.boolean, ow.string),
         browserPoolOptions: ow.object,
         sessionPoolOptions: ow.optional.object,
         persistCookiesPerSession: ow.optional.boolean,

--- a/packages/browser-pool/src/puppeteer/puppeteer-plugin.ts
+++ b/packages/browser-pool/src/puppeteer/puppeteer-plugin.ts
@@ -45,8 +45,7 @@ export class PuppeteerPlugin extends BrowserPlugin<
         }
 
         if (launchOptions!.headless === true) {
-            // to disable deprecation warnings, we should switch to `new` after more testing
-            launchOptions!.headless = 'old' as unknown as boolean;
+            launchOptions!.headless = 'new';
         }
 
         let browser: PuppeteerTypes.Browser;

--- a/packages/playwright-crawler/src/internals/playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/playwright-crawler.ts
@@ -223,7 +223,7 @@ export class PlaywrightCrawler extends BrowserCrawler<{ browserPlugins: [Playwri
 
         if (headless != null) {
             launchContext.launchOptions ??= {} as LaunchOptions;
-            launchContext.launchOptions.headless = headless;
+            launchContext.launchOptions.headless = headless as boolean;
         }
 
         const playwrightLauncher = new PlaywrightLauncher(launchContext, config);

--- a/packages/puppeteer-crawler/src/internals/puppeteer-crawler.ts
+++ b/packages/puppeteer-crawler/src/internals/puppeteer-crawler.ts
@@ -160,15 +160,15 @@ export class PuppeteerCrawler extends BrowserCrawler<{ browserPlugins: [Puppetee
                 + 'Use PuppeteerCrawlerOptions.proxyConfiguration');
         }
 
-        // `browserPlugins` is working when it's not overriden by `launchContext`,
-        // which for crawlers it is always overriden. Hence the error to use the other option.
+        // `browserPlugins` is working when it's not overridden by `launchContext`,
+        // which for crawlers it is always overridden. Hence the error to use the other option.
         if (browserPoolOptions.browserPlugins) {
             throw new Error('browserPoolOptions.browserPlugins is disallowed. Use launchContext.launcher instead.');
         }
 
         if (headless != null) {
             launchContext.launchOptions ??= {} as LaunchOptions;
-            launchContext.launchOptions.headless = headless;
+            launchContext.launchOptions.headless = headless as boolean;
         }
 
         const puppeteerLauncher = new PuppeteerLauncher(launchContext, config);

--- a/packages/puppeteer-crawler/src/internals/puppeteer-launcher.ts
+++ b/packages/puppeteer-crawler/src/internals/puppeteer-launcher.ts
@@ -98,6 +98,11 @@ export class PuppeteerLauncher extends BrowserLauncher<PuppeteerPlugin, unknown>
 
         this.Plugin = PuppeteerPlugin;
     }
+
+    protected override _getDefaultHeadlessOption(): boolean {
+        const headless = super._getDefaultHeadlessOption();
+        return headless ? 'new' as any : headless;
+    }
 }
 
 /**

--- a/test/core/puppeteer_request_interception.test.ts
+++ b/test/core/puppeteer_request_interception.test.ts
@@ -8,9 +8,6 @@ import { runExampleComServer } from '../shared/_helper';
 
 const { addInterceptRequestHandler, removeInterceptRequestHandler } = utils.puppeteer;
 
-// Simple page with image, script and stylesheet links.
-let HTML_PAGE = '';
-
 let serverAddress = 'http://localhost:';
 let port: number;
 let server: Server;
@@ -18,11 +15,6 @@ let server: Server;
 beforeAll(async () => {
     [server, port] = await runExampleComServer();
     serverAddress += port;
-    HTML_PAGE = `<html><body>
-    <link rel="stylesheet" type="text/css" href="${serverAddress}/style.css">
-    <img src="${serverAddress}/image.png" />
-    <script src="${serverAddress}/script.js" defer="defer">></script>
-</body></html>`;
 });
 
 afterAll(() => {
@@ -59,7 +51,7 @@ describe('utils.puppeteer.addInterceptRequestHandler|removeInterceptRequestHandl
             // Save all loaded URLs.
             page.on('response', (response) => loadedUrls.push(response.url()));
 
-            await page.setContent(HTML_PAGE, { waitUntil: 'networkidle0' });
+            await page.goto(`${serverAddress}/special/resources`, { waitUntil: 'networkidle0' });
         } finally {
             await browser.close();
         }
@@ -103,7 +95,7 @@ describe('utils.puppeteer.addInterceptRequestHandler|removeInterceptRequestHandl
                 propagatedUrls.push(request.url());
                 return request.continue();
             });
-            await page.setContent(HTML_PAGE, { waitUntil: 'networkidle0' });
+            await page.goto(`${serverAddress}/special/resources`, { waitUntil: 'networkidle0' });
         } finally {
             await browser.close();
         }
@@ -240,15 +232,13 @@ describe('utils.puppeteer.removeInterceptRequestHandler()', () => {
             });
 
             // Load with scripts and images disabled.
-            await page.setContent('<html><body></body></html>');
-            await page.setContent(HTML_PAGE, { waitUntil: 'networkidle0' });
+            await page.goto(`${serverAddress}/special/resources`, { waitUntil: 'networkidle0' });
             expect(loadedUrls).toEqual(expect.arrayContaining([
                 `${serverAddress}/style.css`,
             ]));
 
             // Try it once again.
-            await page.setContent('<html><body></body></html>');
-            await page.setContent(HTML_PAGE, { waitUntil: 'networkidle0' });
+            await page.goto(`${serverAddress}/special/resources`, { waitUntil: 'networkidle0' });
             expect(loadedUrls).toEqual(expect.arrayContaining([
                 `${serverAddress}/style.css`,
                 `${serverAddress}/style.css`,
@@ -258,8 +248,7 @@ describe('utils.puppeteer.removeInterceptRequestHandler()', () => {
             await removeInterceptRequestHandler(page, abortImagesHandler);
 
             // Try to load once again if images appear there.
-            await page.setContent('<html><body></body></html>');
-            await page.setContent(HTML_PAGE, { waitUntil: 'networkidle0' });
+            await page.goto(`${serverAddress}/special/resources`, { waitUntil: 'networkidle0' });
             expect(loadedUrls).toEqual(expect.arrayContaining([
                 `${serverAddress}/style.css`,
                 `${serverAddress}/style.css`,

--- a/test/core/puppeteer_request_interception.test.ts
+++ b/test/core/puppeteer_request_interception.test.ts
@@ -1,9 +1,7 @@
 import type { Server } from 'http';
-import type { AddressInfo } from 'net';
 
 import { sleep } from '@crawlee/utils';
 import { launchPuppeteer, utils } from 'crawlee';
-import express from 'express';
 import type { HTTPRequest } from 'puppeteer';
 
 import { runExampleComServer } from '../shared/_helper';

--- a/test/core/puppeteer_utils.test.ts
+++ b/test/core/puppeteer_utils.test.ts
@@ -4,7 +4,6 @@ import path from 'path';
 import log from '@apify/log';
 import { KeyValueStore, launchPuppeteer, puppeteerUtils, Request } from '@crawlee/puppeteer';
 import type { Dictionary } from '@crawlee/utils';
-import express from 'express';
 import type { Browser, Page, ResponseForRequest } from 'puppeteer';
 import { runExampleComServer } from 'test/shared/_helper';
 import { MemoryStorageEmulator } from 'test/shared/MemoryStorageEmulator';

--- a/test/core/puppeteer_utils.test.ts
+++ b/test/core/puppeteer_utils.test.ts
@@ -173,9 +173,9 @@ describe('puppeteerUtils', () => {
                 const page = await browser.newPage();
                 await puppeteerUtils.blockRequests(page);
                 page.on('response', (response) => loadedUrls.push(response.url()));
-                await page.goto(`${serverAddress}/special/blocking`, { waitUntil: 'load' });
+                await page.goto(`${serverAddress}/special/resources`, { waitUntil: 'load' });
                 expect(loadedUrls).toEqual([
-                    `${serverAddress}/special/blocking`,
+                    `${serverAddress}/special/resources`,
                     `${serverAddress}/script.js`,
                 ]);
             });
@@ -188,7 +188,7 @@ describe('puppeteerUtils', () => {
                     urlPatterns: ['.css'],
                 });
                 page.on('response', (response) => loadedUrls.push(response.url()));
-                await page.goto(`${serverAddress}/special/blocking`, { waitUntil: 'load' });
+                await page.goto(`${serverAddress}/special/resources`, { waitUntil: 'load' });
 
                 expect(loadedUrls).toEqual(expect.arrayContaining([
                     `${serverAddress}/image.png`,
@@ -203,7 +203,7 @@ describe('puppeteerUtils', () => {
                 const page = await browser.newPage();
                 await puppeteerUtils.blockResources(page);
                 page.on('response', (response) => loadedUrls.push(response.url()));
-                await page.goto(`${serverAddress}/special/blocking`, { waitUntil: 'load' });
+                await page.goto(`${serverAddress}/special/resources`, { waitUntil: 'load' });
 
                 expect(loadedUrls).toEqual(expect.arrayContaining([
                     `${serverAddress}/script.js`,
@@ -216,7 +216,7 @@ describe('puppeteerUtils', () => {
                 const page = await browser.newPage();
                 await puppeteerUtils.blockResources(page, ['script']);
                 page.on('response', (response) => loadedUrls.push(response.url()));
-                await page.goto(`${serverAddress}/special/blocking`, { waitUntil: 'load' });
+                await page.goto(`${serverAddress}/special/resources`, { waitUntil: 'load' });
 
                 expect(loadedUrls).toEqual(expect.arrayContaining([
                     `${serverAddress}/style.css`,

--- a/test/core/puppeteer_utils.test.ts
+++ b/test/core/puppeteer_utils.test.ts
@@ -173,13 +173,11 @@ describe('puppeteerUtils', () => {
                 const page = await browser.newPage();
                 await puppeteerUtils.blockRequests(page);
                 page.on('response', (response) => loadedUrls.push(response.url()));
-                await page.setContent(`<html><body>
-                <link rel="stylesheet" type="text/css" href="${serverAddress}/style.css">
-                <img src="${serverAddress}/image.png">
-                <img src="${serverAddress}/image.gif">
-                <script src="${serverAddress}/script.js" defer="defer">></script>
-            </body></html>`, { waitUntil: 'load' });
-                expect(loadedUrls).toEqual([`${serverAddress}/script.js`]);
+                await page.goto(`${serverAddress}/special/blocking`, { waitUntil: 'load' });
+                expect(loadedUrls).toEqual([
+                    `${serverAddress}/special/blocking`,
+                    `${serverAddress}/script.js`,
+                ]);
             });
 
             test('works with overridden values', async () => {
@@ -190,12 +188,8 @@ describe('puppeteerUtils', () => {
                     urlPatterns: ['.css'],
                 });
                 page.on('response', (response) => loadedUrls.push(response.url()));
-                await page.setContent(`<html><body>
-                <link rel="stylesheet" type="text/css" href="${serverAddress}/style.css">
-                <img src="${serverAddress}/image.png">
-                <img src="${serverAddress}/image.gif">
-                <script src="${serverAddress}/script.js" defer="defer">></script>
-            </body></html>`, { waitUntil: 'load' });
+                await page.goto(`${serverAddress}/special/blocking`, { waitUntil: 'load' });
+
                 expect(loadedUrls).toEqual(expect.arrayContaining([
                     `${serverAddress}/image.png`,
                     `${serverAddress}/script.js`,
@@ -209,11 +203,7 @@ describe('puppeteerUtils', () => {
                 const page = await browser.newPage();
                 await puppeteerUtils.blockResources(page);
                 page.on('response', (response) => loadedUrls.push(response.url()));
-                await page.setContent(`<html><body>
-                <link rel="stylesheet" type="text/css" href="${serverAddress}/style.css">
-                <img src="${serverAddress}/image.png" />
-                <script src="${serverAddress}/script.js" defer="defer">></script>
-            </body></html>`, { waitUntil: 'load' });
+                await page.goto(`${serverAddress}/special/blocking`, { waitUntil: 'load' });
 
                 expect(loadedUrls).toEqual(expect.arrayContaining([
                     `${serverAddress}/script.js`,
@@ -226,11 +216,7 @@ describe('puppeteerUtils', () => {
                 const page = await browser.newPage();
                 await puppeteerUtils.blockResources(page, ['script']);
                 page.on('response', (response) => loadedUrls.push(response.url()));
-                await page.setContent(`<html><body>
-                <link rel="stylesheet" type="text/css" href="${serverAddress}/style.css">
-                <img src="${serverAddress}/image.png" />
-                <script src="${serverAddress}/script.js" defer="defer">></script>
-            </body></html>`, { waitUntil: 'load' });
+                await page.goto(`${serverAddress}/special/blocking`, { waitUntil: 'load' });
 
                 expect(loadedUrls).toEqual(expect.arrayContaining([
                     `${serverAddress}/style.css`,

--- a/test/shared/_helper.ts
+++ b/test/shared/_helper.ts
@@ -70,7 +70,7 @@ export const responseSamples = {
     </div>
     </body>
     </html>`,
-    blocking: `
+    resources: `
     <html><body>
             <link rel="stylesheet" type="text/css" href="/style.css">
             <img src="/image.png">
@@ -184,8 +184,8 @@ export async function runExampleComServer(): Promise<[Server, number]> {
             await setTimeout(32000);
             res.type('html').send('<div>TEST</div>');
         });
-        special.get('/blocking', async (_req, res) => {
-            res.type('html').send(responseSamples.blocking);
+        special.get('/resources', async (_req, res) => {
+            res.type('html').send(responseSamples.resources);
         });
     })();
 

--- a/test/shared/_helper.ts
+++ b/test/shared/_helper.ts
@@ -70,6 +70,13 @@ export const responseSamples = {
     </div>
     </body>
     </html>`,
+    blocking: `
+    <html><body>
+            <link rel="stylesheet" type="text/css" href="/style.css">
+            <img src="/image.png">
+            <img src="/image.gif">
+            <script src="/script.js" defer="defer"></script>
+        </body></html>`,
     cacheable: {
         html: `
 <!doctype html>
@@ -176,6 +183,9 @@ export async function runExampleComServer(): Promise<[Server, number]> {
         special.get('/timeout', async (_req, res) => {
             await setTimeout(32000);
             res.type('html').send('<div>TEST</div>');
+        });
+        special.get('/blocking', async (_req, res) => {
+            res.type('html').send(responseSamples.blocking);
         });
     })();
 


### PR DESCRIPTION
https://developer.chrome.com/articles/new-headless/
 
To opt out of it and keep using the old headless, add `headless: 'old` to your puppeteer crawler options.