### PR TITLE
docs: minor syntax errors in blockRequests docs example

### DIFF
--- a/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
+++ b/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
@@ -610,8 +610,8 @@ export interface PlaywrightContextUtils {
      *         // Block all requests to URLs that include `adsbygoogle.js` and also all defaults.
      *         await blockRequests({
      *             extraUrlPatterns: ['adsbygoogle.js'],
-     *         }),
-     *     }),
+     *         });
+     *     },
      * ],
      * ```
      */


### PR DESCRIPTION
Example for `blockRequests` (https://crawlee.dev/api/playwright-crawler/interface/PlaywrightCrawlingContext#blockRequests) has a couple syntax errors.

![image](https://github.com/apify/crawlee/assets/105007/c9136ab7-f47c-4e22-80bc-13bf9b7c4c8e)
