### PR TITLE
feat: infiniteScroll has maxScrollHeight limit

### DIFF
--- a/packages/puppeteer-crawler/src/internals/utils/puppeteer_utils.ts
+++ b/packages/puppeteer-crawler/src/internals/utils/puppeteer_utils.ts
@@ -446,9 +446,15 @@ export async function gotoExtended(page: Page, request: Request, gotoOptions: Di
 export interface InfiniteScrollOptions {
     /**
      * How many seconds to scroll for. If 0, will scroll until bottom of page.
-     * @default 1
+     * @default 0
      */
     timeoutSecs?: number;
+
+    /**
+     * How many pixels to scroll down. If 0, will scroll until bottom of page.
+     * @default 0
+     */
+    maxScrollHeight?: number;
 
     /**
      * How many seconds to wait for no new content to load before exit.
@@ -483,18 +489,20 @@ export async function infiniteScroll(page: Page, options: InfiniteScrollOptions 
     ow(page, ow.object.validate(validators.browserPage));
     ow(options, ow.object.exactShape({
         timeoutSecs: ow.optional.number,
+        maxScrollHeight: ow.optional.number,
         waitForSecs: ow.optional.number,
         scrollDownAndUp: ow.optional.boolean,
         buttonSelector: ow.optional.string,
         stopScrollCallback: ow.optional.function,
     }));
 
-    const { timeoutSecs = 0, waitForSecs = 4, scrollDownAndUp = false, buttonSelector, stopScrollCallback } = options;
+    const { timeoutSecs = 0, maxScrollHeight = 0, waitForSecs = 4, scrollDownAndUp = false, buttonSelector, stopScrollCallback } = options;
 
     let finished;
     const startTime = Date.now();
     const CHECK_INTERVAL_MILLIS = 1000;
     const SCROLL_HEIGHT_IF_ZERO = 10000;
+    let scrolledDistance = 0;
     const maybeResourceTypesInfiniteScroll = ['xhr', 'fetch', 'websocket', 'other'];
     const resourcesStats = {
         newRequested: 0,
@@ -545,6 +553,12 @@ export async function infiniteScroll(page: Page, options: InfiniteScrollOptions 
             clearInterval(checkFinished);
             finished = true;
         }
+
+        // check if max scroll height has been reached
+        if (maxScrollHeight > 0 && scrolledDistance > maxScrollHeight) {
+            clearInterval(checkFinished);
+            finished = true;
+        }
     }, CHECK_INTERVAL_MILLIS);
 
     const doScroll = async () => {
@@ -554,6 +568,7 @@ export async function infiniteScroll(page: Page, options: InfiniteScrollOptions 
         const delta = bodyScrollHeight === 0 ? SCROLL_HEIGHT_IF_ZERO : bodyScrollHeight;
 
         await page.mouse.wheel({ deltaY: delta });
+        scrolledDistance += delta;
     };
 
     const maybeClickButton = async () => {

--- a/test/core/playwright_utils.test.ts
+++ b/test/core/playwright_utils.test.ts
@@ -266,6 +266,23 @@ describe('playwrightUtils', () => {
                 expect(after).toBe(true);
             });
 
+            test('maxScrollHeight works', async () => {
+                const before = await page.evaluate(isAtBottom);
+                expect(before).toBe(false);
+
+                await playwrightUtils.infiniteScroll(page, {
+                    waitForSecs: Infinity,
+                    maxScrollHeight: 1000,
+                    stopScrollCallback: async () => true,
+                });
+
+                const after = await page.evaluate(isAtBottom);
+                // It scrolls to the bottom in the first scroll so this is correct.
+                // The test passes because the Infinite waitForSecs is broken by the height requirement.
+                // If it didn't, the test would time out.
+                expect(after).toBe(true);
+            });
+
             test('stopScrollCallback works', async () => {
                 const before = await page.evaluate(isAtBottom);
                 expect(before).toBe(false);
@@ -276,9 +293,6 @@ describe('playwrightUtils', () => {
                 });
 
                 const after = await page.evaluate(isAtBottom);
-                // It scrolls to the bottom in the first scroll so this is correct.
-                // The test passes because the Infinite waitForSecs is broken by the callback.
-                // If it didn't, the test would time out.
                 expect(after).toBe(true);
             });
         });

--- a/test/core/puppeteer_utils.test.ts
+++ b/test/core/puppeteer_utils.test.ts
@@ -392,6 +392,23 @@ describe('puppeteerUtils', () => {
                 expect(after).toBe(true);
             });
 
+            test('maxScrollHeight works', async () => {
+                const before = await page.evaluate(isAtBottom);
+                expect(before).toBe(false);
+
+                await puppeteerUtils.infiniteScroll(page, {
+                    waitForSecs: Infinity,
+                    maxScrollHeight: 1000,
+                    stopScrollCallback: async () => true,
+                });
+
+                const after = await page.evaluate(isAtBottom);
+                // It scrolls to the bottom in the first scroll so this is correct.
+                // The test passes because the Infinite waitForSecs is broken by the height requirement.
+                // If it didn't, the test would time out.
+                expect(after).toBe(true);
+            });
+
             test('stopScrollCallback works', async () => {
                 const before = await page.evaluate(isAtBottom);
                 expect(before).toBe(false);
@@ -402,9 +419,6 @@ describe('puppeteerUtils', () => {
                 });
 
                 const after = await page.evaluate(isAtBottom);
-                // It scrolls to the bottom in the first scroll so this is correct.
-                // The test passes because the Infinite waitForSecs is broken by the callback.
-                // If it didn't, the test would time out.
                 expect(after).toBe(true);
             });
         });


### PR DESCRIPTION
Adds the `maxScrollHeight` parameter for the `infiniteScroll` helper functions to stop scrolling when a certain scroll distance has been reached.