### PR TITLE
test: fix assertion in the failing linkedom e2e test

### DIFF
--- a/test/e2e/linkedom-default-ts/actor/main.ts
+++ b/test/e2e/linkedom-default-ts/actor/main.ts
@@ -11,15 +11,14 @@ if (process.env.STORAGE_IMPLEMENTATION === 'LOCAL') {
 
 const crawler = new LinkeDOMCrawler();
 
-crawler.router.addDefaultHandler(async ({ window, document, enqueueLinks, request, log }) => {
+crawler.router.addDefaultHandler(async ({ document, enqueueLinks, request, log }) => {
     const { url } = request;
     await enqueueLinks({
         globs: ['https://crawlee.dev/docs/**'],
     });
 
-    const pageTitle = window.document.title;
-    const { title } = document;
-    assert.strictEqual(pageTitle, title);
+    const pageTitle = document.title;
+    assert.notEqual(pageTitle, '');
     log.info(`URL: ${url} TITLE: ${pageTitle}`);
 
     await Dataset.pushData({ url, pageTitle });


### PR DESCRIPTION
Looks like `linkedom` will allow only one read of the page title and resets it to empty string.

```ts
console.log(document.title); // this will print the correct value
console.log(document.title); // while this will return an empty string...
```