### PR TITLE
fix(http-crawler): replace `IncomingMessage` with `PlainResponse` for context's `response`

### DIFF
--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -51,6 +51,9 @@ export enum RequestState {
  * are considered as pointing to the same web resource. This behavior applies to all Crawlee classes,
  * such as {@apilink RequestList}, {@apilink RequestQueue}, {@apilink PuppeteerCrawler} or {@apilink PlaywrightCrawler}.
  *
+ * > To access and examine the actual request sent over http, with all autofilled headers you can access
+ * `response.request` object from the request handler
+ *
  * Example use:
  *
  * ```javascript

--- a/test/core/crawlers/cheerio_crawler.test.ts
+++ b/test/core/crawlers/cheerio_crawler.test.ts
@@ -380,8 +380,6 @@ describe('CheerioCrawler', () => {
             const crawler = new CheerioCrawler({
                 requestList,
                 requestHandler: ({ response }) => {
-                    // TODO: this accesses IncomingMessage#request, which doesn't exist according to types
-                    // @ts-expect-error
                     headers.push(response.request.options.headers);
                 },
             });


### PR DESCRIPTION
Closes #1964 