### PR TITLE
feat(basic-crawler): allow configuring the automatic status message

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -52,6 +52,11 @@
         "no-console": "error",
         "no-underscore-dangle": 0,
         "no-void": 0,
+        "max-len": ["error", {
+            "code": 160,
+            "ignoreUrls": true,
+            "ignoreComments": true
+        }],
         "import/order": ["error", {
             "groups": ["builtin", "external", ["parent", "sibling"], "index", "object"],
             "alphabetize": { "order": "asc", "caseInsensitive": true },

--- a/packages/types/src/storages.ts
+++ b/packages/types/src/storages.ts
@@ -1,5 +1,3 @@
-import type { LogLevel } from '@apify/log';
-
 import type { AllowedHttpMethods, Dictionary } from './utility-types';
 
 /**
@@ -309,7 +307,7 @@ export interface RequestQueueOptions {
 
 export interface SetStatusMessageOptions {
     isStatusMessageTerminal?: boolean;
-    level?: LogLevel.DEBUG | LogLevel.INFO | LogLevel.WARNING | LogLevel.ERROR | 'DEBUG' | 'INFO' | 'WARNING' | 'ERROR';
+    level?: 'DEBUG' | 'INFO' | 'WARNING' | 'ERROR';
 }
 
 /**

--- a/packages/types/src/storages.ts
+++ b/packages/types/src/storages.ts
@@ -309,7 +309,7 @@ export interface RequestQueueOptions {
 
 export interface SetStatusMessageOptions {
     isStatusMessageTerminal?: boolean;
-    level?: LogLevel.DEBUG | LogLevel.INFO | LogLevel.WARNING | LogLevel.ERROR;
+    level?: LogLevel.DEBUG | LogLevel.INFO | LogLevel.WARNING | LogLevel.ERROR | 'DEBUG' | 'INFO' | 'WARNING' | 'ERROR';
 }
 
 /**

--- a/test/core/crawlers/basic_crawler.test.ts
+++ b/test/core/crawlers/basic_crawler.test.ts
@@ -19,9 +19,7 @@ import {
     CriticalError,
     MissingRouteError,
 } from '@crawlee/basic';
-import {
-    AutoscaledPool, RequestState,
-} from '@crawlee/core';
+import { RequestState } from '@crawlee/core';
 import type { Dictionary } from '@crawlee/utils';
 import { sleep } from '@crawlee/utils';
 import express from 'express';

--- a/test/e2e/cheerio-default/actor/main.js
+++ b/test/e2e/cheerio-default/actor/main.js
@@ -8,8 +8,9 @@ const mainOptions = {
 
 await Actor.main(async () => {
     const crawler = new CheerioCrawler({
-        statusMessageCallback: async () => `this is status message from ${new Date().toISOString()}`,
-        statusMessageLogLevel: 'INFO',
+        statusMessageCallback: async (ctx) => {
+            return ctx.crawler.setStatusMessage(`this is status message from ${new Date().toISOString()}`, { level: 'INFO' });
+        },
         statusMessageLoggingInterval: 1,
         async requestHandler({ $, enqueueLinks, request, log }) {
             const { url } = request;

--- a/test/e2e/cheerio-default/actor/main.js
+++ b/test/e2e/cheerio-default/actor/main.js
@@ -8,6 +8,9 @@ const mainOptions = {
 
 await Actor.main(async () => {
     const crawler = new CheerioCrawler({
+        statusMessageCallback: async () => `this is status message from ${new Date().toISOString()}`,
+        statusMessageLogLevel: 'INFO',
+        statusMessageLoggingInterval: 1,
         async requestHandler({ $, enqueueLinks, request, log }) {
             const { url } = request;
             await enqueueLinks({


### PR DESCRIPTION
Adds `statusMessageCallback` option to all the crawler classes to allow customizing the status message call.

> Allows overriding the default status message. The callback needs to call `crawler.setStatusMessage()` explicitly.
> The default status message is provided in the parameters.

```ts
const crawler = new CheerioCrawler({
    statusMessageCallback: async (ctx) => {
        return ctx.crawler.setStatusMessage(`this is status message from ${new Date().toISOString()}`, { level: 'INFO' }); // log level defaults to 'DEBUG'
    },
    statusMessageLoggingInterval: 1, // defaults to 10s
    async requestHandler({ $, enqueueLinks, request, log }) {
        // ...
    },
});
```