### PR TITLE
feat: retire session on proxy error

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -1144,7 +1144,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
         const { request } = crawlingContext;
 
         if ((request.sessionRotationCount ?? 0) >= this.maxSessionRotations) {
-            throw new Error(`Session failed ${request.sessionRotationCount} times. `
+            throw new Error(`Request failed because of proxy-related errors ${request.sessionRotationCount} times. `
                 + 'This might be caused by a misconfigured proxy or an invalid session pool configuration.');
         }
         request.sessionRotationCount ??= 0;

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -657,6 +657,12 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
         this.autoscaledPoolOptions = { ...autoscaledPoolOptions, ...basicCrawlerAutoscaledPoolConfiguration };
     }
 
+    /**
+     * Checks if the given error is a proxy error by comparing its message to a list of known proxy error messages.
+     * Used for retrying requests that failed due to proxy errors.
+     * @param {Error} error - The error to check.
+     * @returns {boolean} - `true` if the error is a proxy error, `false` otherwise.
+     */
     protected isProxyError(error: Error) {
         return ROTATE_PROXY_ERRORS.some((x: string) => (this._getMessageFromError(error) as any)?.includes(x));
     }
@@ -1142,7 +1148,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
             this.stats.errorTrackerRetry.add(error);
 
             if (error instanceof SessionError) {
-                if ((request.sessionRotationCount ?? 0) > 10) {
+                if ((request.sessionRotationCount ?? 0) >= 10) {
                     throw new Error(`Session rotation failed ${request.sessionRotationCount} times. `
                         + 'This might be caused by a misconfigured proxy or an invalid session pool configuration.');
                 }

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -41,6 +41,7 @@ import {
     RetryRequestError,
 } from '@crawlee/core';
 import type { Dictionary, Awaitable, BatchAddRequestsResult, SetStatusMessageOptions } from '@crawlee/types';
+import { ROTATE_PROXY_ERRORS } from '@crawlee/utils';
 import type { Method, OptionsInit } from 'got-scraping';
 import { gotScraping } from 'got-scraping';
 import ow, { ArgumentError } from 'ow';
@@ -653,6 +654,10 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
         };
 
         this.autoscaledPoolOptions = { ...autoscaledPoolOptions, ...basicCrawlerAutoscaledPoolConfiguration };
+    }
+
+    protected shouldRotateProxies(error: Error) {
+        return ROTATE_PROXY_ERRORS.some((x: string) => (this._getMessageFromError(error) as any)?.includes(x));
     }
 
     protected isRequestBlocked(_crawlingContext: Context) {

--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -24,6 +24,7 @@ import {
     RequestState,
     resolveBaseUrlForEnqueueLinksFiltering,
     validators,
+    SessionError,
 } from '@crawlee/basic';
 import type {
     BrowserController,
@@ -498,8 +499,7 @@ export abstract class BrowserCrawler<
                 tryCancel();
             } catch (e: any) {
                 if (this.isProxyError(e)) {
-                    session?.retire();
-                    throw new Error('Proxy error detected, rotating...');
+                    throw new SessionError();
                 } else {
                     throw e;
                 }

--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -519,8 +519,7 @@ export abstract class BrowserCrawler<
 
         if (this.retryOnBlocked) {
             if (await this.isRequestBlocked(crawlingContext)) {
-                session?.retire();
-                throw new Error('Antibot protection detected, the session has been retired.');
+                throw new SessionError();
             }
         }
 

--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -497,7 +497,7 @@ export abstract class BrowserCrawler<
                 await this._handleNavigation(crawlingContext);
                 tryCancel();
             } catch (e: any) {
-                if (this.shouldRotateProxies(e)) {
+                if (this.isProxyError(e)) {
                     session?.retire();
                     throw new Error('Proxy error detected, rotating...');
                 } else {

--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -493,8 +493,17 @@ export abstract class BrowserCrawler<
         const { request, session } = crawlingContext;
 
         if (!request.skipNavigation) {
-            await this._handleNavigation(crawlingContext);
-            tryCancel();
+            try {
+                await this._handleNavigation(crawlingContext);
+                tryCancel();
+            } catch (e: any) {
+                if (this.shouldRotateProxies(e)) {
+                    session?.retire();
+                    throw new Error('Proxy error detected, rotating...');
+                } else {
+                    throw e;
+                }
+            }
 
             await this._responseHandler(crawlingContext);
             tryCancel();

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -23,3 +23,14 @@ export class RetryRequestError extends Error {
         super(message ?? "Request is being retried at the user's request");
     }
 }
+
+/**
+ * Errors of `SessionError` type will trigger a session rotation.
+ *
+ * This error doesn't respect the `maxRequestRetries` option and has a separate limit of `maxSessionRotations`.
+ */
+export class SessionError extends RetryRequestError {
+    constructor(message?: string) {
+        super(message ?? 'Detected a session error, rotating session...');
+    }
+}

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -108,7 +108,7 @@ export class Request<UserData extends Dictionary = Dictionary> {
     /** The `true` value indicates that the request will not be automatically retried on error. */
     noRetry: boolean;
 
-    /** Indicates the number of times the crawling of the request has rotated the session due to a proxy error */
+    /** Indicates the number of times the crawling of the request has rotated the session due to a session or a proxy error. */
     sessionRotationCount?: number;
 
     /** Indicates the number of times the crawling of the request has been retried on error. */
@@ -163,6 +163,7 @@ export class Request<UserData extends Dictionary = Dictionary> {
             payload,
             noRetry = false,
             retryCount = 0,
+            sessionRotationCount = 0,
             maxRetries,
             errorMessages = [],
             headers = {},
@@ -172,7 +173,14 @@ export class Request<UserData extends Dictionary = Dictionary> {
             keepUrlFragment = false,
             useExtendedUniqueKey = false,
             skipNavigation,
-        } = options as RequestOptions & { loadedUrl?: string; retryCount?: number; maxRetries?: number; errorMessages?: string[]; handledAt?: string | Date };
+        } = options as RequestOptions & {
+            loadedUrl?: string;
+            retryCount?: number;
+            sessionRotationCount?: number;
+            maxRetries?: number;
+            errorMessages?: string[];
+            handledAt?: string | Date;
+        };
 
         let {
             method = 'GET',
@@ -190,6 +198,7 @@ export class Request<UserData extends Dictionary = Dictionary> {
         this.payload = payload;
         this.noRetry = noRetry;
         this.retryCount = retryCount;
+        this.sessionRotationCount = sessionRotationCount;
         this.errorMessages = [...errorMessages];
         this.headers = { ...headers };
         this.handledAt = handledAt as unknown instanceof Date ? (handledAt as Date).toISOString() : handledAt!;

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -22,6 +22,7 @@ const requestOptionalPredicates = {
     payload: ow.optional.any(ow.string, ow.buffer),
     noRetry: ow.optional.boolean,
     retryCount: ow.optional.number,
+    sessionRotationCount: ow.optional.number,
     maxRetries: ow.optional.number,
     errorMessages: ow.optional.array.ofType(ow.string),
     headers: ow.optional.object,
@@ -106,6 +107,9 @@ export class Request<UserData extends Dictionary = Dictionary> {
 
     /** The `true` value indicates that the request will not be automatically retried on error. */
     noRetry: boolean;
+
+    /** Indicates the number of times the crawling of the request has rotated the session due to a proxy error */
+    sessionRotationCount?: number;
 
     /** Indicates the number of times the crawling of the request has been retried on error. */
     retryCount: number;

--- a/packages/http-crawler/src/internals/http-crawler.ts
+++ b/packages/http-crawler/src/internals/http-crawler.ts
@@ -476,8 +476,7 @@ export class HttpCrawler<Context extends InternalHttpCrawlingContext<any, any, H
         }
 
         if (this.retryOnBlocked && await this.isRequestBlocked(crawlingContext)) {
-            crawlingContext.session?.retire();
-            throw new Error('Antibot protection detected, the session has been retired.');
+            throw new SessionError();
         }
 
         request.state = RequestState.REQUEST_HANDLER;

--- a/packages/http-crawler/src/internals/http-crawler.ts
+++ b/packages/http-crawler/src/internals/http-crawler.ts
@@ -435,16 +435,8 @@ export class HttpCrawler<Context extends InternalHttpCrawlingContext<any, any, H
             crawlingContext.proxyInfo = await this.proxyConfiguration.newProxyInfo(sessionId);
         }
         if (!request.skipNavigation) {
-            try {
-                await this._handleNavigation(crawlingContext);
-                tryCancel();
-            } catch (e: any) {
-                if (this.isProxyError(e)) {
-                    throw new SessionError();
-                } else {
-                    throw e;
-                }
-            }
+            await this._handleNavigation(crawlingContext);
+            tryCancel();
 
             const parsed = await this._parseResponse(request, crawlingContext.response!, crawlingContext);
             const response = parsed.response!;
@@ -604,7 +596,11 @@ export class HttpCrawler<Context extends InternalHttpCrawlingContext<any, any, H
                 return undefined as unknown as PlainResponse;
             }
 
-            throw e;
+            if (this.isProxyError(e as Error)) {
+                throw new SessionError();
+            } else {
+                throw e;
+            }
         }
     }
 

--- a/packages/utils/src/internals/blocked.ts
+++ b/packages/utils/src/internals/blocked.ts
@@ -13,5 +13,6 @@ export const ROTATE_PROXY_ERRORS = [
     'ECONNRESET',
     'ECONNREFUSED',
     'ERR_PROXY_CONNECTION_FAILED',
+    'ERR_TUNNEL_CONNECTION_FAILED',
     'Proxy responded with',
 ];

--- a/packages/utils/src/internals/blocked.ts
+++ b/packages/utils/src/internals/blocked.ts
@@ -5,3 +5,9 @@ export const RETRY_CSS_SELECTORS = [
     'iframe[src^="https://challenges.cloudflare.com"]',
     'div#infoDiv0 a[href*="//www.google.com/policies/terms/"]',
 ];
+
+export const ROTATE_PROXY_ERRORS = [
+    'ECONNRESET',
+    'ECONNREFUSED',
+    'ERR_PROXY_CONNECTION_FAILED',
+];

--- a/packages/utils/src/internals/blocked.ts
+++ b/packages/utils/src/internals/blocked.ts
@@ -6,8 +6,12 @@ export const RETRY_CSS_SELECTORS = [
     'div#infoDiv0 a[href*="//www.google.com/policies/terms/"]',
 ];
 
+/**
+ * Content of proxy errors that should trigger a retry, as the proxy is likely getting blocked / is malfunctioning.
+ */
 export const ROTATE_PROXY_ERRORS = [
     'ECONNRESET',
     'ECONNREFUSED',
     'ERR_PROXY_CONNECTION_FAILED',
+    'Proxy responded with',
 ];

--- a/test/core/crawlers/browser_crawler.test.ts
+++ b/test/core/crawlers/browser_crawler.test.ts
@@ -814,7 +814,7 @@ describe('BrowserCrawler', () => {
                 requestHandler: async () => {},
             });
 
-            await browserCrawler.run();
+            await expect(browserCrawler.run()).resolves.not.toThrow();
         });
 
         test('proxy rotation on error stops after maxSessionRotations limit', async () => {

--- a/test/core/crawlers/browser_crawler.test.ts
+++ b/test/core/crawlers/browser_crawler.test.ts
@@ -786,7 +786,74 @@ describe('BrowserCrawler', () => {
 
             delete process.env[ENV_VARS.PROXY_PASSWORD];
         });
+
+        test('proxy rotation on error works as expected', async () => {
+            const goodProxyUrl = 'http://good.proxy';
+            const proxyConfiguration = new ProxyConfiguration({ proxyUrls: ['http://localhost', 'http://localhost:1234', goodProxyUrl] });
+
+            const browserCrawler = new class extends BrowserCrawlerTest {
+                protected override async _navigationHandler(ctx: PuppeteerCrawlingContext): Promise<HTTPResponse | null | undefined> {
+                    const { session } = ctx;
+                    const proxyInfo = await this.proxyConfiguration.newProxyInfo(session?.id);
+
+                    if (proxyInfo.url !== goodProxyUrl) {
+                        throw new Error('ERR_PROXY_CONNECTION_FAILED');
+                    }
+
+                    return null;
+                }
+            }({
+                browserPoolOptions: {
+                    browserPlugins: [puppeteerPlugin],
+                },
+                requestList,
+                maxRequestRetries: 0,
+                maxConcurrency: 1,
+                useSessionPool: true,
+                proxyConfiguration,
+                requestHandler: async () => {},
+            });
+
+            await browserCrawler.run();
+        });
+
+        test('proxy rotation on error stops after maxSessionRotations limit', async () => {
+            const proxyConfiguration = new ProxyConfiguration({ proxyUrls: ['http://localhost', 'http://localhost:1234'] });
+
+            /**
+             * The first increment is the base case when the proxy is retrieved for the first time.
+             */
+            let numberOfRotations = -1;
+            const browserCrawler = new class extends BrowserCrawlerTest {
+                protected override async _navigationHandler(ctx: PuppeteerCrawlingContext): Promise<HTTPResponse | null | undefined> {
+                    const { session } = ctx;
+                    const proxyInfo = await this.proxyConfiguration.newProxyInfo(session?.id);
+
+                    numberOfRotations++;
+
+                    if (proxyInfo.url.includes('localhost')) {
+                        throw new Error('ERR_PROXY_CONNECTION_FAILED');
+                    }
+
+                    return null;
+                }
+            }({
+                browserPoolOptions: {
+                    browserPlugins: [puppeteerPlugin],
+                },
+                requestList,
+                maxRequestRetries: 0,
+                maxConcurrency: 1,
+                useSessionPool: true,
+                proxyConfiguration,
+                requestHandler: async () => {},
+            });
+
+            await expect(browserCrawler.run()).rejects.toThrow();
+            expect(numberOfRotations).toBe(10);
+        });
     });
+
     describe('Crawling context', () => {
         const sources = ['http://example.com/'];
         let requestList: RequestList;
@@ -852,30 +919,6 @@ describe('BrowserCrawler', () => {
             });
             // @ts-expect-error Overriding protected method
             browserCrawler._navigationHandler = gotoFunction;
-
-            await browserCrawler.run();
-        });
-
-        test('failedRequestHandler contains proxyInfo', async () => {
-            const proxyConfiguration = new ProxyConfiguration({ proxyUrls: ['http://localhost'] });
-
-            const browserCrawler = new BrowserCrawlerTest({
-                browserPoolOptions: {
-                    browserPlugins: [puppeteerPlugin],
-                },
-                requestList,
-                maxRequestRetries: 0,
-                maxConcurrency: 1,
-                useSessionPool: true,
-                proxyConfiguration,
-                requestHandler: async () => {
-                    throw new Error('some error');
-                },
-                failedRequestHandler: async (crawlingContext) => {
-                    expect(typeof crawlingContext.proxyInfo).toEqual('object');
-                    expect(crawlingContext.proxyInfo.hasOwnProperty('url')).toEqual(true);
-                },
-            });
 
             await browserCrawler.run();
         });

--- a/test/core/crawlers/browser_crawler.test.ts
+++ b/test/core/crawlers/browser_crawler.test.ts
@@ -842,15 +842,13 @@ describe('BrowserCrawler', () => {
                     browserPlugins: [puppeteerPlugin],
                 },
                 requestList,
-                maxRequestRetries: 0,
-                maxConcurrency: 1,
-                useSessionPool: true,
+                maxSessionRotations: 5,
                 proxyConfiguration,
                 requestHandler: async () => {},
             });
 
             await expect(browserCrawler.run()).rejects.toThrow();
-            expect(numberOfRotations).toBe(10);
+            expect(numberOfRotations).toBe(5);
         });
     });
 

--- a/test/core/crawlers/browser_crawler.test.ts
+++ b/test/core/crawlers/browser_crawler.test.ts
@@ -843,6 +843,7 @@ describe('BrowserCrawler', () => {
                 },
                 requestList,
                 maxSessionRotations: 5,
+                maxConcurrency: 1,
                 proxyConfiguration,
                 requestHandler: async () => {},
             });

--- a/test/core/crawlers/cheerio_crawler.test.ts
+++ b/test/core/crawlers/cheerio_crawler.test.ts
@@ -1047,6 +1047,7 @@ describe('CheerioCrawler', () => {
             const cheerioCrawler = new CheerioCrawler({
                 requestList: requestListNew,
                 maxRequestRetries: 0,
+                maxSessionRotations: 0,
                 requestHandler: () => {},
                 failedRequestHandler: () => {},
                 useSessionPool: true,
@@ -1061,7 +1062,11 @@ describe('CheerioCrawler', () => {
                 return oldHandleRequestF.call(cheerioCrawler, opts);
             };
 
-            await cheerioCrawler.run();
+            try {
+                await cheerioCrawler.run();
+            } catch (e) {
+                // localhost proxy causes proxy errors, session rotations and finally throws, but we don't care
+            }
 
             expect(newUrlSpy).toBeCalledWith(usedSession.id);
         });

--- a/test/core/crawlers/cheerio_crawler.test.ts
+++ b/test/core/crawlers/cheerio_crawler.test.ts
@@ -735,15 +735,13 @@ describe('CheerioCrawler', () => {
                     return null;
                 }
             }({
-                maxRequestRetries: 0,
-                maxConcurrency: 1,
-                useSessionPool: true,
                 proxyConfiguration,
+                maxSessionRotations: 5,
                 requestHandler: async () => {},
             });
 
             await expect(crawler.run([serverAddress])).rejects.toThrow();
-            expect(numberOfRotations).toBe(10);
+            expect(numberOfRotations).toBe(5);
         });
     });
 


### PR DESCRIPTION
When Crawlee sees a proxy-related error in navigation, it retires the current session and retries the request using another session (proxy).

closes #1912 