### PR TITLE
fix: log original error message on session rotation

### DIFF
--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -626,7 +626,7 @@ export abstract class BrowserCrawler<
      */
     protected _throwIfProxyError(error: Error) {
         if (this.isProxyError(error)) {
-            throw new SessionError(error.message);
+            throw new SessionError(this._getMessageFromError(error) as string);
         }
     }
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -31,6 +31,7 @@ export class RetryRequestError extends Error {
  */
 export class SessionError extends RetryRequestError {
     constructor(message?: string) {
-        super(message ?? 'Detected a session error, rotating session...');
+        super(`Detected a session error, rotating session... 
+Error${message ?? ''}`);
     }
 }

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -31,7 +31,6 @@ export class RetryRequestError extends Error {
  */
 export class SessionError extends RetryRequestError {
     constructor(message?: string) {
-        super(`Detected a session error, rotating session... 
-Error${message ?? ''}`);
+        super(`Detected a session error, rotating session... ${message ? `\n${message}` : ''}`);
     }
 }

--- a/packages/http-crawler/src/internals/http-crawler.ts
+++ b/packages/http-crawler/src/internals/http-crawler.ts
@@ -597,7 +597,7 @@ export class HttpCrawler<Context extends InternalHttpCrawlingContext<any, any, H
             }
 
             if (this.isProxyError(e as Error)) {
-                throw new SessionError();
+                throw new SessionError(this._getMessageFromError(e as Error) as string);
             } else {
                 throw e;
             }


### PR DESCRIPTION
The session rotation error message now contains the original proxy error for easier debugging.