### PR TITLE
feat: exceeding maxSessionRotations calls failedRequestHandler

### DIFF
--- a/test/core/crawlers/browser_crawler.test.ts
+++ b/test/core/crawlers/browser_crawler.test.ts
@@ -790,6 +790,7 @@ describe('BrowserCrawler', () => {
         test('proxy rotation on error works as expected', async () => {
             const goodProxyUrl = 'http://good.proxy';
             const proxyConfiguration = new ProxyConfiguration({ proxyUrls: ['http://localhost', 'http://localhost:1234', goodProxyUrl] });
+            const requestHandler = jest.fn();
 
             const browserCrawler = new class extends BrowserCrawlerTest {
                 protected override async _navigationHandler(ctx: PuppeteerCrawlingContext): Promise<HTTPResponse | null | undefined> {
@@ -811,10 +812,11 @@ describe('BrowserCrawler', () => {
                 maxConcurrency: 1,
                 useSessionPool: true,
                 proxyConfiguration,
-                requestHandler: async () => {},
+                requestHandler,
             });
 
             await expect(browserCrawler.run()).resolves.not.toThrow();
+            expect(requestHandler).toHaveBeenCalledTimes(requestList.length());
         });
 
         test('proxy rotation on error respects maxSessionRotations, calls failedRequestHandler', async () => {
@@ -884,7 +886,7 @@ describe('BrowserCrawler', () => {
 
             const spy = jest.spyOn((crawler as any).log, 'warning' as any).mockImplementation(() => {});
 
-            await expect(crawler.run([serverAddress])).rejects.toThrow();
+            await crawler.run([serverAddress]);
 
             expect(spy).toBeCalled();
             expect(spy.mock.calls[0][0]).toEqual(expect.stringContaining(proxyError));


### PR DESCRIPTION
Any request exceeding the `maxSessionRotations` limit currently kills the crawler. This was intended for early exit on too many hard proxy errors, but proved to be somewhat confusing for users using `retryOnBlocked` (any page that the crawler cannot access due to bot protection kills the run).

With this PR, the requests that cross the limit of `maxSessionRotations` now get processed with `failedRequestHandler`. Not sure if this is breaking (definitely might confuse a dev or two), but it's in line with how the crawlers worked before the `SessionError` update (so... it's actually reverting the hidden breaking change?)

Closes #2028