### PR TITLE
feat: remove side effect from the deprecated error context augmentation

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -1355,6 +1355,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
 
                 return error;
             },
+            configurable: true,
         });
 
         return context;


### PR DESCRIPTION
Following the trend of removing side-effects from the Crawlee codebase, this one looks pretty unintentional - the augmented context is passed to a handler, but the changes persist even after the handler is executed.

Fixes #2068 