### PR TITLE
fix: various helpers opening KVS now respect Configuration

### DIFF
--- a/packages/core/src/crawlers/statistics.ts
+++ b/packages/core/src/crawlers/statistics.ts
@@ -77,6 +77,11 @@ export class Statistics {
      */
     readonly requestRetryHistogram: number[] = [];
 
+    /**
+     * Contains the associated Configuration instance
+     */
+    private readonly config: Configuration;
+
     private keyValueStore?: KeyValueStore = undefined;
     private persistStateKey = `SDK_CRAWLER_STATISTICS_${this.id}`;
     private logIntervalMillis: number;
@@ -111,6 +116,7 @@ export class Statistics {
         this.keyValueStore = keyValueStore;
         this.listener = this.persistState.bind(this);
         this.events = config.getEventManager();
+        this.config = config;
 
         // initialize by "resetting"
         this.reset();
@@ -239,7 +245,7 @@ export class Statistics {
      * displaying the current state in predefined intervals
      */
     async startCapturing() {
-        this.keyValueStore ??= await KeyValueStore.open();
+        this.keyValueStore ??= await KeyValueStore.open(null, { config: this.config });
 
         await this._maybeLoadStatistics();
 

--- a/packages/core/src/storages/dataset.ts
+++ b/packages/core/src/storages/dataset.ts
@@ -301,7 +301,7 @@ export class Dataset<Data extends Dictionary = Dictionary> {
      * @param [contentType] Only JSON and CSV are supported currently, defaults to JSON.
      */
     async exportTo(key: string, options?: ExportOptions, contentType?: string): Promise<void> {
-        const kvStore = await KeyValueStore.open(options?.toKVS ?? null);
+        const kvStore = await KeyValueStore.open(options?.toKVS ?? null, { config: this.config });
         const items: Data[] = [];
 
         const fetchNextChunk = async (offset = 0): Promise<void> => {

--- a/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
+++ b/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
@@ -25,6 +25,7 @@ import { LruCache } from '@apify/datastructures';
 import log_ from '@apify/log';
 import type { Request } from '@crawlee/browser';
 import { validators, KeyValueStore, RequestState } from '@crawlee/browser';
+import { Configuration } from '@crawlee/core';
 import type { BatchAddRequestsResult } from '@crawlee/types';
 import type { CheerioRoot, Dictionary } from '@crawlee/utils';
 import * as cheerio from 'cheerio';
@@ -498,6 +499,12 @@ export interface SaveSnapshotOptions {
      * @default null
      */
     keyValueStoreName?: string | null;
+
+    /**
+     * Configuration of the crawler that will be used to save the snapshot.
+     * @default null
+     */
+    config?: Configuration | null;
 }
 
 /**
@@ -513,6 +520,7 @@ export async function saveSnapshot(page: Page, options: SaveSnapshotOptions = {}
         saveScreenshot: ow.optional.boolean,
         saveHtml: ow.optional.boolean,
         keyValueStoreName: ow.optional.string,
+        config: ow.optional.object,
     }));
 
     const {
@@ -521,10 +529,11 @@ export async function saveSnapshot(page: Page, options: SaveSnapshotOptions = {}
         saveScreenshot = true,
         saveHtml = true,
         keyValueStoreName,
+        config,
     } = options;
 
     try {
-        const store = await KeyValueStore.open(keyValueStoreName);
+        const store = await KeyValueStore.open(keyValueStoreName, { config: config ?? Configuration.getGlobalConfig() });
 
         if (saveScreenshot) {
             const screenshotName = `${key}.jpg`;
@@ -756,7 +765,7 @@ export function registerUtilsToContext(context: PlaywrightCrawlingContext): void
     context.blockRequests = (options?: BlockRequestsOptions) => blockRequests(context.page, options);
     context.parseWithCheerio = () => parseWithCheerio(context.page);
     context.infiniteScroll = (options?: InfiniteScrollOptions) => infiniteScroll(context.page, options);
-    context.saveSnapshot = (options?: SaveSnapshotOptions) => saveSnapshot(context.page, options);
+    context.saveSnapshot = (options?: SaveSnapshotOptions) => saveSnapshot(context.page, { ...options, config: context.crawler.config });
     context.enqueueLinksByClickingElements = (options: Omit<EnqueueLinksByClickingElementsOptions, 'page' | 'requestQueue'>) => enqueueLinksByClickingElements({
         ...options,
         page: context.page,

--- a/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
+++ b/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
@@ -24,8 +24,7 @@ import vm from 'vm';
 import { LruCache } from '@apify/datastructures';
 import log_ from '@apify/log';
 import type { Request } from '@crawlee/browser';
-import { validators, KeyValueStore, RequestState } from '@crawlee/browser';
-import { Configuration } from '@crawlee/core';
+import { validators, KeyValueStore, RequestState, Configuration } from '@crawlee/browser';
 import type { BatchAddRequestsResult } from '@crawlee/types';
 import type { CheerioRoot, Dictionary } from '@crawlee/utils';
 import * as cheerio from 'cheerio';
@@ -502,9 +501,9 @@ export interface SaveSnapshotOptions {
 
     /**
      * Configuration of the crawler that will be used to save the snapshot.
-     * @default null
+     * @default Configuration.getGlobalConfig()
      */
-    config?: Configuration | null;
+    config?: Configuration;
 }
 
 /**

--- a/packages/puppeteer-crawler/src/internals/utils/puppeteer_utils.ts
+++ b/packages/puppeteer-crawler/src/internals/utils/puppeteer_utils.ts
@@ -24,8 +24,7 @@ import vm from 'vm';
 import { LruCache } from '@apify/datastructures';
 import log_ from '@apify/log';
 import type { Request } from '@crawlee/browser';
-import { KeyValueStore, RequestState, validators } from '@crawlee/browser';
-import { Configuration } from '@crawlee/core';
+import { KeyValueStore, RequestState, validators, Configuration } from '@crawlee/browser';
 import type { Dictionary, BatchAddRequestsResult } from '@crawlee/types';
 import type { CheerioRoot } from '@crawlee/utils';
 import * as cheerio from 'cheerio';
@@ -634,9 +633,9 @@ export interface SaveSnapshotOptions {
 
     /**
      * Configuration of the crawler that will be used to save the snapshot.
-     * @default null
+     * @default Configuration.getGlobalConfig()
      */
-    config?: Configuration | null;
+    config?: Configuration;
 }
 
 /**


### PR DESCRIPTION
Various parts of Crawlee called `KVS.open()` which lead to possible shared state between multiple concurrent crawlers. This PR makes all those parts to open KVS only with the proper `Configuration` instance.