### PR TITLE
fix: misc outdated/broken example scripts

### DIFF
--- a/docs/examples/export_entire_dataset.mdx
+++ b/docs/examples/export_entire_dataset.mdx
@@ -7,7 +7,7 @@ import RunnableCodeBlock from '@site/src/components/RunnableCodeBlock';
 import ApiLink from '@site/src/components/ApiLink';
 import CrawlSource from '!!raw-loader!roa-loader!./export_entire_dataset.ts';
 
-This `Dataset` example uses the `exportToValue` function to export the entire default dataset to a single CSV file into a key-value store named "my-data".
+This `Dataset` example uses the `exportToValue` function to export the entire default dataset to a single CSV file into the default key-value store.
 
 <RunnableCodeBlock className="language-js" type="cheerio">
 	{CrawlSource}

--- a/docs/examples/export_entire_dataset.ts
+++ b/docs/examples/export_entire_dataset.ts
@@ -16,5 +16,5 @@ const data = [
 await Dataset.pushData(data);
 
 // Export the entirety of the dataset to a single file in
-// a key-value store named "my-data" under the key "OUTPUT"
-await Dataset.exportToCSV('OUTPUT', { toKVS: 'my-data' });
+// the default key-value store under the key "OUTPUT"
+await Dataset.exportToCSV('OUTPUT');

--- a/docs/examples/forms.ts
+++ b/docs/examples/forms.ts
@@ -18,15 +18,17 @@ await page.select('select#search_language', 'JavaScript');
 // Submit the form and wait for full load of next page
 console.log('Submit search form');
 await Promise.all([
-    page.waitForNavigation(),
+    page.waitForNavigation({ waitUntil: 'networkidle2' }),
     page.click('#adv_code_search button[type="submit"]'),
 ]);
 
 // Obtain and print list of search results
-const results = await page.$$eval('div.f4.text-normal a', (nodes) => nodes.map((node) => ({
-    url: node.href,
-    name: node.innerText,
-})));
+const results = await page.$$eval('[data-testid="results-list"] div.search-title > a',
+    (nodes) => nodes.map((node) => ({
+        url: node.href,
+        name: node.innerText,
+    })),
+);
 
 console.log('Results:', results);
 

--- a/docs/examples/map.ts
+++ b/docs/examples/map.ts
@@ -1,9 +1,28 @@
 import { Dataset, KeyValueStore } from 'crawlee';
 
-const dataset = await Dataset.open<{ headingCount: number }>();
+const dataset = await Dataset.open<{
+    url: string,
+    headingCount: number,
+}>();
 
-// calling map function and filtering through mapped items
+// Seeding the dataset with some data
+await dataset.pushData([
+    {
+        url: 'https://crawlee.dev/',
+        headingCount: 11,
+    },
+    {
+        url: 'https://crawlee.dev/storage',
+        headingCount: 8,
+    },
+    {
+        url: 'https://crawlee.dev/proxy',
+        headingCount: 4,
+    },
+]);
+
+// Calling map function and filtering through mapped items...
 const moreThan5headers = (await dataset.map((item) => item.headingCount)).filter((count) => count > 5);
 
-// saving result of map to default Key-value store
+// Saving the result of map to default key-value store...
 await KeyValueStore.setValue('pages_with_more_than_5_headers', moreThan5headers);

--- a/docs/examples/reduce.ts
+++ b/docs/examples/reduce.ts
@@ -1,6 +1,25 @@
 import { Dataset, KeyValueStore } from 'crawlee';
 
-const dataset = await Dataset.open();
+const dataset = await Dataset.open<{
+    url: string,
+    headingCount: number,
+}>();
+
+// Seeding the dataset with some data
+await dataset.pushData([
+    {
+        url: 'https://crawlee.dev/',
+        headingCount: 11,
+    },
+    {
+        url: 'https://crawlee.dev/storage',
+        headingCount: 8,
+    },
+    {
+        url: 'https://crawlee.dev/proxy',
+        headingCount: 4,
+    },
+]);
 
 // calling reduce function and using memo to calculate number of headers
 const pagesHeadingCount = await dataset.reduce((memo, value) => {

--- a/website/versioned_docs/version-3.5/examples/export_entire_dataset.mdx
+++ b/website/versioned_docs/version-3.5/examples/export_entire_dataset.mdx
@@ -7,7 +7,7 @@ import RunnableCodeBlock from '@site/src/components/RunnableCodeBlock';
 import ApiLink from '@site/src/components/ApiLink';
 import CrawlSource from '!!raw-loader!roa-loader!./export_entire_dataset.ts';
 
-This `Dataset` example uses the `exportToValue` function to export the entire default dataset to a single CSV file into a key-value store named "my-data".
+This `Dataset` example uses the `exportToValue` function to export the entire default dataset to a single CSV file into the default key-value store.
 
 <RunnableCodeBlock className="language-js" type="cheerio">
 	{CrawlSource}

--- a/website/versioned_docs/version-3.5/examples/export_entire_dataset.ts
+++ b/website/versioned_docs/version-3.5/examples/export_entire_dataset.ts
@@ -16,5 +16,5 @@ const data = [
 await Dataset.pushData(data);
 
 // Export the entirety of the dataset to a single file in
-// a key-value store named "my-data" under the key "OUTPUT"
-await Dataset.exportToCSV('OUTPUT', { toKVS: 'my-data' });
+// the default key-value store under the key "OUTPUT"
+await Dataset.exportToCSV('OUTPUT');

--- a/website/versioned_docs/version-3.5/examples/forms.ts
+++ b/website/versioned_docs/version-3.5/examples/forms.ts
@@ -18,15 +18,17 @@ await page.select('select#search_language', 'JavaScript');
 // Submit the form and wait for full load of next page
 console.log('Submit search form');
 await Promise.all([
-    page.waitForNavigation(),
+    page.waitForNavigation({ waitUntil: 'networkidle2' }),
     page.click('#adv_code_search button[type="submit"]'),
 ]);
 
 // Obtain and print list of search results
-const results = await page.$$eval('div.f4.text-normal a', (nodes) => nodes.map((node) => ({
-    url: node.href,
-    name: node.innerText,
-})));
+const results = await page.$$eval('[data-testid="results-list"] div.search-title > a',
+    (nodes) => nodes.map((node) => ({
+        url: node.href,
+        name: node.innerText,
+    })),
+);
 
 console.log('Results:', results);
 

--- a/website/versioned_docs/version-3.5/examples/map.ts
+++ b/website/versioned_docs/version-3.5/examples/map.ts
@@ -1,9 +1,28 @@
 import { Dataset, KeyValueStore } from 'crawlee';
 
-const dataset = await Dataset.open<{ headingCount: number }>();
+const dataset = await Dataset.open<{
+    url: string,
+    headingCount: number,
+}>();
 
-// calling map function and filtering through mapped items
+// Seeding the dataset with some data
+await dataset.pushData([
+    {
+        url: 'https://crawlee.dev/',
+        headingCount: 11,
+    },
+    {
+        url: 'https://crawlee.dev/storage',
+        headingCount: 8,
+    },
+    {
+        url: 'https://crawlee.dev/proxy',
+        headingCount: 4,
+    },
+]);
+
+// Calling map function and filtering through mapped items...
 const moreThan5headers = (await dataset.map((item) => item.headingCount)).filter((count) => count > 5);
 
-// saving result of map to default Key-value store
+// Saving the result of map to default key-value store...
 await KeyValueStore.setValue('pages_with_more_than_5_headers', moreThan5headers);

--- a/website/versioned_docs/version-3.5/examples/reduce.ts
+++ b/website/versioned_docs/version-3.5/examples/reduce.ts
@@ -1,6 +1,25 @@
 import { Dataset, KeyValueStore } from 'crawlee';
 
-const dataset = await Dataset.open();
+const dataset = await Dataset.open<{
+    url: string,
+    headingCount: number,
+}>();
+
+// Seeding the dataset with some data
+await dataset.pushData([
+    {
+        url: 'https://crawlee.dev/',
+        headingCount: 11,
+    },
+    {
+        url: 'https://crawlee.dev/storage',
+        headingCount: 8,
+    },
+    {
+        url: 'https://crawlee.dev/proxy',
+        headingCount: 4,
+    },
+]);
 
 // calling reduce function and using memo to calculate number of headers
 const pagesHeadingCount = await dataset.reduce((memo, value) => {


### PR DESCRIPTION
Does not fix the JSDOM example yet, as I didn't manage to scrape my example application (https://barjin.github.io/calculator-app) with JSDOM. Otherwise, it's fixing the mentioned issues in both `next` and `3.5`.