### PR TITLE
docs: add start:fast script for faster docs development

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -66,6 +66,7 @@ module.exports = {
                     path: '../docs',
                     sidebarPath: './sidebars.js',
                     rehypePlugins: [externalLinkProcessor],
+                    disableVersioning: !!process.env.CRAWLEE_DOCS_FAST,
                 },
                 theme: {
                     customCss: '/src/css/custom.css',

--- a/website/package.json
+++ b/website/package.json
@@ -2,6 +2,7 @@
     "scripts": {
         "examples": "docusaurus-examples",
         "start": "rimraf .docusaurus && docusaurus start",
+        "start:fast": "rimraf .docusaurus && CRAWLEE_DOCS_FAST=1 docusaurus start",
         "build": "rimraf .docusaurus && node --max_old_space_size=16000 node_modules/@docusaurus/core/bin/docusaurus.mjs build",
         "publish-gh-pages": "docusaurus-publish",
         "write-translations": "docusaurus write-translations",

--- a/website/roa-loader/index.js
+++ b/website/roa-loader/index.js
@@ -60,6 +60,9 @@ async function encodeAndSign(source) {
 }
 
 module.exports = async function (code) {
+    if (process.env.CRAWLEE_DOCS_FAST) {
+        return { code, hash: 'fast' };
+    }
     console.log(`Signing ${urlToRequest(this.resourcePath)}...`, { working, queue: queue.length });
     const hash = await encodeAndSign(code);
     return { code, hash };


### PR DESCRIPTION
Adds `start:fast` script for faster docs development - in the `fast` mode, the code hashing and docs versions are disabled.