### PR TITLE
feat: newUrlFunction receives Request and can return false

### DIFF
--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -467,19 +467,21 @@ export abstract class BrowserCrawler<
         if (this.proxyConfiguration && (useIncognitoPages || experimentalContainers)) {
             const { session } = crawlingContext;
 
-            const proxyInfo = await this.proxyConfiguration.newProxyInfo(session?.id);
+            const proxyInfo = await this.proxyConfiguration.newProxyInfo(session?.id, crawlingContext.request);
             crawlingContext.proxyInfo = proxyInfo;
 
-            newPageOptions.proxyUrl = proxyInfo.url;
+            if (proxyInfo) {
+                newPageOptions.proxyUrl = proxyInfo.url;
 
-            if (this.proxyConfiguration.isManInTheMiddle) {
-                /**
-                 * @see https://playwright.dev/docs/api/class-browser/#browser-new-context
-                 * @see https://github.com/puppeteer/puppeteer/blob/main/docs/api.md
-                 */
-                newPageOptions.pageOptions = {
-                    ignoreHTTPSErrors: true,
-                };
+                if (this.proxyConfiguration.isManInTheMiddle) {
+                    /**
+                     * @see https://playwright.dev/docs/api/class-browser/#browser-new-context
+                     * @see https://github.com/puppeteer/puppeteer/blob/main/docs/api.md
+                     */
+                    newPageOptions.pageOptions = {
+                        ignoreHTTPSErrors: true,
+                    };
+                }
             }
         }
 
@@ -664,16 +666,19 @@ export abstract class BrowserCrawler<
 
         if (this.proxyConfiguration) {
             const proxyInfo = await this.proxyConfiguration.newProxyInfo(launchContextExtends.session?.id);
-            launchContext.proxyUrl = proxyInfo.url;
-            launchContextExtends.proxyInfo = proxyInfo;
 
-            // Disable SSL verification for MITM proxies
-            if (this.proxyConfiguration.isManInTheMiddle) {
-                /**
-                 * @see https://playwright.dev/docs/api/class-browser/#browser-new-context
-                 * @see https://github.com/puppeteer/puppeteer/blob/main/docs/api.md
-                 */
-                (launchContext.launchOptions as Dictionary).ignoreHTTPSErrors = true;
+            if (proxyInfo) {
+                launchContext.proxyUrl = proxyInfo.url;
+                launchContextExtends.proxyInfo = proxyInfo;
+
+                // Disable SSL verification for MITM proxies
+                if (this.proxyConfiguration.isManInTheMiddle) {
+                    /**
+                     * @see https://playwright.dev/docs/api/class-browser/#browser-new-context
+                     * @see https://github.com/puppeteer/puppeteer/blob/main/docs/api.md
+                     */
+                    (launchContext.launchOptions as Dictionary).ignoreHTTPSErrors = true;
+                }
             }
         }
 

--- a/packages/browser-pool/src/playwright/playwright-controller.ts
+++ b/packages/browser-pool/src/playwright/playwright-controller.ts
@@ -55,7 +55,13 @@ export class PlaywrightController extends BrowserController<BrowserType, SafePar
         }
 
         try {
-            const page = await this.browser.newPage(contextOptions);
+            const page = await this.browser.newPage({
+                ...contextOptions,
+                proxy: contextOptions?.proxy ?? {
+                    server: 'http://disabled',
+                    bypass: '*,',
+                },
+            });
 
             page.once('close', async () => {
                 this.activePages--;

--- a/packages/core/src/proxy_configuration.ts
+++ b/packages/core/src/proxy_configuration.ts
@@ -2,8 +2,10 @@ import log from '@apify/log';
 import type { Dictionary } from '@crawlee/types';
 import ow from 'ow';
 
+import type { Request } from './request';
+
 export interface ProxyConfigurationFunction {
-    (sessionId: string | number): string | Promise<string>;
+    (sessionId: string | number, request?: Request): string | Promise<string | false>;
 }
 
 export interface ProxyConfigurationOptions {
@@ -15,8 +17,8 @@ export interface ProxyConfigurationOptions {
     proxyUrls?: string[];
 
     /**
-     * Custom function that allows you to generate the new proxy URL dynamically. It gets the `sessionId` as a parameter
-     * and should always return stringified proxy URL. Can be asynchronous.
+     * Custom function that allows you to generate the new proxy URL dynamically. It gets the `sessionId` and the current Request object as parameters
+     * and should return either stringified proxy URL or `false` if proxy shouldn't be used. Can be asynchronous.
      * This function is used to generate the URL when {@apilink ProxyConfiguration.newUrl} or {@apilink ProxyConfiguration.newProxyInfo} is called.
      */
     newUrlFunction?: ProxyConfigurationFunction;
@@ -173,9 +175,11 @@ export class ProxyConfiguration {
      *  The identifier must not be longer than 50 characters and include only the following: `0-9`, `a-z`, `A-Z`, `"."`, `"_"` and `"~"`.
      * @return Represents information about used proxy and its configuration.
      */
-    async newProxyInfo(sessionId?: string | number): Promise<ProxyInfo> {
+    async newProxyInfo(sessionId?: string | number, request?: Request): Promise<ProxyInfo | undefined> {
         if (typeof sessionId === 'number') sessionId = `${sessionId}`;
-        const url = await this.newUrl(sessionId);
+        const url = await this.newUrl(sessionId, request);
+
+        if (!url) return undefined;
 
         const { username, password, port, hostname } = new URL(url);
 
@@ -202,11 +206,11 @@ export class ProxyConfiguration {
      * @return A string with a proxy URL, including authentication credentials and port number.
      *  For example, `http://bob:password123@proxy.example.com:8000`
      */
-    async newUrl(sessionId?: string | number): Promise<string> {
+    async newUrl(sessionId?: string | number, request?: Request): Promise<string | false> {
         if (typeof sessionId === 'number') sessionId = `${sessionId}`;
 
         if (this.newUrlFunction) {
-            return this._callNewUrlFunction(sessionId)!;
+            return this._callNewUrlFunction(sessionId, request)!;
         }
 
         return this._handleCustomUrl(sessionId);
@@ -233,13 +237,15 @@ export class ProxyConfiguration {
     }
 
     /**
-     * Calls the custom newUrlFunction and checks format of its return value
+     * Calls the custom newUrlFunction and checks format of its return value.
      */
-    protected async _callNewUrlFunction(sessionId?: string) {
-        let proxyUrl: string;
+    protected async _callNewUrlFunction(sessionId?: string, request?: Request) {
+        let proxyUrl: string | false;
 
         try {
-            proxyUrl = await this.newUrlFunction!(sessionId!);
+            proxyUrl = await this.newUrlFunction!(sessionId!, request);
+            if (!proxyUrl) return false;
+
             new URL(proxyUrl); // eslint-disable-line no-new
             return proxyUrl;
         } catch (err) {

--- a/packages/core/src/proxy_configuration.ts
+++ b/packages/core/src/proxy_configuration.ts
@@ -4,9 +4,7 @@ import ow from 'ow';
 
 import type { Request } from './request';
 
-export interface ProxyConfigurationFunction {
-    (sessionId: string | number, request?: Request): string | Promise<string | false>;
-}
+export type ProxyConfigurationFunction = (sessionId: string | number, request?: Request) => string | Promise<string | false>;
 
 export interface ProxyConfigurationOptions {
     /**
@@ -19,7 +17,11 @@ export interface ProxyConfigurationOptions {
     /**
      * Custom function that allows you to generate the new proxy URL dynamically. It gets the `sessionId` and the current Request object as parameters
      * and should return either stringified proxy URL or `false` if proxy shouldn't be used. Can be asynchronous.
+     *
      * This function is used to generate the URL when {@apilink ProxyConfiguration.newUrl} or {@apilink ProxyConfiguration.newProxyInfo} is called.
+     *
+     * **Note:**
+     *  To use the request-specific proxy with Playwright or PuppeteerCrawler, you need to use it with the `launchContext.useIncognitoPages: true` option.
      */
     newUrlFunction?: ProxyConfigurationFunction;
 }

--- a/packages/core/src/proxy_configuration.ts
+++ b/packages/core/src/proxy_configuration.ts
@@ -4,7 +4,8 @@ import ow from 'ow';
 
 import type { Request } from './request';
 
-export type ProxyConfigurationFunction = (sessionId: string | number, request?: Request) => string | Promise<string | false>;
+type NewUrlRetVal = string | undefined | null;
+export type ProxyConfigurationFunction = (sessionId: string | number, request?: Request) => Promise<NewUrlRetVal> | NewUrlRetVal;
 
 export interface ProxyConfigurationOptions {
     /**
@@ -16,7 +17,7 @@ export interface ProxyConfigurationOptions {
 
     /**
      * Custom function that allows you to generate the new proxy URL dynamically. It gets the `sessionId` and the current Request object as parameters
-     * and should return either stringified proxy URL or `false` if proxy shouldn't be used. Can be asynchronous.
+     * and should return either stringified proxy URL or `null` if proxy shouldn't be used. Can be asynchronous.
      *
      * This function is used to generate the URL when {@apilink ProxyConfiguration.newUrl} or {@apilink ProxyConfiguration.newProxyInfo} is called.
      *
@@ -242,7 +243,7 @@ export class ProxyConfiguration {
      * Calls the custom newUrlFunction and checks format of its return value.
      */
     protected async _callNewUrlFunction(sessionId?: string, request?: Request) {
-        let proxyUrl: string | false;
+        let proxyUrl: NewUrlRetVal;
 
         try {
             proxyUrl = await this.newUrlFunction!(sessionId!, request);

--- a/packages/core/src/storages/request_list.ts
+++ b/packages/core/src/storages/request_list.ts
@@ -677,7 +677,11 @@ export class RequestList {
         // Download remote resource and parse URLs.
         let urlsArr;
         try {
-            urlsArr = await this._downloadListOfUrls({ url: requestsFromUrl, urlRegExp: regex, proxyUrl: await this.proxyConfiguration?.newUrl() });
+            urlsArr = await this._downloadListOfUrls({
+                url: requestsFromUrl,
+                urlRegExp: regex,
+                proxyUrl: (await this.proxyConfiguration?.newUrl() || undefined),
+            });
         } catch (err) {
             throw new Error(`Cannot fetch a request list from ${requestsFromUrl}: ${err}`);
         }

--- a/packages/core/src/storages/request_provider.ts
+++ b/packages/core/src/storages/request_provider.ts
@@ -558,7 +558,11 @@ export abstract class RequestProvider implements IStorage {
         // Download remote resource and parse URLs.
         let urlsArr;
         try {
-            urlsArr = await this._downloadListOfUrls({ url: requestsFromUrl, urlRegExp: regex, proxyUrl: await this.proxyConfiguration?.newUrl() });
+            urlsArr = await this._downloadListOfUrls({
+                url: requestsFromUrl,
+                urlRegExp: regex,
+                proxyUrl: await this.proxyConfiguration?.newUrl() || undefined,
+            });
         } catch (err) {
             throw new Error(`Cannot fetch a request list from ${requestsFromUrl}: ${err}`);
         }

--- a/packages/http-crawler/src/internals/http-crawler.ts
+++ b/packages/http-crawler/src/internals/http-crawler.ts
@@ -453,7 +453,7 @@ export class HttpCrawler<Context extends InternalHttpCrawlingContext<any, any, H
 
         if (this.proxyConfiguration) {
             const sessionId = session ? session.id : undefined;
-            crawlingContext.proxyInfo = await this.proxyConfiguration.newProxyInfo(sessionId);
+            crawlingContext.proxyInfo = await this.proxyConfiguration.newProxyInfo(sessionId, crawlingContext.request);
         }
         if (!request.skipNavigation) {
             await this._handleNavigation(crawlingContext);

--- a/test/core/crawlers/browser_crawler.test.ts
+++ b/test/core/crawlers/browser_crawler.test.ts
@@ -895,7 +895,7 @@ describe('BrowserCrawler', () => {
         test('newUrlFunction works as expected', async () => {
             const proxyConfiguration = new ProxyConfiguration({
                 newUrlFunction: async (sessionId, request) => {
-                    if (request?.url.includes('noproxy')) return false;
+                    if (request?.url.includes('noproxy')) return null;
                     return 'http://localhost:1234';
                 },
             });

--- a/test/core/crawlers/cheerio_crawler.test.ts
+++ b/test/core/crawlers/cheerio_crawler.test.ts
@@ -713,7 +713,7 @@ describe('CheerioCrawler', () => {
             const proxyUrl = serverAddress;
             const proxyConfiguration = new ProxyConfiguration({
                 newUrlFunction: async (sessionId, request) => {
-                    if (request.url.includes('12') || request.url.includes('33')) return false;
+                    if (request.url.includes('12') || request.url.includes('33')) return null;
                     return proxyUrl;
                 },
             });

--- a/test/core/crawlers/cheerio_crawler.test.ts
+++ b/test/core/crawlers/cheerio_crawler.test.ts
@@ -1150,7 +1150,7 @@ describe('CheerioCrawler', () => {
                 // localhost proxy causes proxy errors, session rotations and finally throws, but we don't care
             }
 
-            expect(newUrlSpy).toBeCalledWith(usedSession.id);
+            expect(newUrlSpy).toBeCalledWith(usedSession.id, expect.anything());
         });
     });
 

--- a/test/core/crawlers/playwright_crawler.test.ts
+++ b/test/core/crawlers/playwright_crawler.test.ts
@@ -182,7 +182,7 @@ describe('PlaywrightCrawler', () => {
             proxyConfiguration: new ProxyConfiguration({
                 newUrlFunction: async (_, request) => {
                     if (!request?.url.includes('noproxy')) return `http://127.0.0.5:${customProxyServer.port}`;
-                    return false;
+                    return null;
                 },
             }),
             requestHandler: async ({ request, response }) => {

--- a/test/core/crawlers/puppeteer_crawler.test.ts
+++ b/test/core/crawlers/puppeteer_crawler.test.ts
@@ -504,7 +504,7 @@ describe('PuppeteerCrawler', () => {
                 proxyConfiguration: new ProxyConfiguration({
                     newUrlFunction: async (_, request) => {
                         if (!request?.url.includes('noproxy')) return `http://127.0.0.5:${customProxyServer.port}`;
-                        return false;
+                        return null;
                     },
                 }),
                 requestHandler: async ({ request, response }) => {

--- a/test/core/create-proxy-server.ts
+++ b/test/core/create-proxy-server.ts
@@ -1,4 +1,4 @@
-import { Server as ProxyChainServer } from 'proxy-chain';
+import { Server as ProxyChainServer, type CustomResponse } from 'proxy-chain';
 
 // --proxy-bypass-list=<-loopback> for launching Chrome
 export const createProxyServer = (localAddress: string, username: string, password: string) => {
@@ -8,6 +8,18 @@ export const createProxyServer = (localAddress: string, username: string, passwo
             return {
                 localAddress,
                 requestAuthentication: input.username !== username || input.password !== password,
+            };
+        },
+    });
+};
+
+export const createProxyServerWithResponse = (localAddress: string, response: CustomResponse): ProxyChainServer => {
+    return new ProxyChainServer({
+        port: 0,
+        prepareRequestFunction: () => {
+            return {
+                localAddress,
+                customResponseFunction: () => response,
             };
         },
     });


### PR DESCRIPTION
The user-supplied `newUrlFunction` now accepts the current `Request` object as an optional parameter and can return `false` in case the user wants this request to be processed without proxy.

Closes #2065 