### PR TITLE
fix(types): make return type of RequestProvider.open and RequestQueue(v2).open strict and accurate

### DIFF
--- a/packages/core/src/storages/request_provider.ts
+++ b/packages/core/src/storages/request_provider.ts
@@ -614,7 +614,7 @@ export abstract class RequestProvider implements IStorage {
      *   the function returns the default request queue associated with the crawler run.
      * @param [options] Open Request Queue options.
      */
-    static async open(queueIdOrName?: string | null, options: StorageManagerOptions = {}): Promise<BuiltRequestProvider> {
+    static async open(queueIdOrName?: string | null, options: StorageManagerOptions = {}): Promise<RequestProvider> {
         ow(queueIdOrName, ow.optional.any(ow.string, ow.null));
         ow(options, ow.object.exactShape({
             config: ow.optional.object.instanceOf(Configuration),

--- a/packages/core/src/storages/request_queue.ts
+++ b/packages/core/src/storages/request_queue.ts
@@ -323,4 +323,8 @@ export class RequestQueue extends RequestProvider {
         super._reset();
         this.lastActivity = new Date();
     }
+
+    static override open(...args: Parameters<typeof RequestProvider.open>): Promise<RequestQueue> {
+        return super.open(...args) as Promise<RequestQueue>;
+    }
 }

--- a/packages/core/src/storages/request_queue_v2.ts
+++ b/packages/core/src/storages/request_queue_v2.ts
@@ -291,6 +291,10 @@ class RequestQueue extends RequestProvider {
             }
         }
     }
+
+    static override open(...args: Parameters<typeof RequestProvider.open>): Promise<RequestQueue> {
+        return super.open(...args) as Promise<RequestQueue>;
+    }
 }
 
 export { RequestQueue as RequestQueueV2 };


### PR DESCRIPTION
Resolves compile errors like

```
2023-09-25T10:09:25.017Z src/main.ts:37:5 - error TS2739: Type 'BuiltRequestProvider' is missing the following properties from type 'RequestQueue': _listHeadAndLockPromise, _listHeadAndLock, getOrHydrateRequest, _prolongRequestLock, _clearPossibleLocks
2023-09-25T10:09:25.018Z 37     requestQueue = await RequestQueueV2.open();
2023-09-25T10:09:25.019Z        ~~~~~~~~~~~~
2023-09-25T10:09:25.020Z src/main.ts:60:5 - error TS2322: Type 'BuiltRequestProvider' is not assignable to type 'RequestQueue'.
2023-09-25T10:09:25.021Z 60     requestQueue = await RequestQueueV2.open(requestQueueId);
2023-09-25T10:09:25.023Z        ~~~~~~~~~~~~
```