### PR TITLE
fix: add warning when we detect use of RL and RQ, but RQ is not provided explicitly

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -902,6 +902,11 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
     }
 
     async getRequestQueue() {
+        if (!this.requestQueue && this.requestList) {
+            // eslint-disable-next-line max-len
+            this.log.warningOnce('When using RequestList and RequestQueue at the same time, you should instantiate both explicitly and provide them in the crawler options, to ensure correctly handled restarts of the crawler.');
+        }
+
         this.requestQueue ??= await this._getRequestQueue();
 
         return this.requestQueue!;

--- a/test/core/crawlers/browser_crawler.test.ts
+++ b/test/core/crawlers/browser_crawler.test.ts
@@ -889,7 +889,9 @@ describe('BrowserCrawler', () => {
             await crawler.run([serverAddress]);
 
             expect(spy).toBeCalled();
-            expect(spy.mock.calls[0][0]).toEqual(expect.stringContaining(proxyError));
+            // eslint-disable-next-line max-len
+            expect(spy.mock.calls[0][0]).toEqual('When using RequestList and RequestQueue at the same time, you should instantiate both explicitly and provide them in the crawler options, to ensure correctly handled restarts of the crawler.');
+            expect(spy.mock.calls[1][0]).toEqual(expect.stringContaining(proxyError));
         });
     });
 


### PR DESCRIPTION
Closes #1773