### PR TITLE
fix: RQ request count is consistent after migration

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -783,7 +783,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
                 // eslint-disable-next-line max-len
                 message = `Experiencing problems, ${this.stats.state.requestsFailed - previousState.requestsFailed || this.stats.state.requestsFailed} failed requests in the past ${this.statusMessageLoggingInterval} seconds.`;
             } else {
-                const total = this.requestQueue?.assumedTotalCount || this.requestList?.length();
+                const total = this.requestQueue?.getTotalCount() || this.requestList?.length();
                 message = `Crawled ${this.stats.state.requestsFinished}${total ? `/${total}` : ''} pages, ${this.stats.state.requestsFailed} failed requests.`;
             }
 

--- a/packages/core/src/storages/request_provider.ts
+++ b/packages/core/src/storages/request_provider.ts
@@ -54,12 +54,11 @@ export abstract class RequestProvider implements IStorage {
     constructor(options: InternalRequestProviderOptions, readonly config = Configuration.getGlobalConfig()) {
         this.id = options.id;
         this.name = options.name;
-        const client = options.client.requestQueue(this.id, {
+        this.client = options.client.requestQueue(this.id, {
             clientKey: this.clientKey,
             timeoutSecs: this.timeoutSecs,
         });
 
-        this.client = client;
         this.proxyConfiguration = options.proxyConfiguration;
 
         this.requestCache = new LruCache({ maxLength: options.requestCacheMaxSize });

--- a/packages/core/src/storages/request_provider.ts
+++ b/packages/core/src/storages/request_provider.ts
@@ -71,10 +71,6 @@ export abstract class RequestProvider implements IStorage {
         eventManager.on(EventType.MIGRATING, async () => {
             this.queuePausedForMigration = true;
         });
-
-        (async () => {
-            this.initialCount = (await client.get())?.totalRequestCount ?? 0;
-        })().catch(() => {});
     }
 
     /**
@@ -646,6 +642,9 @@ export abstract class RequestProvider implements IStorage {
         const manager = StorageManager.getManager(this as typeof BuiltRequestProvider, options.config);
         const queue = await manager.openStorage(queueIdOrName, options.storageClient);
         queue.proxyConfiguration = options.proxyConfiguration;
+
+        // eslint-disable-next-line dot-notation
+        queue['initialCount'] = (await queue.client.get())?.totalRequestCount ?? 0;
 
         return queue;
     }


### PR DESCRIPTION
Until now, the `assumedTotalCount` got reset on a migration (it was a purely local counter). This causes #1855, which is not too bad, but manifests at a very prominent place in the console. 

I'm not *way too confident* about the async iife in the constructor, but I think it should work just fine, as the new `totalCount` property is purely approximative (and is marked as such it the comment).
Closes #1855 