### PR TITLE
fix: e2e cheerio-throw-on-ssl-errors

### DIFF
--- a/test/e2e/cheerio-throw-on-ssl-errors/test.mjs
+++ b/test/e2e/cheerio-throw-on-ssl-errors/test.mjs
@@ -7,5 +7,5 @@ const { stats, datasetItems } = await runActor(testActorDirname);
 
 await expect(stats.requestsFinished > 5 && stats.requestsFinished < 10, 'All requests finished');
 await expect(stats.requestsFailed > 20 && stats.requestsFailed < 30, 'Number of failed requests');
-await expect(datasetItems.length > 5 && datasetItems.length < 10, 'Number of dataset items');
+await expect(datasetItems.length >= 5 && datasetItems.length < 10, 'Number of dataset items');
 await expect(validateDataset(datasetItems, ['url', 'title']), 'Dataset items validation');


### PR DESCRIPTION
Ever since Oct 10, the Cheerio SSL errors test has been failing in Crawlee. This is because before, Crawlee managed to process the https://no-sct.badssl.com/ website, but now it doesn't (failing with various errors like "expired certificate" and "unable to verify the first certificate"). This error now happens even on the last-known-working commit built with `yarn --immutable`.

Inspired by [the fix from the JS SDK](https://github.com/apify/apify-sdk-js/pull/247/) :) Perhaps @vladfrangu did you learn something about the error when looking into it?