### PR TITLE
feat(core): add `crawler.exportData()` helper

### DIFF
--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -54,12 +54,18 @@ jobs:
 
             -   name: Install Dependencies
                 run: yarn
+                env:
+                    YARN_IGNORE_NODE: 1
 
             -   name: Build
                 run: yarn ci:build
+                env:
+                    YARN_IGNORE_NODE: 1
 
             -   name: Tests
                 run: yarn test
+                env:
+                    YARN_IGNORE_NODE: 1
 
     docs:
         name: Docs build
@@ -91,6 +97,8 @@ jobs:
 
             -   name: Install Dependencies
                 run: yarn
+                env:
+                    YARN_IGNORE_NODE: 1
 
             -   name: Build & deploy docs
                 run: |
@@ -99,6 +107,7 @@ jobs:
                     yarn build
                 env:
                     APIFY_SIGNING_TOKEN: ${{ secrets.APIFY_SIGNING_TOKEN }}
+                    YARN_IGNORE_NODE: 1
 
     lint:
         name: Lint
@@ -130,9 +139,13 @@ jobs:
 
             -   name: Install Dependencies
                 run: yarn
+                env:
+                    YARN_IGNORE_NODE: 1
 
             -   name: ESLint
                 run: yarn lint
+                env:
+                    YARN_IGNORE_NODE: 1
 
     release_next:
         name: Release @next
@@ -166,9 +179,13 @@ jobs:
 
             -   name: Install Dependencies
                 run: yarn
+                env:
+                    YARN_IGNORE_NODE: 1
 
             -   name: Build
                 run: yarn ci:build
+                env:
+                    YARN_IGNORE_NODE: 1
 
             -   name: Generate changed packages list
                 id: changed-packages
@@ -194,6 +211,7 @@ jobs:
                     NPM_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_NPM_TOKEN }}
                     GIT_USER: "noreply@apify.com:${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}"
                     GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
+                    YARN_IGNORE_NODE: 1
 
             -   name: Collect versions for Docker images
                 id: versions

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -6,6 +6,9 @@ on:
     pull_request:
         branches: [ master ]
 
+env:
+    YARN_IGNORE_NODE: 1
+
 jobs:
     # `yarn install` is done in a separate job and cached to speed up the following jobs.
     build_and_test:
@@ -54,18 +57,12 @@ jobs:
 
             -   name: Install Dependencies
                 run: yarn
-                env:
-                    YARN_IGNORE_NODE: 1
 
             -   name: Build
                 run: yarn ci:build
-                env:
-                    YARN_IGNORE_NODE: 1
 
             -   name: Tests
                 run: yarn test
-                env:
-                    YARN_IGNORE_NODE: 1
 
     docs:
         name: Docs build
@@ -97,8 +94,6 @@ jobs:
 
             -   name: Install Dependencies
                 run: yarn
-                env:
-                    YARN_IGNORE_NODE: 1
 
             -   name: Build & deploy docs
                 run: |
@@ -107,7 +102,6 @@ jobs:
                     yarn build
                 env:
                     APIFY_SIGNING_TOKEN: ${{ secrets.APIFY_SIGNING_TOKEN }}
-                    YARN_IGNORE_NODE: 1
 
     lint:
         name: Lint
@@ -139,13 +133,9 @@ jobs:
 
             -   name: Install Dependencies
                 run: yarn
-                env:
-                    YARN_IGNORE_NODE: 1
 
             -   name: ESLint
                 run: yarn lint
-                env:
-                    YARN_IGNORE_NODE: 1
 
     release_next:
         name: Release @next
@@ -179,13 +169,9 @@ jobs:
 
             -   name: Install Dependencies
                 run: yarn
-                env:
-                    YARN_IGNORE_NODE: 1
 
             -   name: Build
                 run: yarn ci:build
-                env:
-                    YARN_IGNORE_NODE: 1
 
             -   name: Generate changed packages list
                 id: changed-packages
@@ -211,7 +197,6 @@ jobs:
                     NPM_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_NPM_TOKEN }}
                     GIT_USER: "noreply@apify.com:${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}"
                     GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
-                    YARN_IGNORE_NODE: 1
 
             -   name: Collect versions for Docker images
                 id: versions

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -11,6 +11,7 @@ import type {
     CrawlingContext,
     EnqueueLinksOptions,
     EventManager,
+    DatasetExportOptions,
     FinalStatistics,
     GetUserDataFromRequest,
     ProxyInfo,
@@ -962,7 +963,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
      * Retrieves all the data from the default crawler {@apilink Dataset} and exports them to the specified format.
      * Supported formats are currently 'json' and 'csv', and will be inferred from the `path` automatically.
      */
-    async exportData<Data>(path: string, format?: 'json' | 'csv'): Promise<Data[]> {
+    async exportData<Data>(path: string, format?: 'json' | 'csv', options?: DatasetExportOptions): Promise<Data[]> {
         const supportedFormats = ['json', 'csv'];
 
         if (!format && path.match(/\.(json|csv)$/i)) {
@@ -978,7 +979,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
         }
 
         const dataset = await this.getDataset();
-        const items = await dataset.exportTo('', {}, 'object');
+        const items = await dataset.export(options);
 
         if (format === 'csv') {
             const value = stringify([

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -938,10 +938,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
      * Pushes data to the default crawler {@apilink Dataset} by calling {@apilink Dataset.pushData}.
      */
     async pushData(...args: Parameters<Dataset['pushData']>): Promise<void> {
-        if (this.dataset == null) {
-            this.dataset = await Dataset.open(undefined, { config: this.config });
-        }
-
+        this.dataset ??= await Dataset.open(undefined, { config: this.config });
         return this.dataset.pushData(...args);
     }
 

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -946,6 +946,10 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
      * Retrieves the default crawler {@apilink Dataset}.
      */
     getDataset(): Dataset {
+        if (!this.dataset) {
+            throw new Error(`This crawler instance does not have a default dataset yet, did you call \`crawler.run()\` first?`);
+        }
+
         return this.dataset;
     }
 

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -1,3 +1,5 @@
+import { dirname } from 'node:path';
+
 import type { Log } from '@apify/log';
 import defaultLog, { LogLevel } from '@apify/log';
 import { addTimeoutToPromise, TimeoutError, tryCancel } from '@apify/timeout';
@@ -47,7 +49,7 @@ import {
 import type { Awaitable, BatchAddRequestsResult, Dictionary, SetStatusMessageOptions } from '@crawlee/types';
 import { ROTATE_PROXY_ERRORS } from '@crawlee/utils';
 import { stringify } from 'csv-stringify/sync';
-import { writeFile, writeJSON } from 'fs-extra';
+import { ensureDir, writeFile, writeJSON } from 'fs-extra';
 import type { Method, OptionsInit } from 'got-scraping';
 import { gotScraping } from 'got-scraping';
 import ow, { ArgumentError } from 'ow';
@@ -986,11 +988,13 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
                 Object.keys(items[0]),
                 ...items.map((item) => Object.values(item)),
             ]);
+            await ensureDir(dirname(path));
             await writeFile(path, value);
             this.log.info(`Export to ${path} finished!`);
         }
 
         if (format === 'json') {
+            await ensureDir(dirname(path));
             await writeJSON(path, items, { spaces: 4 });
             this.log.info(`Export to ${path} finished!`);
         }

--- a/packages/core/src/storages/dataset.ts
+++ b/packages/core/src/storages/dataset.ts
@@ -139,6 +139,8 @@ export interface DatasetDataOptions {
     skipEmpty?: boolean;
 }
 
+export interface DatasetExportOptions extends Omit<DatasetDataOptions, 'offset' | 'limit'> {}
+
 export interface DatasetIteratorOptions extends Omit<DatasetDataOptions, 'offset' | 'limit' | 'clean' | 'skipHidden' | 'skipEmpty'> {
     /** @internal */
     offset?: number;
@@ -162,7 +164,7 @@ export interface DatasetIteratorOptions extends Omit<DatasetDataOptions, 'offset
     format?: string;
 }
 
-export interface ExportOptions {
+export interface DatasetExportToOptions extends DatasetExportOptions {
     fromDataset?: string;
     toKVS?: string;
 }
@@ -294,19 +296,15 @@ export class Dataset<Data extends Dictionary = Dictionary> {
     }
 
     /**
-     * Save the entirety of the dataset's contents into one file within a key-value store.
-     *
-     * @param key The name of the value to save the data in.
-     * @param [options] An optional options object where you can provide the dataset and target KVS name.
-     * @param [contentType] Only JSON and CSV are supported currently, defaults to JSON.
+     * Returns all the data from the dataset. This will iterate through the whole dataset
+     * via the `listItems()` client method, which gives you only paginated results.
      */
-    async exportTo(key: string, options?: ExportOptions, contentType?: string): Promise<Data[]> {
-        const kvStore = await KeyValueStore.open(options?.toKVS ?? null, { config: this.config });
+    async export(options: DatasetExportOptions = {}): Promise<Data[]> {
         const items: Data[] = [];
 
         const fetchNextChunk = async (offset = 0): Promise<void> => {
             const limit = 1000;
-            const value = await this.client.listItems({ offset, limit });
+            const value = await this.client.listItems({ offset, limit, ...options });
 
             if (value.count === 0) {
                 return;
@@ -320,6 +318,20 @@ export class Dataset<Data extends Dictionary = Dictionary> {
         };
 
         await fetchNextChunk();
+
+        return items;
+    }
+
+    /**
+     * Save the entirety of the dataset's contents into one file within a key-value store.
+     *
+     * @param key The name of the value to save the data in.
+     * @param [options] An optional options object where you can provide the dataset and target KVS name.
+     * @param [contentType] Only JSON and CSV are supported currently, defaults to JSON.
+     */
+    async exportTo(key: string, options?: DatasetExportToOptions, contentType?: string): Promise<Data[]> {
+        const kvStore = await KeyValueStore.open(options?.toKVS ?? null, { config: this.config });
+        const items = await this.export(options);
 
         if (contentType === 'text/csv') {
             const value = stringify([
@@ -335,9 +347,7 @@ export class Dataset<Data extends Dictionary = Dictionary> {
             return items;
         }
 
-        if (contentType !== 'object') {
-            throw new Error(`Unsupported content type: ${contentType}`);
-        }
+        throw new Error(`Unsupported content type: ${contentType}`);
 
         return items;
     }
@@ -348,7 +358,7 @@ export class Dataset<Data extends Dictionary = Dictionary> {
      * @param key The name of the value to save the data in.
      * @param [options] An optional options object where you can provide the target KVS name.
      */
-    async exportToJSON(key: string, options?: Omit<ExportOptions, 'fromDataset'>) {
+    async exportToJSON(key: string, options?: Omit<DatasetExportToOptions, 'fromDataset'>) {
         await this.exportTo(key, options, 'application/json');
     }
 
@@ -358,7 +368,7 @@ export class Dataset<Data extends Dictionary = Dictionary> {
      * @param key The name of the value to save the data in.
      * @param [options] An optional options object where you can provide the target KVS name.
      */
-    async exportToCSV(key: string, options?: Omit<ExportOptions, 'fromDataset'>) {
+    async exportToCSV(key: string, options?: Omit<DatasetExportToOptions, 'fromDataset'>) {
         await this.exportTo(key, options, 'text/csv');
     }
 
@@ -368,7 +378,7 @@ export class Dataset<Data extends Dictionary = Dictionary> {
      * @param key The name of the value to save the data in.
      * @param [options] An optional options object where you can provide the dataset and target KVS name.
      */
-    static async exportToJSON(key: string, options?: ExportOptions) {
+    static async exportToJSON(key: string, options?: DatasetExportToOptions) {
         const dataset = await this.open(options?.fromDataset);
         await dataset.exportToJSON(key, options);
     }
@@ -379,7 +389,7 @@ export class Dataset<Data extends Dictionary = Dictionary> {
      * @param key The name of the value to save the data in.
      * @param [options] An optional options object where you can provide the dataset and target KVS name.
      */
-    static async exportToCSV(key: string, options?: ExportOptions) {
+    static async exportToCSV(key: string, options?: DatasetExportToOptions) {
         const dataset = await this.open(options?.fromDataset);
         await dataset.exportToCSV(key, options);
     }

--- a/packages/core/src/storages/dataset.ts
+++ b/packages/core/src/storages/dataset.ts
@@ -300,7 +300,7 @@ export class Dataset<Data extends Dictionary = Dictionary> {
      * @param [options] An optional options object where you can provide the dataset and target KVS name.
      * @param [contentType] Only JSON and CSV are supported currently, defaults to JSON.
      */
-    async exportTo(key: string, options?: ExportOptions, contentType?: string): Promise<void> {
+    async exportTo(key: string, options?: ExportOptions, contentType?: string): Promise<Data[]> {
         const kvStore = await KeyValueStore.open(options?.toKVS ?? null, { config: this.config });
         const items: Data[] = [];
 
@@ -326,14 +326,20 @@ export class Dataset<Data extends Dictionary = Dictionary> {
                 Object.keys(items[0]),
                 ...items.map((item) => Object.values(item)),
             ]);
-            return kvStore.setValue(key, value, { contentType });
+            await kvStore.setValue(key, value, { contentType });
+            return items;
         }
 
         if (contentType === 'application/json') {
-            return kvStore.setValue(key, items);
+            await kvStore.setValue(key, items);
+            return items;
         }
 
-        throw new Error(`Unsupported content type: ${contentType}`);
+        if (contentType !== 'object') {
+            throw new Error(`Unsupported content type: ${contentType}`);
+        }
+
+        return items;
     }
 
     /**

--- a/test/core/crawlers/basic_crawler.test.ts
+++ b/test/core/crawlers/basic_crawler.test.ts
@@ -1389,13 +1389,9 @@ describe('BasicCrawler', () => {
         const payload: Dictionary[] = [{ foo: 'bar', baz: 123 }];
         const getPayload: (id: string) => Dictionary[] = (id) => [{ foo: id }];
 
-        const tmpDir: string = `${__dirname}/tmp`;
+        const tmpDir: string = `${__dirname}/tmp/foo/bar`;
 
         beforeAll(async () => {
-            await mkdir(tmpDir);
-        });
-
-        afterAll(async () => {
             await rm(tmpDir, { recursive: true, force: true });
         });
 

--- a/test/core/crawlers/basic_crawler.test.ts
+++ b/test/core/crawlers/basic_crawler.test.ts
@@ -2,6 +2,7 @@ import type { Server } from 'http';
 import http from 'http';
 import type { AddressInfo } from 'net';
 import { readFile, rm } from 'node:fs/promises';
+import { join } from 'path';
 
 import log from '@apify/log';
 import type {
@@ -1383,9 +1384,11 @@ describe('BasicCrawler', () => {
         });
     });
 
-    describe('Dataset helpers, crawler paralellism', () => {
+    describe.only('Dataset helpers, crawler paralellism', () => {
         const payload: Dictionary[] = [{ foo: 'bar', baz: 123 }];
         const getPayload: (id: string) => Dictionary[] = (id) => [{ foo: id }];
+
+        const rootPath = join(__dirname, '..', '..', 'tmp');
 
         test('should expose default Dataset methods', async () => {
             const crawler = new BasicCrawler();
@@ -1404,14 +1407,12 @@ describe('BasicCrawler', () => {
             await crawler.pushData(row);
             await crawler.pushData(row);
 
-            const root = process.cwd();
+            await crawler.exportData(`${rootPath}/result.csv`);
+            await crawler.exportData(`${rootPath}/result.json`);
 
-            await crawler.exportData(`${root}/storage/result.csv`);
-            await crawler.exportData(`${root}/storage/result.json`);
-
-            const csv = await readFile(`${root}/storage/result.csv`);
+            const csv = await readFile(`${rootPath}/result.csv`);
             expect(csv.toString()).toBe('foo,baz\nbar,123\nbar,123\nbar,123\n');
-            const json = await readFile(`${root}/storage/result.json`);
+            const json = await readFile(`${rootPath}/result.json`);
             expect(json.toString()).toBe('[\n'
                 + '    {\n'
                 + '        "foo": "bar",\n'
@@ -1427,8 +1428,8 @@ describe('BasicCrawler', () => {
                 + '    }\n'
                 + ']\n');
 
-            await rm(`${root}/storage/result.csv`);
-            await rm(`${root}/storage/result.json`);
+            await rm(`${rootPath}/result.csv`);
+            await rm(`${rootPath}/result.json`);
         });
 
         test('should expose pushData helper', async () => {

--- a/test/core/crawlers/basic_crawler.test.ts
+++ b/test/core/crawlers/basic_crawler.test.ts
@@ -1385,7 +1385,7 @@ describe('BasicCrawler', () => {
         });
     });
 
-    describe.only('Dataset helpers, crawler paralellism', () => {
+    describe('Dataset helpers, crawler paralellism', () => {
         const payload: Dictionary[] = [{ foo: 'bar', baz: 123 }];
         const getPayload: (id: string) => Dictionary[] = (id) => [{ foo: id }];
 

--- a/test/core/crawlers/basic_crawler.test.ts
+++ b/test/core/crawlers/basic_crawler.test.ts
@@ -1,3 +1,4 @@
+import { mkdir, mkdtemp } from 'fs/promises';
 import type { Server } from 'http';
 import http from 'http';
 import type { AddressInfo } from 'net';
@@ -1388,7 +1389,15 @@ describe('BasicCrawler', () => {
         const payload: Dictionary[] = [{ foo: 'bar', baz: 123 }];
         const getPayload: (id: string) => Dictionary[] = (id) => [{ foo: id }];
 
-        const rootPath = join(__dirname, '..', '..', 'tmp');
+        const tmpDir: string = `${__dirname}/tmp`;
+
+        beforeAll(async () => {
+            await mkdir(tmpDir);
+        });
+
+        afterAll(async () => {
+            await rm(tmpDir, { recursive: true, force: true });
+        });
 
         test('should expose default Dataset methods', async () => {
             const crawler = new BasicCrawler();
@@ -1407,12 +1416,12 @@ describe('BasicCrawler', () => {
             await crawler.pushData(row);
             await crawler.pushData(row);
 
-            await crawler.exportData(`${rootPath}/result.csv`);
-            await crawler.exportData(`${rootPath}/result.json`);
+            await crawler.exportData(`${tmpDir}/result.csv`);
+            await crawler.exportData(`${tmpDir}/result.json`);
 
-            const csv = await readFile(`${rootPath}/result.csv`);
+            const csv = await readFile(`${tmpDir}/result.csv`);
             expect(csv.toString()).toBe('foo,baz\nbar,123\nbar,123\nbar,123\n');
-            const json = await readFile(`${rootPath}/result.json`);
+            const json = await readFile(`${tmpDir}/result.json`);
             expect(json.toString()).toBe('[\n'
                 + '    {\n'
                 + '        "foo": "bar",\n'
@@ -1428,8 +1437,8 @@ describe('BasicCrawler', () => {
                 + '    }\n'
                 + ']\n');
 
-            await rm(`${rootPath}/result.csv`);
-            await rm(`${rootPath}/result.json`);
+            await rm(`${tmpDir}/result.csv`);
+            await rm(`${tmpDir}/result.json`);
         });
 
         test('should expose pushData helper', async () => {

--- a/test/core/crawlers/basic_crawler.test.ts
+++ b/test/core/crawlers/basic_crawler.test.ts
@@ -27,6 +27,7 @@ import express from 'express';
 import { MemoryStorageEmulator } from 'test/shared/MemoryStorageEmulator';
 
 import { startExpressAppPromise } from '../../shared/_helper';
+import * as process from 'process';
 
 describe('BasicCrawler', () => {
     let logLevel: number;
@@ -1404,15 +1405,14 @@ describe('BasicCrawler', () => {
             await crawler.pushData(row);
             await crawler.pushData(row);
 
-            await crawler.exportData('./storage/result.csv');
-            await crawler.exportData('./storage/result.json');
+            const root = process.cwd();
 
-            // try to wait a bit, otherwise the CI reports non-existent file
-            await sleep(500);
+            await crawler.exportData(`${root}/storage/result.csv`);
+            await crawler.exportData(`${root}/storage/result.json`);
 
-            const csv = await readFile('./storage/result.csv');
+            const csv = await readFile(`${root}/storage/result.csv`);
             expect(csv.toString()).toBe('foo,baz\nbar,123\nbar,123\nbar,123\n');
-            const json = await readFile('./storage/result.json');
+            const json = await readFile(`${root}/storage/result.json`);
             expect(json.toString()).toBe('[\n'
                 + '    {\n'
                 + '        "foo": "bar",\n'
@@ -1428,8 +1428,8 @@ describe('BasicCrawler', () => {
                 + '    }\n'
                 + ']\n');
 
-            await rm('./storage/result.csv');
-            await rm('./storage/result.json');
+            await rm(`${root}/storage/result.csv`);
+            await rm(`${root}/storage/result.json`);
         });
 
         test('should expose pushData helper', async () => {

--- a/test/core/crawlers/basic_crawler.test.ts
+++ b/test/core/crawlers/basic_crawler.test.ts
@@ -27,7 +27,6 @@ import express from 'express';
 import { MemoryStorageEmulator } from 'test/shared/MemoryStorageEmulator';
 
 import { startExpressAppPromise } from '../../shared/_helper';
-import * as process from 'process';
 
 describe('BasicCrawler', () => {
     let logLevel: number;


### PR DESCRIPTION
Retrieves all the data from the default crawler `Dataset` and exports them to the specified format. Supported formats are currently 'json' and 'csv', and will be inferred from the `path` automatically.

```ts
const crawler = new BasicCrawler({ ... });
crawler.pushData({ ... });

await crawler.exportData('./data.csv');
```