### PR TITLE
Added "Edit this page" link to docs

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -67,6 +67,9 @@ module.exports = {
                     sidebarPath: './sidebars.js',
                     rehypePlugins: [externalLinkProcessor],
                     disableVersioning: !!process.env.CRAWLEE_DOCS_FAST,
+                    editUrl: ({ docPath }) => {
+                        return `https://holocron.so/github/pr/apify/crawlee/master/editor/docs/${docPath}`
+                    },
                 },
                 theme: {
                     customCss: '/src/css/custom.css',


### PR DESCRIPTION
With this PR readers can suggest changes to the docs with an easy to use WYSIWYG markdown editor.

[This](https://holocron.so/github/pr/apify/crawlee/master/editor) is how the editor looks like for this repo.

https://github.com/remorses/docusaurus-example/assets/31321188/43c8bc68-3668-4a25-bf1c-a70eceab7bcb