### PR TITLE
feat: allow configuring crawler statistics

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -25,6 +25,7 @@ import type {
     SessionPoolOptions,
     Source,
     StatisticState,
+    StatisticsOptions,
 } from '@crawlee/core';
 import {
     AutoscaledPool,
@@ -338,6 +339,12 @@ export interface BasicCrawlerOptions<Context extends CrawlingContext = BasicCraw
      * WARNING: these options are not guaranteed to be stable and may change or be removed at any time.
      */
     experiments?: CrawlerExperiments;
+
+    /**
+     * Customize the way statistics collecting works, such as logging interval or
+     * whether to output them to the Key-Value store.
+     */
+    statisticsOptions?: StatisticsOptions;
 }
 
 /**
@@ -524,6 +531,8 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
         // internal
         log: ow.optional.object,
         experiments: ow.optional.object,
+
+        statisticsOptions: ow.optional.object,
     };
 
     /**
@@ -569,6 +578,8 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
 
             statusMessageLoggingInterval = 10,
             statusMessageCallback,
+
+            statisticsOptions,
         } = options;
 
         this.requestList = requestList;
@@ -650,7 +661,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
         this.sameDomainDelayMillis = sameDomainDelaySecs * 1000;
         this.maxSessionRotations = maxSessionRotations;
         this.handledRequestsCount = 0;
-        this.stats = new Statistics({ logMessage: `${log.getOptions().prefix} request statistics:`, config });
+        this.stats = new Statistics({ logMessage: `${log.getOptions().prefix} request statistics:`, config, ...statisticsOptions });
         this.sessionPoolOptions = {
             ...sessionPoolOptions,
             log,

--- a/packages/core/src/crawlers/statistics.ts
+++ b/packages/core/src/crawlers/statistics.ts
@@ -40,6 +40,13 @@ const errorTrackerConfig = {
 };
 
 /**
+ * Override persistence-related options provided in {@apilink StatisticsOptions} for a single method call
+ */
+interface PersistenceOptionsOverrides {
+    enablePersistence?: boolean;
+}
+
+/**
  * The statistics class provides an interface to collecting and logging run
  * statistics for requests.
  *
@@ -159,13 +166,8 @@ export class Statistics {
         this._teardown();
     }
 
-    async resetStore(opts?: {
-        /**
-         * If true, manually reset KV store entry for the statistics, ignoring the {@apilink StatisticsOptions.enablePersistence} flag
-         */
-        force?: boolean;
-    }) {
-        if (!this.enablePersistence && !opts?.force) {
+    async resetStore(opts?: PersistenceOptionsOverrides) {
+        if (!(this.enablePersistence || opts?.enablePersistence)) {
             return;
         }
         if (!this.keyValueStore) {
@@ -298,13 +300,8 @@ export class Statistics {
     /**
      * Persist internal state to the key value store
      */
-    async persistState(opts?: {
-        /**
-         * If true, ignore the {@apilink StatisticsOptions.enablePersistence} flag
-         */
-        force?: boolean;
-    }) {
-        if (!this.enablePersistence && !opts?.force) {
+    async persistState(opts?: PersistenceOptionsOverrides) {
+        if (!(this.enablePersistence || opts?.enablePersistence)) {
             return;
         }
         // this might be called before startCapturing was called without using await, should not crash

--- a/packages/core/src/crawlers/statistics.ts
+++ b/packages/core/src/crawlers/statistics.ts
@@ -122,7 +122,9 @@ export class Statistics {
             logMessage = 'Statistics',
             keyValueStore,
             config = Configuration.getGlobalConfig(),
-            persistenceOptions = {},
+            persistenceOptions = {
+                enable: true,
+            },
         } = options;
 
         this.logIntervalMillis = logIntervalSecs * 1000;

--- a/packages/core/src/crawlers/statistics.ts
+++ b/packages/core/src/crawlers/statistics.ts
@@ -165,7 +165,7 @@ export class Statistics {
          */
         force?: boolean;
     }) {
-        if (!this.enablePersistence && opts?.force !== true) {
+        if (!this.enablePersistence && !opts?.force) {
             return;
         }
         if (!this.keyValueStore) {

--- a/packages/core/src/crawlers/statistics.ts
+++ b/packages/core/src/crawlers/statistics.ts
@@ -159,17 +159,15 @@ export class Statistics {
         this._teardown();
     }
 
-    async resetStore() {
-        if (!this.enablePersistence) {
+    async resetStore(opts?: {
+        /**
+         * If true, manually reset KV store entry for the statistics, ignoring the {@apilink StatisticsOptions.enablePersistence} flag
+         */
+        force?: boolean;
+    }) {
+        if (!this.enablePersistence && opts?.force !== true) {
             return;
         }
-        return this.resetStoreForce();
-    }
-
-    /**
-     * Manually reset KV store entry for the statistics, ignoring the {@apilink StatisticsOptions.enablePersistence} flag
-     */
-    async resetStoreForce() {
         if (!this.keyValueStore) {
             return;
         }
@@ -300,18 +298,15 @@ export class Statistics {
     /**
      * Persist internal state to the key value store
      */
-    async persistState() {
-        // this might be called before startCapturing was called without using await, should not crash
-        if (!this.enablePersistence || !this.keyValueStore) {
+    async persistState(opts?: {
+        /**
+         * If true, ignore the {@apilink StatisticsOptions.enablePersistence} flag
+         */
+        force?: boolean;
+    }) {
+        if (!this.enablePersistence && opts?.force !== true) {
             return;
         }
-        return this.persistStateForce();
-    }
-
-    /**
-     * Same as {@apilink Statistics.persistState}, but ignores the {@apilink StatisticsOptions.enablePersistence} flag
-     */
-    async persistStateForce() {
         // this might be called before startCapturing was called without using await, should not crash
         if (!this.keyValueStore) {
             return;
@@ -438,7 +433,6 @@ export interface StatisticsOptions {
 
     /**
      * Use this flag to disable or enable periodic statistics persistence to key value store.
-     * You can persist to KV store or reset the record there manually by calling {@apilink Statistics.persistStateForce} or {@apilink Statistics.resetStoreForce}
      * @default true
      */
     enablePersistence?: boolean;

--- a/packages/core/src/crawlers/statistics.ts
+++ b/packages/core/src/crawlers/statistics.ts
@@ -409,7 +409,7 @@ export class Statistics {
 }
 
 /**
- * Configuration for the [Statistics](https://crawlee.dev/api/next/core/class/Statistics) instance used by the crawler
+ * Configuration for the {@apilink Statistics} instance used by the crawler
  */
 export interface StatisticsOptions {
     /**

--- a/packages/core/src/crawlers/statistics.ts
+++ b/packages/core/src/crawlers/statistics.ts
@@ -304,7 +304,7 @@ export class Statistics {
          */
         force?: boolean;
     }) {
-        if (!this.enablePersistence && opts?.force !== true) {
+        if (!this.enablePersistence && !opts?.force) {
             return;
         }
         // this might be called before startCapturing was called without using await, should not crash

--- a/packages/core/src/crawlers/statistics.ts
+++ b/packages/core/src/crawlers/statistics.ts
@@ -167,7 +167,7 @@ export class Statistics {
     }
 
     async resetStore(opts?: PersistenceOptionsOverrides) {
-        if (!(this.enablePersistence || opts?.enablePersistence)) {
+        if (!this.enablePersistence && !opts?.enablePersistence) {
             return;
         }
         if (!this.keyValueStore) {
@@ -301,7 +301,7 @@ export class Statistics {
      * Persist internal state to the key value store
      */
     async persistState(opts?: PersistenceOptionsOverrides) {
-        if (!(this.enablePersistence || opts?.enablePersistence)) {
+        if (!this.enablePersistence && !opts?.enablePersistence) {
             return;
         }
         // this might be called before startCapturing was called without using await, should not crash

--- a/packages/core/src/session_pool/session_pool.ts
+++ b/packages/core/src/session_pool/session_pool.ts
@@ -172,7 +172,9 @@ export class SessionPool extends EventEmitter {
             sessionOptions = {},
             blockedStatusCodes = [401, 403, 429],
             log = defaultLog,
-            persistenceOptions = {},
+            persistenceOptions = {
+                enable: true,
+            },
         } = options;
 
         this.config = config;

--- a/packages/core/src/session_pool/session_pool.ts
+++ b/packages/core/src/session_pool/session_pool.ts
@@ -341,7 +341,7 @@ export class SessionPool extends EventEmitter {
          */
         force?: boolean;
     }): Promise<void> {
-        if (!this.enablePersistence && opts?.force !== true) {
+        if (!this.enablePersistence && !opts?.force) {
             return;
         }
         this.log.debug('Persisting state', {

--- a/packages/core/src/session_pool/session_pool.ts
+++ b/packages/core/src/session_pool/session_pool.ts
@@ -315,7 +315,7 @@ export class SessionPool extends EventEmitter {
     }
 
     async resetStore(opts?: PersistenceOptionsOverrides) {
-        if (!(this.enablePersistence || opts?.enablePersistence)) {
+        if (!this.enablePersistence && !opts?.enablePersistence) {
             return;
         }
         await this.keyValueStore?.setValue(this.persistStateKey, null);
@@ -338,7 +338,7 @@ export class SessionPool extends EventEmitter {
      * The state is persisted automatically in regular intervals.
      */
     async persistState(opts?: PersistenceOptionsOverrides): Promise<void> {
-        if (!(this.enablePersistence || opts?.enablePersistence)) {
+        if (!this.enablePersistence && !opts?.enablePersistence) {
             return;
         }
         this.log.debug('Persisting state', {

--- a/packages/core/src/session_pool/session_pool.ts
+++ b/packages/core/src/session_pool/session_pool.ts
@@ -61,8 +61,6 @@ export interface SessionPoolOptions {
 
     /**
      * If set to true, `SessionPool` will periodically persist its state to the key-value store.
-     * Othewise, {@apilink SessionPool.persistState} and {@apilink SessionPool.resetStore} will have no effect,
-     * but you will still be able to call their "*Force" counterparts for manual resetting and persisting.
      * @default true
      */
     enablePersistence?: boolean;
@@ -309,17 +307,15 @@ export class SessionPool extends EventEmitter {
         return this._createSession();
     }
 
-    async resetStore() {
-        if (!this.enablePersistence) {
+    async resetStore(opts?: {
+        /**
+         * If true, manually reset KV store entry, ignoring the {@apilink SessionPoolOptions.enablePersistence} flag
+         */
+        force?: boolean;
+    }) {
+        if (!this.enablePersistence && opts?.force !== true) {
             return;
         }
-        return this.resetStoreForce();
-    }
-
-    /**
-     * Manually reset KV store entry for the the session pool state, ignoring the {@apilink SessionPoolOptions.enablePersistence} option.
-     */
-    async resetStoreForce() {
         await this.keyValueStore?.setValue(this.persistStateKey, null);
     }
 
@@ -339,17 +335,15 @@ export class SessionPool extends EventEmitter {
      * Persists the current state of the `SessionPool` into the default {@apilink KeyValueStore}.
      * The state is persisted automatically in regular intervals.
      */
-    async persistState(): Promise<void> {
-        if (!this.enablePersistence) {
+    async persistState(opts?: {
+        /**
+         * If true, ignore the {@apilink SessionPoolOptions.enablePersistence} flag
+         */
+        force?: boolean;
+    }): Promise<void> {
+        if (!this.enablePersistence && opts?.force !== true) {
             return;
         }
-        return this.persistStateForce();
-    }
-
-    /**
-     * Like {@apilink SessionPool.persistState}, but ignores the {@apilink SessionPoolOptions.enablePersistence} option.
-     */
-    async persistStateForce() {
         this.log.debug('Persisting state', {
             persistStateKeyValueStoreId: this.persistStateKeyValueStoreId,
             persistStateKey: this.persistStateKey,

--- a/packages/core/src/session_pool/session_pool.ts
+++ b/packages/core/src/session_pool/session_pool.ts
@@ -313,7 +313,7 @@ export class SessionPool extends EventEmitter {
          */
         force?: boolean;
     }) {
-        if (!this.enablePersistence && opts?.force !== true) {
+        if (!this.enablePersistence && !opts?.force) {
             return;
         }
         await this.keyValueStore?.setValue(this.persistStateKey, null);


### PR DESCRIPTION
Allow disabling automatic persistence in Statistics and SessionPool.
Add additional methods for manual disabling in case it's needed, but just not the automatic one
Closes #1789 