### PR TITLE
fix(MemoryStorage): lock request JSON file when reading to support multiple process crawling

### DIFF
--- a/packages/memory-storage/src/fs/common.ts
+++ b/packages/memory-storage/src/fs/common.ts
@@ -1,5 +1,5 @@
 export interface StorageImplementation<T> {
-    get(): Promise<T>;
+    get(force?: boolean): Promise<T>;
     update(data: T): void | Promise<void>;
     delete(): void | Promise<void>;
 }

--- a/packages/memory-storage/src/resource-clients/request-queue.ts
+++ b/packages/memory-storage/src/resource-clients/request-queue.ts
@@ -200,7 +200,8 @@ export class RequestQueueClient extends BaseClient implements storage.RequestQue
                     break;
                 }
 
-                const request = await storageEntry.get();
+                // Always fetch from fs, as this also locks and we do not want to end up in a state where another process locked the request but we have cached it as unlocked
+                const request = await storageEntry.get(true);
 
                 if (isLocked(request)) {
                     continue;


### PR DESCRIPTION
Needed for https://github.com/apify/crawlee-parallel-scraping-example