### PR TITLE
docs: set fixed width for short docs articles

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -233,7 +233,7 @@ nav.navbar .dropdown__menu {
 }
 
 .main-wrapper > div {
-    max-width: calc(min(100%, var(--max-layout-width))) !important;
+    width: calc(min(100%, var(--max-layout-width))) !important;
 }
 
 .main-wrapper a[class*='sidebarLogo'] img {


### PR DESCRIPTION
Articles collapse to the width of their content. If the content is too short, it looks weird.

| before | after |
|---|---|
| ![obrazek](https://github.com/apify/crawlee/assets/61918049/71088a43-9ae6-40ff-b3ff-2f0cfe405b17) | ![obrazek](https://github.com/apify/crawlee/assets/61918049/7657c3ae-dfba-409e-a07f-236093a17440) |

Tested in mobile too, all should work fine.

CC @janbuchar thanks for the report