### PR TITLE
docs: improve warning message on empty RequestList

### DIFF
--- a/packages/core/src/storages/request_list.ts
+++ b/packages/core/src/storages/request_list.ts
@@ -681,7 +681,7 @@ export class RequestList {
 
         // Skip if resource contained no URLs.
         if (!urlsArr.length) {
-            this.log.warning('list fetched, but it is empty.', { requestsFromUrl, regex });
+            this.log.warning('The fetched list contains no valid URLs.', { requestsFromUrl, regex });
             return [];
         }
 

--- a/packages/core/src/storages/request_provider.ts
+++ b/packages/core/src/storages/request_provider.ts
@@ -576,7 +576,7 @@ export abstract class RequestProvider implements IStorage {
 
         // Skip if resource contained no URLs.
         if (!urlsArr.length) {
-            this.log.warning('list fetched, but it is empty.', { requestsFromUrl, regex });
+            this.log.warning('The fetched list contains no valid URLs.', { requestsFromUrl, regex });
             return [];
         }
 


### PR DESCRIPTION
If the user submits a list of invalid URLs (e.g. without the `protocol` part), the message about an "empty" list can get confusing.

Mentioned in https://console.apify.com/actors/aYG0l9s7dbB7j3gbS/issues/pGohDSeaCzL4xZ2bI