### PR TITLE
feat: accessing crawler state, key-value store and named datasets via crawling context

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -1240,7 +1240,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
                     cookieJar,
                 });
             },
-            getKeyValueStore: KeyValueStore.open
+            getKeyValueStore: KeyValueStore.open,
         };
 
         this.crawlingContexts.set(crawlingContext.id, crawlingContext);

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -1214,9 +1214,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
                 });
             },
             addRequests: this.addRequests.bind(this),
-            pushData: async (data: Parameters<Dataset['pushData']>[0], datasetIdOrName?: string) => {
-                return this.pushData(data, datasetIdOrName);
-            },
+            pushData: this.pushData.bind(this),
             sendRequest: async (overrideOptions?: OptionsInit) => {
                 const cookieJar = session ? {
                     getCookieString: async (url: string) => session!.getCookieString(url),
@@ -1240,7 +1238,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
                     cookieJar,
                 });
             },
-            getKeyValueStore: KeyValueStore.open,
+            getKeyValueStore: async (idOrName?: string) => KeyValueStore.open(idOrName, { config: this.config }),
         };
 
         this.crawlingContexts.set(crawlingContext.id, crawlingContext);

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -1213,7 +1213,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
                     ...options,
                 });
             },
-            addRequests: this.addRequests,
+            addRequests: this.addRequests.bind(this),
             pushData: async (data: Parameters<Dataset['pushData']>[0], datasetIdOrName?: string) => {
                 return this.pushData(data, datasetIdOrName);
             },

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -954,18 +954,18 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
     }
 
     /**
-     * Pushes data to the default crawler {@apilink Dataset} by calling {@apilink Dataset.pushData}.
+     * Pushes data to the specified {@apilink Dataset}, or the default crawler {@apilink Dataset} by calling {@apilink Dataset.pushData}.
      */
-    async pushData(...args: Parameters<Dataset['pushData']>): Promise<void> {
-        const dataset = await this.getDataset();
-        return dataset.pushData(...args);
+    async pushData(data: Parameters<Dataset['pushData']>[0], datasetIdOrName?: string): Promise<void> {
+        const dataset = await this.getDataset(datasetIdOrName);
+        return dataset.pushData(data);
     }
 
     /**
-     * Retrieves the default crawler {@apilink Dataset}.
+     * Retrieves the specified {@apilink Dataset}, or the default crawler {@apilink Dataset}.
      */
-    async getDataset(): Promise<Dataset> {
-        return Dataset.open(undefined, { config: this.config });
+    async getDataset(idOrName?: string): Promise<Dataset> {
+        return Dataset.open(idOrName, { config: this.config });
     }
 
     /**
@@ -1213,8 +1213,9 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
                     ...options,
                 });
             },
-            pushData: async (...args: Parameters<Dataset['pushData']>) => {
-                return this.pushData(...args);
+            addRequests: this.addRequests,
+            pushData: async (data: Parameters<Dataset['pushData']>[0], datasetIdOrName?: string) => {
+                return this.pushData(data, datasetIdOrName);
             },
             sendRequest: async (overrideOptions?: OptionsInit) => {
                 const cookieJar = session ? {
@@ -1239,6 +1240,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
                     cookieJar,
                 });
             },
+            getKeyValueStore: KeyValueStore.open
         };
 
         this.crawlingContexts.set(crawlingContext.id, crawlingContext);

--- a/packages/core/src/crawlers/crawler_commons.ts
+++ b/packages/core/src/crawlers/crawler_commons.ts
@@ -58,7 +58,7 @@ export interface RestrictedCrawlingContext<UserData extends Dictionary = Diction
      * @param options Options for the request queue
      */
     addRequests: (
-        requestsLike: Source[],
+        requestsLike: (string | Source)[],
         options?: RequestQueueOperationOptions,
     ) => Promise<void>;
 

--- a/packages/core/src/crawlers/crawler_commons.ts
+++ b/packages/core/src/crawlers/crawler_commons.ts
@@ -67,7 +67,7 @@ export interface CrawlingContext<Crawler = unknown, UserData extends Dictionary 
      */
     pushData(data: Parameters<Dataset['pushData']>[0], datasetIdOrName?: string): Promise<void>;
 
-    getKeyValueStore: (idOrName?: string) => Promise<KeyValueStore>
+    getKeyValueStore: (idOrName?: string) => Promise<KeyValueStore>;
 
     /**
      * Fires HTTP request via [`got-scraping`](https://crawlee.dev/docs/guides/got-scraping), allowing to override the request
@@ -92,12 +92,12 @@ export interface CrawlingContext<Crawler = unknown, UserData extends Dictionary 
 export interface RestrictedCrawlingContext<UserData extends Dictionary = Dictionary> {
     request: Request<UserData>;
     pushData: (record: Dictionary, datasetIdOrName?: string) => Promise<void>;
-    enqueueLinks: (options?: Omit<EnqueueLinksOptions, "requestQueue">) => Promise<void>;
+    enqueueLinks: (options?: Omit<EnqueueLinksOptions, 'requestQueue'>) => Promise<void>;
     addRequests: (
         requestsLike: Source[],
         options?: RequestQueueOperationOptions,
     ) => Promise<void>;
     useState: <State = Dictionary<unknown>>(defaultValue?: State) => Promise<State>;
-    getKeyValueStore: (idOrName?: string) => Promise<Pick<KeyValueStore, "id" | "name" | "getValue" | "getAutoSavedValue" | "setValue">>
+    getKeyValueStore: (idOrName?: string) => Promise<Pick<KeyValueStore, 'id' | 'name' | 'getValue' | 'getAutoSavedValue' | 'setValue'>>;
     log: Log;
 }

--- a/packages/core/src/crawlers/crawler_commons.ts
+++ b/packages/core/src/crawlers/crawler_commons.ts
@@ -65,7 +65,7 @@ export interface RestrictedCrawlingContext<UserData extends Dictionary = Diction
     /**
      * Returns the state - a piece of mutable persistent data shared across all the request handler runs.
      */
-    useState: <State = Dictionary<unknown>>(defaultValue?: State) => Promise<State>;
+    useState: <State extends Dictionary = Dictionary>(defaultValue?: State) => Promise<State>;
 
     /**
      * Get a key-value store with given name or id, or the default one for the crawler.

--- a/packages/core/src/crawlers/crawler_commons.ts
+++ b/packages/core/src/crawlers/crawler_commons.ts
@@ -5,9 +5,9 @@ import type { Response as GotResponse, OptionsInit } from 'got-scraping';
 import type { EnqueueLinksOptions } from '../enqueue_links/enqueue_links';
 import type { Log } from '../log';
 import type { ProxyInfo } from '../proxy_configuration';
-import type { Request } from '../request';
+import type { Request, Source } from '../request';
 import type { Session } from '../session_pool/session';
-import { type Dataset } from '../storages';
+import { RequestQueueOperationOptions, type Dataset } from '../storages';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export interface CrawlingContext<Crawler = unknown, UserData extends Dictionary = Dictionary> extends Record<string & {}, unknown> {
@@ -80,4 +80,18 @@ export interface CrawlingContext<Crawler = unknown, UserData extends Dictionary 
      * ```
      */
     sendRequest<Response = string>(overrideOptions?: Partial<OptionsInit>): Promise<GotResponse<Response>>;
+}
+
+export interface RestrictedCrawlingContext<UserData extends Dictionary = Dictionary> {
+    request: Request<UserData>;
+    pushData: (record: Dictionary, datasetName?: string) => Promise<void>;
+    enqueueLinks: (options?: EnqueueLinksOptions) => Promise<void>;
+    addRequests: (
+        requestsLike: Source[],
+        options?: RequestQueueOperationOptions,
+    ) => Promise<void>;
+    getStoreValue: <Value = unknown>(key: string, defaultValue?: Value) => Promise<Value>
+    setStoreValue: <Value = unknown>(key: string, value: Value) => Promise<void>
+    useState: <State = Dictionary<unknown>>(defaultValue?: State) => Promise<State>
+    log: Log
 }

--- a/packages/core/src/crawlers/crawler_commons.ts
+++ b/packages/core/src/crawlers/crawler_commons.ts
@@ -53,6 +53,11 @@ export interface CrawlingContext<Crawler = unknown, UserData extends Dictionary 
      */
     enqueueLinks(options?: EnqueueLinksOptions): Promise<BatchAddRequestsResult>;
 
+    addRequests: (
+        requestsLike: Source[],
+        options?: RequestQueueOperationOptions,
+    ) => Promise<void>;
+
     /**
      * This function allows you to push data to the default {@apilink Dataset} currently used by the crawler.
      *
@@ -60,7 +65,9 @@ export interface CrawlingContext<Crawler = unknown, UserData extends Dictionary 
      *
      * @param [data] Data to be pushed to the default dataset.
      */
-    pushData(...args: Parameters<Dataset['pushData']>): Promise<void>;
+    pushData(data: Parameters<Dataset['pushData']>[0], datasetIdOrName?: string): Promise<void>;
+
+    getKeyValueStore: (idOrName?: string) => Promise<KeyValueStore>
 
     /**
      * Fires HTTP request via [`got-scraping`](https://crawlee.dev/docs/guides/got-scraping), allowing to override the request
@@ -84,13 +91,13 @@ export interface CrawlingContext<Crawler = unknown, UserData extends Dictionary 
 
 export interface RestrictedCrawlingContext<UserData extends Dictionary = Dictionary> {
     request: Request<UserData>;
-    pushData: (record: Dictionary, datasetName?: string) => Promise<void>;
-    enqueueLinks: (options?: EnqueueLinksOptions) => Promise<void>;
+    pushData: (record: Dictionary, datasetIdOrName?: string) => Promise<void>;
+    enqueueLinks: (options?: Omit<EnqueueLinksOptions, "requestQueue">) => Promise<void>;
     addRequests: (
         requestsLike: Source[],
         options?: RequestQueueOperationOptions,
     ) => Promise<void>;
     useState: <State = Dictionary<unknown>>(defaultValue?: State) => Promise<State>;
-    getKeyValueStore: () => Promise<Pick<KeyValueStore, "getValue" | "getAutoSavedValue" | "setValue" | "id" | "name">>
+    getKeyValueStore: (idOrName?: string) => Promise<Pick<KeyValueStore, "id" | "name" | "getValue" | "getAutoSavedValue" | "setValue">>
     log: Log;
 }

--- a/packages/core/src/crawlers/crawler_commons.ts
+++ b/packages/core/src/crawlers/crawler_commons.ts
@@ -7,7 +7,7 @@ import type { Log } from '../log';
 import type { ProxyInfo } from '../proxy_configuration';
 import type { Request, Source } from '../request';
 import type { Session } from '../session_pool/session';
-import type { RequestQueueOperationOptions, Dataset, RecordOptions } from '../storages';
+import type { RequestQueueOperationOptions, Dataset, KeyValueStore } from '../storages';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export interface CrawlingContext<Crawler = unknown, UserData extends Dictionary = Dictionary> extends Record<string & {}, unknown> {
@@ -90,8 +90,7 @@ export interface RestrictedCrawlingContext<UserData extends Dictionary = Diction
         requestsLike: Source[],
         options?: RequestQueueOperationOptions,
     ) => Promise<void>;
-    getStoreValue: <Value = unknown>(key: string, defaultValue?: Value) => Promise<Value>;
-    setStoreValue: <Value = unknown>(key: string, value: Value, options?: RecordOptions) => Promise<void>;
     useState: <State = Dictionary<unknown>>(defaultValue?: State) => Promise<State>;
+    getKeyValueStore: () => Promise<Pick<KeyValueStore, "getValue" | "getAutoSavedValue" | "setValue" | "id" | "name">>
     log: Log;
 }

--- a/packages/core/src/crawlers/crawler_commons.ts
+++ b/packages/core/src/crawlers/crawler_commons.ts
@@ -7,7 +7,7 @@ import type { Log } from '../log';
 import type { ProxyInfo } from '../proxy_configuration';
 import type { Request, Source } from '../request';
 import type { Session } from '../session_pool/session';
-import { RequestQueueOperationOptions, type Dataset } from '../storages';
+import type { RequestQueueOperationOptions, Dataset, RecordOptions } from '../storages';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export interface CrawlingContext<Crawler = unknown, UserData extends Dictionary = Dictionary> extends Record<string & {}, unknown> {
@@ -90,8 +90,8 @@ export interface RestrictedCrawlingContext<UserData extends Dictionary = Diction
         requestsLike: Source[],
         options?: RequestQueueOperationOptions,
     ) => Promise<void>;
-    getStoreValue: <Value = unknown>(key: string, defaultValue?: Value) => Promise<Value>
-    setStoreValue: <Value = unknown>(key: string, value: Value) => Promise<void>
-    useState: <State = Dictionary<unknown>>(defaultValue?: State) => Promise<State>
-    log: Log
+    getStoreValue: <Value = unknown>(key: string, defaultValue?: Value) => Promise<Value>;
+    setStoreValue: <Value = unknown>(key: string, value: Value, options?: RecordOptions) => Promise<void>;
+    useState: <State = Dictionary<unknown>>(defaultValue?: State) => Promise<State>;
+    log: Log;
 }


### PR DESCRIPTION
## New/updated `CrawlingContext` methods

- `getKeyValueStore` - replacement for direct `KeyValueStore.open` calls
- `addRequests`, `useState` - basically shortcuts to the respective methods on the `crawler`
- `pushData` and `getDataset` - there's a new parameter that allows changing the target dataset

These changes should help the users avoid touching global `Dataset` and `KeyValueStore` instances and the `crawler` field. Not touching global crawlee/apify-sdk stuff should become **the way** to write request handlers, piece by piece. 

## `RestrictedCrawlingContext` interface

A subset of the `CrawlingContext` interface that should be enough for the vast majority of use cases. This is not used anywhere yet. If a user sticks to using this, the side-effects of the request handler should be well contained - we can for example run a request handler with a mock implementation of `RestrictedCrawlingContext` and inspect the "output" that the handler produced. I intend to use this for a more general adaptive crawler in the near future. 

The restriction should also make it possible to run the request handlers repeatedly without corrupting the state/dataset/etc. This property can be useful for example in developer tools, for implementation of new ways of crawling (beyond adaptive :slightly_smiling_face:), or for making the existing crawlers more robust in case of errors in the handlers.

I do not intend to remove the original `CrawlingContext` though - if you find out you need to go "power user mode", you should always be free to do so. On the other hand, the `RestrictedCrawlingContext` may be too restricted in some areas. I'm definitely open to judiciously adding back functionality over time, if needed. Right now, I'd like to keep the interfaces as simple as possible so that the near-future adaptive crawler can be implemented with a smaller footprint.