### PR TITLE
fix: filter out nullish globs

### DIFF
--- a/packages/core/src/enqueue_links/shared.ts
+++ b/packages/core/src/enqueue_links/shared.ts
@@ -78,7 +78,7 @@ export function constructRegExpObjectsFromPseudoUrls(pseudoUrls: PseudoUrlInput[
  */
 export function constructGlobObjectsFromGlobs(globs: GlobInput[]): GlobObject[] {
     return globs
-        .filter((glob) => ((glob as GlobObject).glob || (glob as string)).trim().length > 0)
+        .filter((glob) => glob && ((glob as GlobObject).glob || (glob as string) || '').trim().length > 0)
         .map((item) => {
         // Get glob object from cache.
             let globObject = enqueueLinksPatternCache.get(item);

--- a/packages/core/src/enqueue_links/shared.ts
+++ b/packages/core/src/enqueue_links/shared.ts
@@ -78,7 +78,22 @@ export function constructRegExpObjectsFromPseudoUrls(pseudoUrls: PseudoUrlInput[
  */
 export function constructGlobObjectsFromGlobs(globs: GlobInput[]): GlobObject[] {
     return globs
-        .filter((glob) => glob && ((glob as GlobObject).glob || (glob as string) || '').trim().length > 0)
+        .filter((glob) => {
+            // Skip possibly nullish, empty strings
+            if (!glob) {
+                return false;
+            }
+
+            if (typeof glob === 'string') {
+                return glob.trim().length > 0;
+            }
+
+            if (glob.glob) {
+                return glob.glob.trim().length > 0;
+            }
+
+            return false;
+        })
         .map((item) => {
         // Get glob object from cache.
             let globObject = enqueueLinksPatternCache.get(item);

--- a/test/core/enqueue_links/enqueue_links.test.ts
+++ b/test/core/enqueue_links/enqueue_links.test.ts
@@ -157,6 +157,8 @@ describe('enqueueLinks()', () => {
                 'https://example.com/**/*',
                 '',
                 { glob: ' ' },
+                // Empty string used to throw an error (https://console.apify.com/actors/aYG0l9s7dbB7j3gbS/issues/Wd0Ahfk9Vd2OPk4Uf)
+                { glob: '' },
                 { glob: '?(http|https)://cool.com/', method: 'POST' as const },
             ];
 


### PR DESCRIPTION
Was noticed as an issue when running through apify where we'd get an empty element that throws a very non descriptive error

Reported here: https://console.apify.com/actors/aYG0l9s7dbB7j3gbS/issues/Wd0Ahfk9Vd2OPk4Uf