### PR TITLE
refactor(browser-pool): drop const modifier for BrowserName enum

### DIFF
--- a/packages/browser-pool/src/fingerprinting/types.ts
+++ b/packages/browser-pool/src/fingerprinting/types.ts
@@ -13,7 +13,7 @@ export interface FingerprintGeneratorOptions {
     * List of `BrowserSpecification` objects
     * or one of `chrome`, `edge`, `firefox` and `safari`.
     */
-    browsers?: BrowserSpecification[] | BrowserName[];
+    browsers?: BrowserSpecification[] | (typeof BrowserName[keyof typeof BrowserName])[];
     /**
     * Browser generation query based on the real world data.
     *  For more info see the [query docs](https://github.com/browserslist/browserslist#full-list).
@@ -61,18 +61,18 @@ const SUPPORTED_HTTP_VERSIONS = ['1', '2'] as const;
  */
 type HttpVersion = typeof SUPPORTED_HTTP_VERSIONS[number];
 
-export const enum BrowserName {
-    chrome = 'chrome',
-    firefox = 'firefox',
-    safari = 'safari',
-    edge = 'edge',
-}
+export const BrowserName = {
+    chrome: 'chrome',
+    firefox: 'firefox',
+    safari: 'safari',
+    edge: 'edge',
+} as const;
 
 export interface BrowserSpecification {
     /**
     * String representing the browser name.
     */
-    name: BrowserName;
+    name: typeof BrowserName[keyof typeof BrowserName];
     /**
     * Minimum version of browser used.
     */

--- a/packages/browser-pool/src/fingerprinting/types.ts
+++ b/packages/browser-pool/src/fingerprinting/types.ts
@@ -13,7 +13,7 @@ export interface FingerprintGeneratorOptions {
     * List of `BrowserSpecification` objects
     * or one of `chrome`, `edge`, `firefox` and `safari`.
     */
-    browsers?: BrowserSpecification[] | (typeof BrowserName[keyof typeof BrowserName])[];
+    browsers?: BrowserSpecification[] | BrowserName[];
     /**
     * Browser generation query based on the real world data.
     *  For more info see the [query docs](https://github.com/browserslist/browserslist#full-list).
@@ -61,18 +61,18 @@ const SUPPORTED_HTTP_VERSIONS = ['1', '2'] as const;
  */
 type HttpVersion = typeof SUPPORTED_HTTP_VERSIONS[number];
 
-export const BrowserName = {
-    chrome: 'chrome',
-    firefox: 'firefox',
-    safari: 'safari',
-    edge: 'edge',
-} as const;
+export enum BrowserName {
+    chrome = 'chrome',
+    firefox = 'firefox',
+    safari = 'safari',
+    edge = 'edge',
+}
 
 export interface BrowserSpecification {
     /**
     * String representing the browser name.
     */
-    name: typeof BrowserName[keyof typeof BrowserName];
+    name: BrowserName;
     /**
     * Minimum version of browser used.
     */

--- a/packages/browser-pool/src/fingerprinting/utils.ts
+++ b/packages/browser-pool/src/fingerprinting/utils.ts
@@ -18,7 +18,7 @@ export const getGeneratorDefaultOptions = (launchContext: LaunchContext): Finger
     return options;
 };
 
-const getBrowserName = (browserPlugin: BrowserPlugin, launchOptions: any): BrowserName => {
+const getBrowserName = (browserPlugin: BrowserPlugin, launchOptions: any): typeof BrowserName[keyof typeof BrowserName] => {
     const { library } = browserPlugin;
     let browserName;
 

--- a/packages/browser-pool/src/fingerprinting/utils.ts
+++ b/packages/browser-pool/src/fingerprinting/utils.ts
@@ -18,7 +18,7 @@ export const getGeneratorDefaultOptions = (launchContext: LaunchContext): Finger
     return options;
 };
 
-const getBrowserName = (browserPlugin: BrowserPlugin, launchOptions: any): typeof BrowserName[keyof typeof BrowserName] => {
+const getBrowserName = (browserPlugin: BrowserPlugin, launchOptions: any): BrowserName => {
     const { library } = browserPlugin;
     let browserName;
 


### PR DESCRIPTION
<details>
<summary>Old PR description</summary>

I think we may want to add an alias for the resulting type using BrowserName.

Typechecking and tests are running fine.

What do you guys think ?

</details>

This PR aims to allow the `BrowserName` enum to be used :
- in TS < 5, with `isolatedModules`
- in TS >= 5, with `verbatimModuleSyntax`

Removing the `const` modifier, does not break the runtime nor the typing.