### PR TITLE
feat: adaptive playwright crawler

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
         "@types/htmlparser2": "^3.10.3",
         "@types/inquirer": "^8.2.1",
         "@types/is-ci": "^3.0.1",
+        "@types/lodash.isequal": "^4.5.8",
         "@types/lodash.merge": "^4.6.7",
         "@types/mime-types": "^2.1.1",
         "@types/node": "^20.0.0",

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -427,7 +427,7 @@ export interface CrawlerExperiments {
  * @category Crawlers
  */
 export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext> {
-    private static readonly CRAWLEE_STATE_KEY = 'CRAWLEE_STATE';
+    protected static readonly CRAWLEE_STATE_KEY = 'CRAWLEE_STATE';
 
     /**
      * A reference to the underlying {@apilink Statistics} class that collects and logs run statistics for requests.

--- a/packages/browser-crawler/package.json
+++ b/packages/browser-crawler/package.json
@@ -59,6 +59,7 @@
         "@crawlee/types": "3.7.3",
         "@crawlee/utils": "3.7.3",
         "ow": "^0.28.1",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.0",
+        "type-fest": "^4.0.0"
     }
 }

--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -786,7 +786,7 @@ export async function browserCrawlerEnqueueLinks({
  * @ignore
  */
 // eslint-disable-next-line @typescript-eslint/ban-types
-async function extractUrlsFromPage(page: { $$eval: Function }, selector: string, baseUrl: string): Promise<string[]> {
+export async function extractUrlsFromPage(page: { $$eval: Function }, selector: string, baseUrl: string): Promise<string[]> {
     const urls = await page.$$eval(selector, (linkEls: HTMLLinkElement[]) => linkEls.map((link) => link.getAttribute('href')).filter((href) => !!href)) ?? [];
     const [base] = await page.$$eval('base', (els: HTMLLinkElement[]) => els.map((el) => el.getAttribute('href')));
     const absoluteBaseUrl = base && tryAbsoluteURL(base, baseUrl);

--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -40,6 +40,7 @@ import { BROWSER_CONTROLLER_EVENTS, BrowserPool } from '@crawlee/browser-pool';
 import type { Cookie as CookieObject } from '@crawlee/types';
 import { CLOUDFLARE_RETRY_CSS_SELECTORS, RETRY_CSS_SELECTORS, sleep } from '@crawlee/utils';
 import ow from 'ow';
+import type { ReadonlyDeep } from 'type-fest';
 
 import type { BrowserLaunchContext } from './browser-launcher';
 
@@ -749,7 +750,7 @@ export abstract class BrowserCrawler<
 
 /** @internal */
 interface EnqueueLinksInternalOptions {
-    options?: EnqueueLinksOptions;
+    options?: ReadonlyDeep<Omit<EnqueueLinksOptions, 'requestQueue'>> & Pick<EnqueueLinksOptions, 'requestQueue'>;
     page: CommonPage;
     requestQueue: RequestProvider;
     originalRequestUrl: string;

--- a/packages/core/src/crawlers/crawler_commons.ts
+++ b/packages/core/src/crawlers/crawler_commons.ts
@@ -9,8 +9,7 @@ import type { Request, Source } from '../request';
 import type { Session } from '../session_pool/session';
 import type { RequestQueueOperationOptions, Dataset, KeyValueStore } from '../storages';
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-export interface RestrictedCrawlingContext<UserData extends Dictionary = Dictionary> extends Record<string & {}, unknown>{
+export interface RestrictedCrawlingContext<UserData extends Dictionary = Dictionary> extends Record<string, unknown>{
     /**
      * The original {@apilink Request} object.
      */

--- a/packages/core/src/crawlers/crawler_commons.ts
+++ b/packages/core/src/crawlers/crawler_commons.ts
@@ -1,13 +1,16 @@
 import type { Dictionary, BatchAddRequestsResult } from '@crawlee/types';
 // @ts-expect-error This throws a compilation error due to got-scraping being ESM only but we only import types, so its alllll gooooood
 import type { Response as GotResponse, OptionsInit } from 'got-scraping';
+import type { ReadonlyDeep } from 'type-fest';
 
+import type { Configuration } from '../configuration';
 import type { EnqueueLinksOptions } from '../enqueue_links/enqueue_links';
 import type { Log } from '../log';
 import type { ProxyInfo } from '../proxy_configuration';
 import type { Request, Source } from '../request';
 import type { Session } from '../session_pool/session';
-import type { RequestQueueOperationOptions, Dataset, KeyValueStore } from '../storages';
+import type { RequestQueueOperationOptions, Dataset, RecordOptions } from '../storages';
+import { KeyValueStore } from '../storages';
 
 export interface RestrictedCrawlingContext<UserData extends Dictionary = Dictionary> extends Record<string, unknown>{
     /**
@@ -22,7 +25,7 @@ export interface RestrictedCrawlingContext<UserData extends Dictionary = Diction
      *
      * @param [data] Data to be pushed to the default dataset.
      */
-    pushData(data: Parameters<Dataset['pushData']>[0], datasetIdOrName?: string): Promise<void>;
+    pushData(data: ReadonlyDeep<Parameters<Dataset['pushData']>[0]>, datasetIdOrName?: string): Promise<void>;
 
     /**
      * This function automatically finds and enqueues links from the current page, adding them to the {@apilink RequestQueue}
@@ -48,7 +51,7 @@ export interface RestrictedCrawlingContext<UserData extends Dictionary = Diction
      *
      * @param [options] All `enqueueLinks()` parameters are passed via an options object.
      */
-    enqueueLinks: (options?: Omit<EnqueueLinksOptions, 'requestQueue'>) => Promise<unknown>;
+    enqueueLinks: (options?: ReadonlyDeep<Omit<EnqueueLinksOptions, 'requestQueue'>>) => Promise<unknown>;
 
     /**
      * Add requests directly to the request queue.
@@ -57,8 +60,8 @@ export interface RestrictedCrawlingContext<UserData extends Dictionary = Diction
      * @param options Options for the request queue
      */
     addRequests: (
-        requestsLike: (string | Source)[],
-        options?: RequestQueueOperationOptions,
+        requestsLike: ReadonlyDeep<(string | Source)[]>,
+        options?: ReadonlyDeep<RequestQueueOperationOptions>,
     ) => Promise<void>;
 
     /**
@@ -114,7 +117,9 @@ export interface CrawlingContext<Crawler = unknown, UserData extends Dictionary 
      * @param [options] All `enqueueLinks()` parameters are passed via an options object.
      * @returns Promise that resolves to {@apilink BatchAddRequestsResult} object.
      */
-    enqueueLinks(options?: EnqueueLinksOptions): Promise<BatchAddRequestsResult>;
+    enqueueLinks(
+        options?: ReadonlyDeep<Omit<EnqueueLinksOptions, 'requestQueue'>> & Pick<EnqueueLinksOptions, 'requestQueue'>
+    ): Promise<BatchAddRequestsResult>;
 
     /**
      * Get a key-value store with given name or id, or the default one for the crawler.
@@ -139,4 +144,134 @@ export interface CrawlingContext<Crawler = unknown, UserData extends Dictionary 
      * ```
      */
     sendRequest<Response = string>(overrideOptions?: Partial<OptionsInit>): Promise<GotResponse<Response>>;
+}
+
+/**
+ * A partial implementation of {@apilink RestrictedCrawlingContext} that stores parameters of calls to context methods for later inspection.
+ */
+export class RequestHandlerResult {
+    private _keyValueStoreChanges: Record<string, Record<string, {changedValue: unknown; options?: RecordOptions}>> = {};
+    private pushDataCalls: Parameters<RestrictedCrawlingContext['pushData']>[] = [];
+    private addRequestsCalls: Parameters<RestrictedCrawlingContext['addRequests']>[] = [];
+    private enqueueLinksCalls: Parameters<RestrictedCrawlingContext['enqueueLinks']>[] = [];
+
+    constructor(private config: Configuration, private crawleeStateKey: string) {}
+
+    /**
+     * A record of calls to {@apilink RestrictedCrawlingContext.pushData}, {@apilink RestrictedCrawlingContext.addRequests}, {@apilink RestrictedCrawlingContext.enqueueLinks} made by a request handler.
+     */
+    get calls(): ReadonlyDeep<{
+        pushData: Parameters<RestrictedCrawlingContext['pushData']>[];
+        addRequests: Parameters<RestrictedCrawlingContext['addRequests']>[];
+        enqueueLinks: Parameters<RestrictedCrawlingContext['enqueueLinks']>[];
+    }> {
+        return { pushData: this.pushDataCalls, addRequests: this.addRequestsCalls, enqueueLinks: this.enqueueLinksCalls };
+    }
+
+    /**
+     * A record of changes made to key-value stores by a request handler.
+     */
+    get keyValueStoreChanges(): ReadonlyDeep<Record<string, Record<string, {changedValue: unknown; options?: RecordOptions}>>> {
+        return this._keyValueStoreChanges;
+    }
+
+    /**
+     * Items added to datasets by a request handler.
+     */
+    get datasetItems(): ReadonlyDeep<{item: Dictionary; datasetIdOrName?: string}[]> {
+        return this.pushDataCalls.flatMap(([data, datasetIdOrName]) => (Array.isArray(data) ? data : [data]).map((item) => ({ item, datasetIdOrName })));
+    }
+
+    /**
+     * URLs enqueued to the request queue by a request handler, either via {@apilink RestrictedCrawlingContext.addRequests} or {@apilink RestrictedCrawlingContext.enqueueLinks}
+     */
+    get enqueuedUrls(): ReadonlyDeep<{url: string; label?: string}[]> {
+        const result: {url: string; label? : string}[] = [];
+
+        for (const [options] of this.enqueueLinksCalls) {
+            result.push(...(options?.urls?.map((url) => ({ url, label: options?.label })) ?? []));
+        }
+
+        for (const [requests] of this.addRequestsCalls) {
+            for (const request of requests) {
+                if (typeof request === 'object' && (!('requestsFromUrl' in request) || request.requestsFromUrl !== undefined) && request.url !== undefined) {
+                    result.push({ url: request.url, label: request.label });
+                } else if (typeof request === 'string') {
+                    result.push({ url: request });
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * URL lists enqueued to the request queue by a request handler via {@apilink RestrictedCrawlingContext.addRequests} using the `requestsFromUrl` option.
+     */
+    get enqueuedUrlLists(): ReadonlyDeep<{listUrl: string; label? : string}[]> {
+        const result: {listUrl: string; label? : string}[] = [];
+
+        for (const [requests] of this.addRequestsCalls) {
+            for (const request of requests) {
+                if (typeof request === 'object' && 'requestsFromUrl' in request && request.requestsFromUrl !== undefined) {
+                    result.push({ listUrl: request.requestsFromUrl, label: request.label });
+                }
+            }
+        }
+
+        return result;
+    }
+
+    pushData: RestrictedCrawlingContext['pushData'] = async (data, datasetIdOrName) => {
+        this.pushDataCalls.push([data, datasetIdOrName]);
+    };
+
+    enqueueLinks: RestrictedCrawlingContext['enqueueLinks'] = async (options) => {
+        this.enqueueLinksCalls.push([options]);
+    };
+
+    addRequests: RestrictedCrawlingContext['addRequests'] = async (requests, options = {}) => {
+        this.addRequestsCalls.push([requests, options]);
+    };
+
+    useState: RestrictedCrawlingContext['useState'] = async (defaultValue) => {
+        const store = await this.getKeyValueStore(undefined);
+        return await store.getAutoSavedValue(this.crawleeStateKey, defaultValue);
+    };
+
+    getKeyValueStore: RestrictedCrawlingContext['getKeyValueStore'] = async (idOrName) => {
+        const store = await KeyValueStore.open(idOrName, { config: this.config });
+
+        return {
+            id: this.idOrDefault(idOrName),
+            name: idOrName,
+            getValue: async (key) => this.getKeyValueStoreChangedValue(idOrName, key) ?? await store.getValue(key),
+            getAutoSavedValue: async <T extends Dictionary = Dictionary>(key: string, defaultValue: T = {} as T) => {
+                let value = this.getKeyValueStoreChangedValue(idOrName, key);
+                if (value === null) {
+                    value = await store.getValue(key) ?? defaultValue;
+                    this.setKeyValueStoreChangedValue(idOrName, key, value);
+                }
+
+                return value as T;
+            },
+            setValue: async (key, value, options) => {
+                this.setKeyValueStoreChangedValue(idOrName, key, value, options);
+            },
+        };
+    };
+
+    private idOrDefault = (idOrName?: string): string => idOrName ?? this.config.get('defaultKeyValueStoreId');
+
+    private getKeyValueStoreChangedValue = (idOrName: string | undefined, key: string) => {
+        const id = this.idOrDefault(idOrName);
+        this._keyValueStoreChanges[id] ??= {};
+        return this.keyValueStoreChanges[id][key]?.changedValue ?? null;
+    };
+
+    private setKeyValueStoreChangedValue = (idOrName: string | undefined, key: string, changedValue: unknown, options?: RecordOptions) => {
+        const id = this.idOrDefault(idOrName);
+        this._keyValueStoreChanges[id] ??= {};
+        this._keyValueStoreChanges[id][key] = { changedValue, options };
+    };
 }

--- a/packages/core/src/crawlers/crawler_commons.ts
+++ b/packages/core/src/crawlers/crawler_commons.ts
@@ -148,6 +148,8 @@ export interface CrawlingContext<Crawler = unknown, UserData extends Dictionary 
 
 /**
  * A partial implementation of {@apilink RestrictedCrawlingContext} that stores parameters of calls to context methods for later inspection.
+ *
+ * @experimental
  */
 export class RequestHandlerResult {
     private _keyValueStoreChanges: Record<string, Record<string, {changedValue: unknown; options?: RecordOptions}>> = {};

--- a/packages/core/src/crawlers/crawler_commons.ts
+++ b/packages/core/src/crawlers/crawler_commons.ts
@@ -152,7 +152,7 @@ export interface CrawlingContext<Crawler = unknown, UserData extends Dictionary 
  * @experimental
  */
 export class RequestHandlerResult {
-    private _keyValueStoreChanges: Record<string, Record<string, {changedValue: unknown; options?: RecordOptions}>> = {};
+    private _keyValueStoreChanges: Record<string, Record<string, { changedValue: unknown; options?: RecordOptions }>> = {};
     private pushDataCalls: Parameters<RestrictedCrawlingContext['pushData']>[] = [];
     private addRequestsCalls: Parameters<RestrictedCrawlingContext['addRequests']>[] = [];
     private enqueueLinksCalls: Parameters<RestrictedCrawlingContext['enqueueLinks']>[] = [];
@@ -173,21 +173,21 @@ export class RequestHandlerResult {
     /**
      * A record of changes made to key-value stores by a request handler.
      */
-    get keyValueStoreChanges(): ReadonlyDeep<Record<string, Record<string, {changedValue: unknown; options?: RecordOptions}>>> {
+    get keyValueStoreChanges(): ReadonlyDeep<Record<string, Record<string, { changedValue: unknown; options?: RecordOptions }>>> {
         return this._keyValueStoreChanges;
     }
 
     /**
      * Items added to datasets by a request handler.
      */
-    get datasetItems(): ReadonlyDeep<{item: Dictionary; datasetIdOrName?: string}[]> {
+    get datasetItems(): ReadonlyDeep<{ item: Dictionary; datasetIdOrName?: string }[]> {
         return this.pushDataCalls.flatMap(([data, datasetIdOrName]) => (Array.isArray(data) ? data : [data]).map((item) => ({ item, datasetIdOrName })));
     }
 
     /**
      * URLs enqueued to the request queue by a request handler, either via {@apilink RestrictedCrawlingContext.addRequests} or {@apilink RestrictedCrawlingContext.enqueueLinks}
      */
-    get enqueuedUrls(): ReadonlyDeep<{url: string; label?: string}[]> {
+    get enqueuedUrls(): ReadonlyDeep<{ url: string; label?: string }[]> {
         const result: {url: string; label? : string}[] = [];
 
         for (const [options] of this.enqueueLinksCalls) {
@@ -210,7 +210,7 @@ export class RequestHandlerResult {
     /**
      * URL lists enqueued to the request queue by a request handler via {@apilink RestrictedCrawlingContext.addRequests} using the `requestsFromUrl` option.
      */
-    get enqueuedUrlLists(): ReadonlyDeep<{listUrl: string; label? : string}[]> {
+    get enqueuedUrlLists(): ReadonlyDeep<{ listUrl: string; label? : string }[]> {
         const result: {listUrl: string; label? : string}[] = [];
 
         for (const [requests] of this.addRequestsCalls) {

--- a/packages/core/src/crawlers/statistics.ts
+++ b/packages/core/src/crawlers/statistics.ts
@@ -93,8 +93,8 @@ export class Statistics {
      */
     private readonly config: Configuration;
 
-    private keyValueStore?: KeyValueStore = undefined;
-    private persistStateKey = `SDK_CRAWLER_STATISTICS_${this.id}`;
+    protected keyValueStore?: KeyValueStore = undefined;
+    protected persistStateKey = `SDK_CRAWLER_STATISTICS_${this.id}`;
     private logIntervalMillis: number;
     private logMessage: string;
     private listener: () => Promise<void>;

--- a/packages/core/src/enqueue_links/enqueue_links.ts
+++ b/packages/core/src/enqueue_links/enqueue_links.ts
@@ -21,7 +21,7 @@ export interface EnqueueLinksOptions extends RequestQueueOperationOptions {
     limit?: number;
 
     /** An array of URLs to enqueue. */
-    urls?: string[];
+    urls?: Readonly<string[]>;
 
     /** A request queue to which the URLs will be enqueued. */
     requestQueue?: RequestProvider;
@@ -60,7 +60,7 @@ export interface EnqueueLinksOptions extends RequestQueueOperationOptions {
      * If `globs` is an empty array or `undefined`, and `regexps` are also not defined, then the function
      * enqueues the links with the same subdomain.
      */
-    globs?: GlobInput[];
+    globs?: Readonly<GlobInput[]>;
 
     /**
      * An array of glob pattern strings, regexp patterns or plain objects
@@ -72,7 +72,7 @@ export interface EnqueueLinksOptions extends RequestQueueOperationOptions {
      * Glob matching is always case-insensitive.
      * If you need case-sensitive matching, provide a regexp.
      */
-    exclude?: (GlobInput | RegExpInput)[];
+    exclude?: Readonly<(GlobInput | RegExpInput)[]>;
 
     /**
      * An array of regular expressions or plain objects
@@ -84,7 +84,7 @@ export interface EnqueueLinksOptions extends RequestQueueOperationOptions {
      * If `regexps` is an empty array or `undefined`, and `globs` are also not defined, then the function
      * enqueues the links with the same subdomain.
      */
-    regexps?: RegExpInput[];
+    regexps?: Readonly<RegExpInput[]>;
 
     /**
      * *NOTE:* In future versions of SDK the options will be removed.
@@ -104,7 +104,7 @@ export interface EnqueueLinksOptions extends RequestQueueOperationOptions {
      *
      * @deprecated prefer using `globs` or `regexps` instead
      */
-    pseudoUrls?: PseudoUrlInput[];
+    pseudoUrls?: Readonly<PseudoUrlInput[]>;
 
     /**
      * Just before a new {@apilink Request} is constructed and enqueued to the {@apilink RequestQueue}, this function can be used

--- a/packages/core/src/enqueue_links/shared.ts
+++ b/packages/core/src/enqueue_links/shared.ts
@@ -52,7 +52,7 @@ export function updateEnqueueLinksPatternCache(item: GlobInput | RegExpInput | P
  * to construct RegExps from PseudoUrl strings.
  * @ignore
  */
-export function constructRegExpObjectsFromPseudoUrls(pseudoUrls: PseudoUrlInput[]): RegExpObject[] {
+export function constructRegExpObjectsFromPseudoUrls(pseudoUrls: Readonly<PseudoUrlInput[]>): RegExpObject[] {
     return pseudoUrls.map((item) => {
         // Get pseudoUrl object from cache.
         let regexpObject = enqueueLinksPatternCache.get(item);
@@ -76,7 +76,7 @@ export function constructRegExpObjectsFromPseudoUrls(pseudoUrls: PseudoUrlInput[
  * to construct Glob objects from Glob pattern strings.
  * @ignore
  */
-export function constructGlobObjectsFromGlobs(globs: GlobInput[]): GlobObject[] {
+export function constructGlobObjectsFromGlobs(globs: Readonly<GlobInput[]>): GlobObject[] {
     return globs
         .filter((glob) => {
             // Skip possibly nullish, empty strings
@@ -126,7 +126,7 @@ export function validateGlobPattern(glob: string): string {
  * to check RegExps input and return valid RegExps.
  * @ignore
  */
-export function constructRegExpObjectsFromRegExps(regexps: RegExpInput[]): RegExpObject[] {
+export function constructRegExpObjectsFromRegExps(regexps: Readonly<RegExpInput[]>): RegExpObject[] {
     return regexps.map((item) => {
         // Get regexp object from cache.
         let regexpObject = enqueueLinksPatternCache.get(item);

--- a/packages/playwright-crawler/package.json
+++ b/packages/playwright-crawler/package.json
@@ -58,6 +58,7 @@
         "@apify/timeout": "^0.3.1",
         "@crawlee/browser": "3.7.3",
         "@crawlee/browser-pool": "3.7.3",
+        "@crawlee/core": "3.7.3",
         "@crawlee/types": "3.7.3",
         "@crawlee/utils": "3.7.3",
         "cheerio": "^1.0.0-rc.12",

--- a/packages/playwright-crawler/package.json
+++ b/packages/playwright-crawler/package.json
@@ -55,6 +55,7 @@
     "dependencies": {
         "@apify/datastructures": "^2.0.0",
         "@apify/log": "^2.4.0",
+        "@apify/timeout": "^0.3.1",
         "@crawlee/browser": "3.7.3",
         "@crawlee/browser-pool": "3.7.3",
         "@crawlee/types": "3.7.3",
@@ -62,8 +63,10 @@
         "cheerio": "^1.0.0-rc.12",
         "idcac-playwright": "^0.1.2",
         "jquery": "^3.6.0",
+        "ml-logistic-regression": "^2.0.0",
         "ow": "^0.28.1",
         "portadom": "^1.0.4",
+        "string-comparison": "^1.3.0",
         "tslib": "^2.4.0"
     },
     "peerDependencies": {

--- a/packages/playwright-crawler/package.json
+++ b/packages/playwright-crawler/package.json
@@ -64,6 +64,7 @@
         "cheerio": "^1.0.0-rc.12",
         "idcac-playwright": "^0.1.2",
         "jquery": "^3.6.0",
+        "lodash.isequal": "^4.5.0",
         "ml-logistic-regression": "^2.0.0",
         "ow": "^0.28.1",
         "portadom": "^1.0.4",

--- a/packages/playwright-crawler/package.json
+++ b/packages/playwright-crawler/package.json
@@ -67,7 +67,6 @@
         "lodash.isequal": "^4.5.0",
         "ml-logistic-regression": "^2.0.0",
         "ow": "^0.28.1",
-        "portadom": "^1.0.4",
         "string-comparison": "^1.3.0",
         "tslib": "^2.4.0"
     },

--- a/packages/playwright-crawler/package.json
+++ b/packages/playwright-crawler/package.json
@@ -63,6 +63,7 @@
         "idcac-playwright": "^0.1.2",
         "jquery": "^3.6.0",
         "ow": "^0.28.1",
+        "portadom": "^1.0.4",
         "tslib": "^2.4.0"
     },
     "peerDependencies": {

--- a/packages/playwright-crawler/src/index.ts
+++ b/packages/playwright-crawler/src/index.ts
@@ -6,3 +6,4 @@ export * from './internals/adaptive-playwright-crawler';
 export * as playwrightUtils from './internals/utils/playwright-utils';
 export * as playwrightClickElements from './internals/enqueue-links/click-elements';
 export type { DirectNavigationOptions as PlaywrightDirectNavigationOptions } from './internals/utils/playwright-utils';
+export type { RenderingType } from './internals/utils/rendering-type-prediction';

--- a/packages/playwright-crawler/src/index.ts
+++ b/packages/playwright-crawler/src/index.ts
@@ -1,6 +1,7 @@
 export * from '@crawlee/browser';
 export * from './internals/playwright-crawler';
 export * from './internals/playwright-launcher';
+export * from './internals/adaptive-playwright-crawler';
 
 export * as playwrightUtils from './internals/utils/playwright-utils';
 export * as playwrightClickElements from './internals/enqueue-links/click-elements';

--- a/packages/playwright-crawler/src/internals/adaptive-playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/adaptive-playwright-crawler.ts
@@ -6,7 +6,6 @@ import type { Awaitable, Dictionary } from '@crawlee/types';
 import { extractUrlsFromCheerio } from '@crawlee/utils';
 import { load, type Cheerio, type Element } from 'cheerio';
 import isEqual from 'lodash.isequal';
-import { cheerioPortadom, playwrightLocatorPortadom, type Portadom } from 'portadom';
 
 import type { PlaywrightCrawlerOptions, PlaywrightCrawlingContext } from './playwright-crawler';
 import { PlaywrightCrawler } from './playwright-crawler';
@@ -15,7 +14,9 @@ import { RenderingTypePredictor, type RenderingType } from './utils/rendering-ty
 type Result<TResult> = {result: TResult; ok: true} | {error: unknown; ok: false}
 
 interface AdaptivePlaywrightCrawlerContext extends RestrictedCrawlingContext {
-    dom: Portadom<unknown, unknown>;
+    /**
+     * Wait for an element matching the selector to appear and return a Cheerio object of matched elements.
+     */
     querySelector: (selector: string, timeoutMs?: number) => Awaitable<Cheerio<Element>>;
 }
 
@@ -180,7 +181,6 @@ export class AdaptivePlaywrightCrawler extends PlaywrightCrawler {
                             return (playwrightContext: PlaywrightCrawlingContext) => this.adaptiveRequestHandler({
                                 request: crawlingContext.request,
                                 log: crawlingContext.log,
-                                dom: playwrightLocatorPortadom(playwrightContext.page.locator(':root'), playwrightContext.page) as Portadom<unknown, unknown>,
                                 querySelector: async (selector, timeoutMs) => {
                                     const locator = playwrightContext.page.locator(selector).first();
                                     await locator.waitFor({ timeout: timeoutMs });
@@ -229,7 +229,6 @@ export class AdaptivePlaywrightCrawler extends PlaywrightCrawler {
                     this.adaptiveRequestHandler({
                         request: crawlingContext.request,
                         log: crawlingContext.log,
-                        dom: cheerioPortadom($.root(), response.url) as Portadom<unknown, unknown>,
                         querySelector: (selector) => $(selector) as Cheerio<Element>,
                         enqueueLinks: async (options: Parameters<RestrictedCrawlingContext['enqueueLinks']>[0] = {}) => {
                             const urls = extractUrlsFromCheerio($, options.selector, options.baseUrl ?? loadedUrl);

--- a/packages/playwright-crawler/src/internals/adaptive-playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/adaptive-playwright-crawler.ts
@@ -10,7 +10,7 @@ import { cheerioPortadom, playwrightLocatorPortadom, type CheerioPortadom, type 
 
 import type { PlaywrightCrawlerOptions, PlaywrightCrawlingContext } from './playwright-crawler';
 import { PlaywrightCrawler } from './playwright-crawler';
-import { RenderingTypePredictor, type RenderingType } from './rendering-type-prediction';
+import { RenderingTypePredictor, type RenderingType } from './utils/rendering-type-prediction';
 
 type Result<TResult> = {result: TResult; ok: true} | {error: unknown; ok: false}
 

--- a/packages/playwright-crawler/src/internals/adaptive-playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/adaptive-playwright-crawler.ts
@@ -157,7 +157,7 @@ export class AdaptivePlaywrightCrawler extends PlaywrightCrawler {
     protected override async _runRequestHandler(crawlingContext: PlaywrightCrawlingContext<Dictionary>): Promise<void> {
         const url = new URL(crawlingContext.request.loadedUrl ?? crawlingContext.request.url);
 
-        const renderingTypePrediction = this.renderingTypePredictor.predict(url);
+        const renderingTypePrediction = this.renderingTypePredictor.predict(url, crawlingContext.request.label);
         const shouldDetectRenderingType = Math.random() < renderingTypePrediction.detectionProbabilityRecommendation;
 
         if (!shouldDetectRenderingType) {
@@ -204,7 +204,7 @@ export class AdaptivePlaywrightCrawler extends PlaywrightCrawler {
             })();
 
             crawlingContext.log.info(`Detected rendering type ${detectionResult} for ${crawlingContext.request.url}`);
-            this.renderingTypePredictor.storeResult(url, detectionResult);
+            this.renderingTypePredictor.storeResult(url, crawlingContext.request.label, detectionResult);
         }
     }
 

--- a/packages/playwright-crawler/src/internals/adaptive-playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/adaptive-playwright-crawler.ts
@@ -61,7 +61,31 @@ export interface AdaptivePlaywrightCrawlerOptions extends Omit<PlaywrightCrawler
 }
 
 /**
- * An extension of {@apilink PlaywrightCrawler} that uses a more limited interface so that it is able to switch to HTTP-only crawling when it detects it may be possible.
+ * An extension of {@apilink PlaywrightCrawler} that uses a more limited request handler interface so that it is able to switch to HTTP-only crawling when it detects it may be possible.
+ *
+ * **Example usage:**
+ *
+ * ```javascript
+ * const crawler = new AdaptivePlaywrightCrawler({
+ *     renderingTypeDetectionRatio: 0.1,
+ *     async requestHandler({ querySelector, pushData, enqueueLinks, request, log }) {
+ *         // This function is called to extract data from a single web page
+ *         const $prices = await querySelector('span.price')
+ *
+ *         await pushData({
+ *             url: request.url,
+ *             price: $prices.filter(':contains("$")').first().text(),
+ *         })
+ *
+ *         await enqueueLinks({ selector: '.pagination a' })
+ *     },
+ * });
+ *
+ * await crawler.run([
+ *     'http://www.example.com/page-1',
+ *     'http://www.example.com/page-2',
+ * ]);
+ * ```
  *
  * @experimental
  */

--- a/packages/playwright-crawler/src/internals/adaptive-playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/adaptive-playwright-crawler.ts
@@ -52,6 +52,11 @@ interface AdaptivePlaywrightCrawlerOptions extends Omit<PlaywrightCrawlerOptions
      * If neither `resultComparator` nor `resultChecker` are specified, a deep comparison of returned dataset items is used as a default.
      */
     resultComparator?: (resultA: RequestHandlerResult, resultB: RequestHandlerResult) => boolean;
+
+    /**
+     * A custom rendering type predictor
+     */
+    renderingTypePredictor?: Pick<RenderingTypePredictor, 'predict' | 'storeResult'>;
 }
 
 /**
@@ -59,14 +64,23 @@ interface AdaptivePlaywrightCrawlerOptions extends Omit<PlaywrightCrawlerOptions
  */
 export class AdaptivePlaywrightCrawler extends PlaywrightCrawler {
     private adaptiveRequestHandler: AdaptivePlaywrightCrawlerOptions['requestHandler'];
-    private renderingTypePredictor: RenderingTypePredictor;
+    private renderingTypePredictor: NonNullable<AdaptivePlaywrightCrawlerOptions['renderingTypePredictor']>;
     private resultChecker: NonNullable<AdaptivePlaywrightCrawlerOptions['resultChecker']>;
     private resultComparator: NonNullable<AdaptivePlaywrightCrawlerOptions['resultComparator']>;
 
-    constructor({ requestHandler, renderingTypeDetectionRatio, resultChecker, resultComparator, ...options }: AdaptivePlaywrightCrawlerOptions) {
+    constructor(
+        {
+            requestHandler,
+            renderingTypeDetectionRatio,
+            renderingTypePredictor,
+            resultChecker,
+            resultComparator,
+            ...options
+        }: AdaptivePlaywrightCrawlerOptions,
+    ) {
         super(options);
         this.adaptiveRequestHandler = requestHandler;
-        this.renderingTypePredictor = new RenderingTypePredictor({ detectionRatio: renderingTypeDetectionRatio });
+        this.renderingTypePredictor = renderingTypePredictor ?? new RenderingTypePredictor({ detectionRatio: renderingTypeDetectionRatio });
         this.resultChecker = resultChecker ?? (() => true);
 
         if (resultComparator !== undefined) {

--- a/packages/playwright-crawler/src/internals/adaptive-playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/adaptive-playwright-crawler.ts
@@ -227,21 +227,19 @@ export class AdaptivePlaywrightCrawler extends PlaywrightCrawler {
 
         try {
             await addTimeoutToPromise(
-                async () => Promise.resolve(
-                    this.adaptiveRequestHandler({
-                        request: crawlingContext.request,
-                        log: crawlingContext.log,
-                        querySelector: (selector) => $(selector) as Cheerio<Element>,
-                        enqueueLinks: async (options: Parameters<RestrictedCrawlingContext['enqueueLinks']>[0] = {}) => {
-                            const urls = extractUrlsFromCheerio($, options.selector, options.baseUrl ?? loadedUrl);
-                            await result.enqueueLinks({ ...options, urls });
-                        },
-                        addRequests: result.addRequests,
-                        pushData: result.pushData,
-                        useState: result.useState,
-                        getKeyValueStore: result.getKeyValueStore,
-                    }),
-                ),
+                async () => this.adaptiveRequestHandler({
+                    request: crawlingContext.request,
+                    log: crawlingContext.log,
+                    querySelector: (selector) => $(selector) as Cheerio<Element>,
+                    enqueueLinks: async (options: Parameters<RestrictedCrawlingContext['enqueueLinks']>[0] = {}) => {
+                        const urls = extractUrlsFromCheerio($, options.selector, options.baseUrl ?? loadedUrl);
+                        await result.enqueueLinks({ ...options, urls });
+                    },
+                    addRequests: result.addRequests,
+                    pushData: result.pushData,
+                    useState: result.useState,
+                    getKeyValueStore: result.getKeyValueStore,
+                }),
                 this.requestHandlerTimeoutInnerMillis,
                 'Request handler timed out',
             );

--- a/packages/playwright-crawler/src/internals/adaptive-playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/adaptive-playwright-crawler.ts
@@ -19,7 +19,7 @@ interface AdaptivePlaywrightCrawlerContext extends RestrictedCrawlingContext {
     querySelector: (selector: string, timeoutMs?: number) => Awaitable<Cheerio<Element>>;
 }
 
-interface AdaptivePlaywrightCrawlerOptions extends Omit<PlaywrightCrawlerOptions, 'requestHandler'> {
+export interface AdaptivePlaywrightCrawlerOptions extends Omit<PlaywrightCrawlerOptions, 'requestHandler'> {
     /**
      * Function that is called to process each request.
      *
@@ -187,9 +187,13 @@ export class AdaptivePlaywrightCrawler extends PlaywrightCrawler {
                                     return (await playwrightContext.parseWithCheerio())(selector) as Cheerio<Element>;
                                 },
                                 enqueueLinks: async (options = {}) => {
+                                    const selector = options.selector ?? 'a';
+                                    const locator = playwrightContext.page.locator(selector).first();
+                                    await locator.waitFor();
+
                                     const urls = await extractUrlsFromPage(
                                         playwrightContext.page,
-                                        options.selector ?? 'a',
+                                        selector,
                                         options.baseUrl ?? playwrightContext.request.loadedUrl ?? playwrightContext.request.url,
                                     );
                                     await result.enqueueLinks({ ...options, urls });

--- a/packages/playwright-crawler/src/internals/adaptive-playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/adaptive-playwright-crawler.ts
@@ -71,7 +71,7 @@ interface AdaptivePlaywrightCrawlerContext extends RestrictedCrawlingContext {
     querySelector: (selector: string, timeoutMs?: number) => Awaitable<Cheerio<Element>>;
 }
 
-export interface AdaptivePlaywrightCrawlerOptions extends Omit<PlaywrightCrawlerOptions, 'requestHandler'> {
+export interface AdaptivePlaywrightCrawlerOptions extends Omit<PlaywrightCrawlerOptions, 'requestHandler' | 'handlePageFunction'> {
     /**
      * Function that is called to process each request.
      *

--- a/packages/playwright-crawler/src/internals/adaptive-playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/adaptive-playwright-crawler.ts
@@ -1,4 +1,8 @@
 import { addTimeoutToPromise } from '@apify/timeout';
+import { BasicCrawler } from '@crawlee/basic';
+import type { Source, Configuration, RecordOptions, RestrictedCrawlingContext } from '@crawlee/core';
+import { KeyValueStore } from '@crawlee/core';
+import type { Awaitable, Dictionary } from '@crawlee/types';
 import { extractUrlsFromCheerio } from '@crawlee/utils';
 import type { Cheerio, Document } from 'cheerio';
 import { load } from 'cheerio';
@@ -7,8 +11,6 @@ import { cheerioPortadom, playwrightLocatorPortadom, type CheerioPortadom, type 
 import type { PlaywrightCrawlerOptions, PlaywrightCrawlingContext } from './playwright-crawler';
 import { PlaywrightCrawler } from './playwright-crawler';
 import { RenderingTypePredictor, type RenderingType } from './rendering-type-prediction';
-import type { Source, Awaitable, Dictionary, RestrictedCrawlingContext, Configuration, RecordOptions } from '..';
-import { BasicCrawler, KeyValueStore } from '..';
 
 type Result<TResult> = NonNullable<{result: TResult; ok: true} | {error: unknown; ok: false}>
 
@@ -181,7 +183,7 @@ export class AdaptivePlaywrightCrawler extends PlaywrightCrawler {
             ...Object.entries(keyValueStoreChanges).map(async ([storeIdOrName, changes]) => {
                 const store = await crawlingContext.getKeyValueStore(storeIdOrName);
                 await Promise.all(
-                    Object.entries(changes).map(async ([key, { changedValue, options }]) => store.setValue(key, changedValue, options))
+                    Object.entries(changes).map(async ([key, { changedValue, options }]) => store.setValue(key, changedValue, options)),
                 );
             }),
         ]);

--- a/packages/playwright-crawler/src/internals/adaptive-playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/adaptive-playwright-crawler.ts
@@ -201,7 +201,8 @@ export class AdaptivePlaywrightCrawler extends PlaywrightCrawler {
         const result = new RequestHandlerResult(this.config, AdaptivePlaywrightCrawler.CRAWLEE_STATE_KEY);
 
         const response = await crawlingContext.sendRequest({});
-        const loadedUrl = crawlingContext.request.loadedUrl = response.url;
+        const loadedUrl = response.url;
+        crawlingContext.request.loadedUrl = loadedUrl;
         const $ = load(response.body);
 
         try {

--- a/packages/playwright-crawler/src/internals/adaptive-playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/adaptive-playwright-crawler.ts
@@ -1,0 +1,71 @@
+import { playwrightLocatorPortadom, type CheerioPortadom, type PlaywrightLocatorPortadom } from 'portadom';
+
+import type { PlaywrightCrawlerOptions, PlaywrightCrawlingContext } from './playwright-crawler';
+import { PlaywrightCrawler } from './playwright-crawler';
+import type { Awaitable, Dictionary, RestrictedCrawlingContext } from '..';
+
+interface AdaptivePlaywrightCrawlerContext extends RestrictedCrawlingContext {
+    dom: CheerioPortadom | PlaywrightLocatorPortadom;
+}
+
+interface AdaptivePlaywrightCrawlerOptions extends Omit<PlaywrightCrawlerOptions, 'requestHandler'> {
+    requestHandler: (crawlingContext: AdaptivePlaywrightCrawlerContext) => Awaitable<void>;
+}
+
+class RequestHandlerResult {
+    pushData: RestrictedCrawlingContext['pushData'] = async (data, datasetIdOrName) => {
+
+    }
+    enqueueLinks: RestrictedCrawlingContext['enqueueLinks'] = async (options) => {
+
+    }
+    addRequests: RestrictedCrawlingContext['addRequests'] = async (requests, options) => {
+
+    }
+    useState: RestrictedCrawlingContext['useState'] = async (defaultValue) => {
+
+    }
+    getKeyValueStore: RestrictedCrawlingContext['getKeyValueStore'] = async (idOrName) => {
+        return {
+            id: idOrName,
+            name: idOrName,
+            getValue: (key) => {},
+            getAutoSavedValue: (key, defaultValue) => {},
+            setValue: (key, value, options) => {
+
+            },
+        }
+    }
+}
+
+export class AdaptivePlaywrightCrawler extends PlaywrightCrawler {
+    private _requestHandler: AdaptivePlaywrightCrawlerOptions['requestHandler'];
+
+    constructor({ requestHandler, ...options }: AdaptivePlaywrightCrawlerOptions) {
+        super({
+            ...options,
+            requestHandler: async (context) => {
+                await this._requestHandler({ ...context, dom: playwrightLocatorPortadom(context.page.locator(':root'), context.page) });
+            }
+        });
+        this._requestHandler = requestHandler;
+    }
+
+    protected override async _runRequestHandler(context: PlaywrightCrawlingContext<Dictionary>): Promise<void> {
+        let shouldDetectRenderingType = false
+        let renderingType: 'static' | 'clientOnly' = 'static'
+
+    }
+
+    protected async commitResult(context: PlaywrightCrawlingContext<Dictionary>, result: RequestHandlerResult): Promise<void> {
+
+    }
+
+    protected async runRequestHandlerInBrowser(context: PlaywrightCrawlingContext<Dictionary>): Promise<RequestHandlerResult> {
+
+    }
+
+    protected async runRequestHandlerWithPlainHTTP(context: PlaywrightCrawlingContext<Dictionary>): Promise<RequestHandlerResult> {
+
+    }
+}

--- a/packages/playwright-crawler/src/internals/adaptive-playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/adaptive-playwright-crawler.ts
@@ -62,6 +62,8 @@ export interface AdaptivePlaywrightCrawlerOptions extends Omit<PlaywrightCrawler
 
 /**
  * An extension of {@apilink PlaywrightCrawler} that uses a more limited interface so that it is able to switch to HTTP-only crawling when it detects it may be possible.
+ *
+ * @experimental
  */
 export class AdaptivePlaywrightCrawler extends PlaywrightCrawler {
     private adaptiveRequestHandler: AdaptivePlaywrightCrawlerOptions['requestHandler'];

--- a/packages/playwright-crawler/src/internals/adaptive-playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/adaptive-playwright-crawler.ts
@@ -1,30 +1,33 @@
-import { playwrightLocatorPortadom, type CheerioPortadom, type PlaywrightLocatorPortadom } from 'portadom';
+import { addTimeoutToPromise } from '@apify/timeout';
+import { extractUrlsFromCheerio } from '@crawlee/utils';
+import type { Cheerio, Document } from 'cheerio';
+import { load } from 'cheerio';
+import { cheerioPortadom, playwrightLocatorPortadom, type CheerioPortadom, type PlaywrightLocatorPortadom } from 'portadom';
 
 import type { PlaywrightCrawlerOptions, PlaywrightCrawlingContext } from './playwright-crawler';
 import { PlaywrightCrawler } from './playwright-crawler';
+import { RenderingTypePredictor, type RenderingType } from './rendering-type-prediction';
 import type { Awaitable, Dictionary, RestrictedCrawlingContext } from '..';
 
-interface AdaptivePlaywrightCrawlerContext extends RestrictedCrawlingContext {
-    dom: CheerioPortadom | PlaywrightLocatorPortadom;
-}
-
-interface AdaptivePlaywrightCrawlerOptions extends Omit<PlaywrightCrawlerOptions, 'requestHandler'> {
-    requestHandler: (crawlingContext: AdaptivePlaywrightCrawlerContext) => Awaitable<void>;
-}
+type Result<TResult> = NonNullable<{result: TResult; ok: true} | {error: unknown; ok: false}>
 
 class RequestHandlerResult {
     pushData: RestrictedCrawlingContext['pushData'] = async (data, datasetIdOrName) => {
 
-    }
+    };
+
     enqueueLinks: RestrictedCrawlingContext['enqueueLinks'] = async (options) => {
 
-    }
+    };
+
     addRequests: RestrictedCrawlingContext['addRequests'] = async (requests, options) => {
 
-    }
+    };
+
     useState: RestrictedCrawlingContext['useState'] = async (defaultValue) => {
 
-    }
+    };
+
     getKeyValueStore: RestrictedCrawlingContext['getKeyValueStore'] = async (idOrName) => {
         return {
             id: idOrName,
@@ -34,38 +37,146 @@ class RequestHandlerResult {
             setValue: (key, value, options) => {
 
             },
-        }
-    }
+        };
+    };
+}
+
+interface AdaptivePlaywrightCrawlerContext extends RestrictedCrawlingContext {
+    dom: CheerioPortadom<Cheerio<Document>> | PlaywrightLocatorPortadom;
+}
+
+interface AdaptivePlaywrightCrawlerOptions extends Omit<PlaywrightCrawlerOptions, 'requestHandler'> {
+    requestHandler: (crawlingContext: AdaptivePlaywrightCrawlerContext) => Awaitable<void>;
+    renderingTypeDetectionRatio: number;
+    resultChecker?: (result: RequestHandlerResult) => boolean;
+    resultComparator?: (resultA: RequestHandlerResult, resultB: RequestHandlerResult) => boolean;
 }
 
 export class AdaptivePlaywrightCrawler extends PlaywrightCrawler {
     private _requestHandler: AdaptivePlaywrightCrawlerOptions['requestHandler'];
+    private renderingTypePredictor: RenderingTypePredictor;
+    private resultChecker: NonNullable<AdaptivePlaywrightCrawlerOptions['resultChecker']>;
+    private resultComparator: NonNullable<AdaptivePlaywrightCrawlerOptions['resultComparator']>;
 
-    constructor({ requestHandler, ...options }: AdaptivePlaywrightCrawlerOptions) {
+    constructor({ requestHandler, renderingTypeDetectionRatio, resultChecker, resultComparator, ...options }: AdaptivePlaywrightCrawlerOptions) {
         super({
             ...options,
             requestHandler: async (context) => {
                 await this._requestHandler({ ...context, dom: playwrightLocatorPortadom(context.page.locator(':root'), context.page) });
-            }
+            },
         });
         this._requestHandler = requestHandler;
+        this.renderingTypePredictor = new RenderingTypePredictor({ detectionRatio: renderingTypeDetectionRatio });
+        this.resultChecker = resultChecker ?? (() => true);
+        this.resultComparator = resultComparator ?? (() => true); // TODO
     }
 
-    protected override async _runRequestHandler(context: PlaywrightCrawlingContext<Dictionary>): Promise<void> {
-        let shouldDetectRenderingType = false
-        let renderingType: 'static' | 'clientOnly' = 'static'
+    protected override async _runRequestHandler(crawlingContext: PlaywrightCrawlingContext<Dictionary>): Promise<void> {
+        const url = new URL(crawlingContext.request.loadedUrl ?? crawlingContext.request.url);
+
+        const renderingTypePrediction = this.renderingTypePredictor.predict(url);
+        const shouldDetectRenderingType = Math.random() < renderingTypePrediction.detectionProbabilityRecommendation;
+
+        if (!shouldDetectRenderingType) {
+            crawlingContext.log.info(`Predicted rendering type ${renderingTypePrediction} for ${crawlingContext.request.url}`);
+        }
+
+        if (renderingTypePrediction.renderingType === 'static' || !shouldDetectRenderingType) {
+            crawlingContext.log.info(`Running HTTP-only request handler for ${crawlingContext.request.url}`);
+
+            const plainHTTPRun = await this.runRequestHandlerWithPlainHTTP(crawlingContext);
+
+            if (plainHTTPRun.ok && this.resultChecker(plainHTTPRun.result)) {
+                crawlingContext.log.info(`HTTP-only request handler succeeded for ${crawlingContext.request.url}`);
+                await this.commitResult(crawlingContext, plainHTTPRun.result);
+                return;
+            } if (!plainHTTPRun.ok) {
+                crawlingContext.log.exception(plainHTTPRun.error as Error, `HTTP-only request handler failed for ${crawlingContext.request.url}`);
+            } else {
+                crawlingContext.log.warning(`HTTP-only request handler returned a suspicious result for ${crawlingContext.request.url}`);
+            }
+        }
+
+        crawlingContext.log.info(`Running browser request handler for ${crawlingContext.request.url}`);
+        const browserRun = await this.runRequestHandlerInBrowser(crawlingContext);
+        if (!browserRun.ok) {
+            throw browserRun.error;
+        }
+        await this.commitResult(crawlingContext, browserRun.result);
+
+        if (shouldDetectRenderingType) {
+            const plainHTTPRun = await this.runRequestHandlerWithPlainHTTP(crawlingContext);
+
+            const detectionResult: RenderingType = (() => {
+                if (!plainHTTPRun.ok) {
+                    return 'clientOnly';
+                }
+
+                if (this.resultComparator(plainHTTPRun.result, browserRun.result)) {
+                    return 'static';
+                }
+
+                return 'clientOnly';
+            })();
+
+            crawlingContext.log.info(`Detected rendering type ${detectionResult} for ${crawlingContext.request.url}`);
+            this.renderingTypePredictor.storeResult(url, detectionResult);
+        }
+    }
+
+    protected async commitResult(crawlingContext: PlaywrightCrawlingContext<Dictionary>, result: RequestHandlerResult): Promise<void> {
 
     }
 
-    protected async commitResult(context: PlaywrightCrawlingContext<Dictionary>, result: RequestHandlerResult): Promise<void> {
-
+    protected async runRequestHandlerInBrowser(crawlingContext: PlaywrightCrawlingContext<Dictionary>): Promise<Result<RequestHandlerResult>> {
+        const result = new RequestHandlerResult();
+        const instrumentedContext = {
+            ...crawlingContext,
+            pushData: result.pushData,
+            enqueueLinks: result.enqueueLinks,
+            addRequests: result.addRequests,
+            useState: result.useState,
+            getKeyValueStore: result.getKeyValueStore,
+        };
+        try {
+            await (super._runRequestHandler as (context: RestrictedCrawlingContext) => Promise<void>)(instrumentedContext);
+            return { result, ok: true };
+        } catch (error) {
+            return { error, ok: false };
+        }
     }
 
-    protected async runRequestHandlerInBrowser(context: PlaywrightCrawlingContext<Dictionary>): Promise<RequestHandlerResult> {
+    protected async runRequestHandlerWithPlainHTTP(crawlingContext: PlaywrightCrawlingContext<Dictionary>): Promise<Result<RequestHandlerResult>> {
+        const result = new RequestHandlerResult();
 
-    }
+        const response = await crawlingContext.sendRequest({});
+        const loadedUrl = response.url;
+        const $ = load(response.body);
 
-    protected async runRequestHandlerWithPlainHTTP(context: PlaywrightCrawlingContext<Dictionary>): Promise<RequestHandlerResult> {
+        try {
+            await addTimeoutToPromise(
+                async () => Promise.resolve(
+                    this._requestHandler({
+                        request: { ...crawlingContext.request, loadedUrl } as any,
+                        log: crawlingContext.log,
+                        dom: cheerioPortadom($.root(), response.url),
+                        enqueueLinks: async (options: Parameters<RestrictedCrawlingContext['enqueueLinks']>[0] = {}) => {
+                            const urls = extractUrlsFromCheerio($, options.selector, loadedUrl);
+                            await result.enqueueLinks({ ...options, urls });
+                        },
+                        addRequests: result.addRequests,
+                        pushData: result.pushData,
+                        useState: result.useState,
+                        getKeyValueStore: result.getKeyValueStore,
+                    }),
+                ),
+                this.requestHandlerTimeoutInnerMillis,
+                'Request handler timed out',
+            );
 
+            return { result, ok: true };
+        } catch (error) {
+            return { error, ok: false };
+        }
     }
 }

--- a/packages/playwright-crawler/src/internals/rendering-type-prediction.ts
+++ b/packages/playwright-crawler/src/internals/rendering-type-prediction.ts
@@ -36,7 +36,7 @@ export class RenderingTypePredictor {
 
     constructor({ detectionRatio }: { detectionRatio: number }) {
         this.detectionRatio = detectionRatio;
-        this.logreg = new LogisticRegression({ numSteps: 1000, learningRate: 5e-2 });
+        this.logreg = new LogisticRegression({ numSteps: 1000, learningRate: 0.05 });
     }
 
     public predict(url: URL): { renderingType: RenderingType; detectionProbabilityRecommendation: number } {

--- a/packages/playwright-crawler/src/internals/rendering-type-prediction.ts
+++ b/packages/playwright-crawler/src/internals/rendering-type-prediction.ts
@@ -30,7 +30,7 @@ const mean = (values: number[]) => (values.length > 0 ? sum(values) / values.len
 type FeatureVector = [staticResultsSimilarity: number, clientOnlyResultsSimilarity: number];
 
 export class RenderingTypePredictor {
-    private renderingTypeDetectionResults = new Map<RenderingType, URLComponents[]>();
+    private renderingTypeDetectionResults = new Map<RenderingType, Map<string | undefined, URLComponents[]>>();
     private detectionRatio: number;
     private logreg: LogisticRegression;
 
@@ -39,40 +39,44 @@ export class RenderingTypePredictor {
         this.logreg = new LogisticRegression({ numSteps: 1000, learningRate: 0.05 });
     }
 
-    public predict(url: URL): { renderingType: RenderingType; detectionProbabilityRecommendation: number } {
+    public predict(url: URL, label: string | undefined): { renderingType: RenderingType; detectionProbabilityRecommendation: number } {
         if (this.logreg.classifiers.length === 0) {
             return { renderingType: 'clientOnly', detectionProbabilityRecommendation: 1 };
         }
 
-        const urlFeature = new Matrix([this.calculateFeatureVector(urlComponents(url))]);
+        const urlFeature = new Matrix([this.calculateFeatureVector(urlComponents(url), label)]);
         const [prediction] = this.logreg.predict(urlFeature);
         const scores = [this.logreg.classifiers[0].testScores(urlFeature), this.logreg.classifiers[1].testScores(urlFeature)];
 
         return {
             renderingType: prediction === 1 ? 'static' : 'clientOnly',
-            detectionProbabilityRecommendation: Math.abs(scores[0] - scores[1]) < 0.1 ? 1 : this.detectionRatio * Math.max(1, 5 - this.resultCount),
+            detectionProbabilityRecommendation: Math.abs(scores[0] - scores[1]) < 0.1 ? 1 : this.detectionRatio * Math.max(1, 5 - this.resultCount(label)),
         };
     }
 
-    public storeResult(url: URL, renderingType: RenderingType) {
+    public storeResult(url: URL, label: string | undefined, renderingType: RenderingType) {
         if (!this.renderingTypeDetectionResults.has(renderingType)) {
-            this.renderingTypeDetectionResults.set(renderingType, []);
+            this.renderingTypeDetectionResults.set(renderingType, new Map());
         }
 
-    this.renderingTypeDetectionResults.get(renderingType)!.push(urlComponents(url));
-    this.retrain();
+        if (!this.renderingTypeDetectionResults.get(renderingType)!.has(label)) {
+            this.renderingTypeDetectionResults.get(renderingType)!.set(label, []);
+        }
+
+        this.renderingTypeDetectionResults.get(renderingType)!.get(label)!.push(urlComponents(url));
+        this.retrain();
     }
 
-    public get resultCount(): number {
+    private resultCount(label: string | undefined): number {
         return Array.from(this.renderingTypeDetectionResults.values())
-            .map((results) => results.length)
+            .map((results) => results.get(label)?.length ?? 0)
             .reduce((acc, value) => acc + value, 0);
     }
 
-    protected calculateFeatureVector(url: URLComponents): FeatureVector {
+    protected calculateFeatureVector(url: URLComponents, label: string | undefined): FeatureVector {
         return [
-            mean((this.renderingTypeDetectionResults.get('static') ?? []).map((otherUrl) => calculateUrlSimilarity(url, otherUrl) ?? 0)) ?? 0,
-            mean((this.renderingTypeDetectionResults.get('clientOnly') ?? []).map((otherUrl) => calculateUrlSimilarity(url, otherUrl) ?? 0)) ?? 0,
+            mean((this.renderingTypeDetectionResults.get('static')?.get(label) ?? []).map((otherUrl) => calculateUrlSimilarity(url, otherUrl) ?? 0)) ?? 0,
+            mean((this.renderingTypeDetectionResults.get('clientOnly')?.get(label) ?? []).map((otherUrl) => calculateUrlSimilarity(url, otherUrl) ?? 0)) ?? 0,
         ];
     }
 
@@ -83,10 +87,12 @@ export class RenderingTypePredictor {
         ];
         const Y: number[] = [0, 1];
 
-        for (const [renderingType, urls] of this.renderingTypeDetectionResults.entries()) {
-            for (const url of urls) {
-                X.push(this.calculateFeatureVector(url));
-                Y.push(renderingType === 'static' ? 1 : 0);
+        for (const [renderingType, urlsByLabel] of this.renderingTypeDetectionResults.entries()) {
+            for (const [label, urls] of urlsByLabel) {
+                for (const url of urls) {
+                    X.push(this.calculateFeatureVector(url, label));
+                    Y.push(renderingType === 'static' ? 1 : 0);
+                }
             }
         }
 

--- a/packages/playwright-crawler/src/internals/rendering-type-prediction.ts
+++ b/packages/playwright-crawler/src/internals/rendering-type-prediction.ts
@@ -1,0 +1,95 @@
+import LogisticRegression from 'ml-logistic-regression';
+import { Matrix } from 'ml-matrix';
+import stringComparison from 'string-comparison';
+
+export type RenderingType = 'clientOnly' | 'static'
+
+type URLComponents = string[];
+
+const urlComponents = (url: URL): URLComponents => {
+    return [url.hostname, ...url.pathname.split('/')];
+};
+
+const calculateUrlSimilarity = (a: URLComponents, b: URLComponents): number | undefined => {
+    const values: number[] = [];
+
+    if (a[0] !== b[0]) {
+        return 0;
+    }
+
+    for (let i = 1; i < Math.max(a.length, b.length); i++) {
+        values.push(stringComparison.jaroWinkler.similarity(a[i] ?? '', b[i] ?? '') > 0.8 ? 1 : 0);
+    }
+
+    return sum(values) / Math.max(a.length, b.length);
+};
+
+const sum = (values: number[]) => values.reduce((acc, value) => acc + value);
+const mean = (values: number[]) => (values.length > 0 ? sum(values) / values.length : undefined);
+
+type FeatureVector = [staticResultsSimilarity: number, clientOnlyResultsSimilarity: number];
+
+export class RenderingTypePredictor {
+    private renderingTypeDetectionResults = new Map<RenderingType, URLComponents[]>();
+    private detectionRatio: number;
+    private logreg: LogisticRegression;
+
+    constructor({ detectionRatio }: { detectionRatio: number }) {
+        this.detectionRatio = detectionRatio;
+        this.logreg = new LogisticRegression({ numSteps: 1000, learningRate: 5e-2 });
+    }
+
+    public predict(url: URL): { renderingType: RenderingType; detectionProbabilityRecommendation: number } {
+        if (this.logreg.classifiers.length === 0) {
+            return { renderingType: 'clientOnly', detectionProbabilityRecommendation: 1 };
+        }
+
+        const urlFeature = new Matrix([this.calculateFeatureVector(urlComponents(url))]);
+        const [prediction] = this.logreg.predict(urlFeature);
+        const scores = [this.logreg.classifiers[0].testScores(urlFeature), this.logreg.classifiers[1].testScores(urlFeature)];
+
+        return {
+            renderingType: prediction === 1 ? 'static' : 'clientOnly',
+            detectionProbabilityRecommendation: Math.abs(scores[0] - scores[1]) < 0.1 ? 1 : this.detectionRatio * Math.max(1, 5 - this.resultCount),
+        };
+    }
+
+    public storeResult(url: URL, renderingType: RenderingType) {
+        if (!this.renderingTypeDetectionResults.has(renderingType)) {
+            this.renderingTypeDetectionResults.set(renderingType, []);
+        }
+
+    this.renderingTypeDetectionResults.get(renderingType)!.push(urlComponents(url));
+    this.retrain();
+    }
+
+    public get resultCount(): number {
+        return Array.from(this.renderingTypeDetectionResults.values())
+            .map((results) => results.length)
+            .reduce((acc, value) => acc + value, 0);
+    }
+
+    protected calculateFeatureVector(url: URLComponents): FeatureVector {
+        return [
+            mean((this.renderingTypeDetectionResults.get('static') ?? []).map((otherUrl) => calculateUrlSimilarity(url, otherUrl) ?? 0)) ?? 0,
+            mean((this.renderingTypeDetectionResults.get('clientOnly') ?? []).map((otherUrl) => calculateUrlSimilarity(url, otherUrl) ?? 0)) ?? 0,
+        ];
+    }
+
+    protected retrain(): void {
+        const X: FeatureVector[] = [
+            [0, 1],
+            [1, 0],
+        ];
+        const Y: number[] = [0, 1];
+
+        for (const [renderingType, urls] of this.renderingTypeDetectionResults.entries()) {
+            for (const url of urls) {
+                X.push(this.calculateFeatureVector(url));
+                Y.push(renderingType === 'static' ? 1 : 0);
+            }
+        }
+
+        this.logreg.train(new Matrix(X), Matrix.columnVector(Y));
+    }
+}

--- a/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
+++ b/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
@@ -32,6 +32,7 @@ import { getInjectableScript as getCookieClosingScript } from 'idcac-playwright'
 import ow from 'ow';
 import type { Page, Response, Route } from 'playwright';
 
+import { RenderingTypePredictor } from './rendering-type-prediction';
 import type { EnqueueLinksByClickingElementsOptions } from '../enqueue-links/click-elements';
 import { enqueueLinksByClickingElements } from '../enqueue-links/click-elements';
 import type { PlaywrightCrawlingContext } from '../playwright-crawler';
@@ -789,4 +790,5 @@ export const playwrightUtils = {
     saveSnapshot,
     compileScript,
     closeCookieModals,
+    RenderingTypePredictor,
 };

--- a/packages/playwright-crawler/src/internals/utils/rendering-type-prediction.ts
+++ b/packages/playwright-crawler/src/internals/utils/rendering-type-prediction.ts
@@ -29,13 +29,15 @@ const mean = (values: number[]) => (values.length > 0 ? sum(values) / values.len
 
 type FeatureVector = [staticResultsSimilarity: number, clientOnlyResultsSimilarity: number];
 
-interface RenderingTypePredictorOptions {
+export interface RenderingTypePredictorOptions {
     /** A number between 0 and 1 that determines the desired ratio of rendering type detections */
     detectionRatio: number;
 }
 
 /**
  * Stores rendering type information for previously crawled URLs and predicts the rendering type for URLs that have yet to be crawled and recommends when rendering type detection should be performed.
+ *
+ * @experimental
  */
 export class RenderingTypePredictor {
     private renderingTypeDetectionResults = new Map<RenderingType, Map<string | undefined, URLComponents[]>>();

--- a/packages/playwright-crawler/src/logistic-regression.d.ts
+++ b/packages/playwright-crawler/src/logistic-regression.d.ts
@@ -1,0 +1,22 @@
+declare module 'ml-logistic-regression' {
+  import Matrix from 'ml-matrix';
+
+  class LogisticRegressionTwoClasses {
+    testScores(Xtest: Matrix): number;
+  }
+
+  export default class LogisticRegression {
+    classifiers: LogisticRegressionTwoClasses[];
+
+    constructor(
+      options: Partial<{
+        numSteps: number;
+        learningRate: number;
+      }>,
+    );
+
+    train(X: Matrix, Y: Matrix): void;
+
+    predict(Xtest: Matrix): number[];
+  }
+}

--- a/test/core/crawlers/adaptive_playwright_crawler.test.ts
+++ b/test/core/crawlers/adaptive_playwright_crawler.test.ts
@@ -1,0 +1,99 @@
+import type { Server } from 'http';
+import type { AddressInfo } from 'net';
+
+import {
+    AdaptivePlaywrightCrawler, RequestList,
+} from '@crawlee/playwright';
+import express from 'express';
+import { startExpressAppPromise } from 'test/shared/_helper';
+import { MemoryStorageEmulator } from 'test/shared/MemoryStorageEmulator';
+
+describe('AdaptivePlaywrightCrawler', () => {
+    // Set up an express server that will serve test pages
+    const HOSTNAME = '127.0.0.1';
+    let port: number;
+    let server: Server;
+
+    beforeAll(async () => {
+        const app = express();
+        server = await startExpressAppPromise(app, 0);
+        port = (server.address() as AddressInfo).port;
+
+        app.get('/static', (req, res) => {
+            res.send(`
+                <html>
+                    <head>
+                        <title>Example Domain</title>
+                    </head>
+                    <body>
+                        <h1>Heading</h1>
+                    </body>
+                </html>
+             `);
+            res.status(200);
+        });
+
+        app.get('/dynamic', (req, res) => {
+            res.send(`
+                <html>
+                    <head>
+                        <title>Example Domain</title>
+                        <script type="text/javascript">
+                            setTimeout(() => {document.body.innerHTML = "<h1>Heading</h1>"}, 2000)
+                        </script>
+                    </head>
+                    <body>
+                    </body>
+                </html>
+             `);
+            res.status(200);
+        });
+    });
+    afterAll(async () => {
+        server.close();
+    });
+
+    // Set up local storage emulator
+    const localStorageEmulator = new MemoryStorageEmulator();
+
+    beforeEach(async () => {
+        await localStorageEmulator.init();
+    });
+    afterAll(async () => {
+        await localStorageEmulator.destroy();
+    });
+
+    describe('should detect page rendering type', () => {
+        test.each([['/static', 'static'], ['/dynamic', 'clientOnly']] as const)('for %s', async (path, expectedType) => {
+            // Set up a mock rendering type predictor that will check detection results
+            const renderingTypePredictor = {
+                predict: (_url: URL) => ({ detectionProbabilityRecommendation: 1, renderingType: 'clientOnly' } as const),
+                storeResult: (_url: URL, _label: string | unknown, _renderingType: string) => {},
+            };
+
+            const predictSpy = vi.spyOn(renderingTypePredictor, 'predict');
+            const storeResultSpy = vi.spyOn(renderingTypePredictor, 'storeResult');
+
+            const url = new URL(`http://${HOSTNAME}:${port}${path}`);
+
+            const crawler = new AdaptivePlaywrightCrawler({
+                renderingTypeDetectionRatio: 0.1,
+                renderingTypePredictor,
+                maxConcurrency: 1,
+                maxRequestRetries: 0,
+                maxRequestsPerCrawl: 1,
+                requestHandler: async ({ pushData, querySelector }) => {
+                    await pushData({
+                        heading: (await querySelector('h1')).text(),
+                    });
+                },
+                requestList: await RequestList.open({ sources: [url.toString()] }),
+            });
+
+            await crawler.run();
+
+            expect(predictSpy).toHaveBeenCalledWith(url, undefined);
+            expect(storeResultSpy).toHaveBeenCalledWith(url, undefined, expectedType);
+        });
+    });
+});

--- a/test/core/crawlers/adaptive_playwright_crawler.test.ts
+++ b/test/core/crawlers/adaptive_playwright_crawler.test.ts
@@ -1,6 +1,7 @@
 import type { Server } from 'http';
 import type { AddressInfo } from 'net';
 
+import type { AdaptivePlaywrightCrawlerOptions } from '@crawlee/playwright';
 import {
     AdaptivePlaywrightCrawler, RequestList,
 } from '@crawlee/playwright';
@@ -19,7 +20,7 @@ describe('AdaptivePlaywrightCrawler', () => {
         server = await startExpressAppPromise(app, 0);
         port = (server.address() as AddressInfo).port;
 
-        app.get('/static', (req, res) => {
+        app.get('/static', (_req, res) => {
             res.send(`
                 <html>
                     <head>
@@ -27,19 +28,33 @@ describe('AdaptivePlaywrightCrawler', () => {
                     </head>
                     <body>
                         <h1>Heading</h1>
+                        <a href="/static?q=1">Link 1</a>
+                        <a href="/static?q=2">Link 2</a>
+                        <a href="/static?q=3">Link 3</a>
+                        <a href="/static?q=4">Link 4</a>
+                        <a href="/static?q=5">Link 5</a>
                     </body>
                 </html>
              `);
             res.status(200);
         });
 
-        app.get('/dynamic', (req, res) => {
+        app.get('/dynamic', (_req, res) => {
             res.send(`
                 <html>
                     <head>
                         <title>Example Domain</title>
                         <script type="text/javascript">
-                            setTimeout(() => {document.body.innerHTML = "<h1>Heading</h1>"}, 2000)
+                            setTimeout(() => {
+                                document.body.innerHTML = [
+                                    '<h1>Heading</h1>',
+                                    '<a href="/static?q=1">Link 1</a>',
+                                    '<a href="/static?q=2">Link 2</a>',
+                                    '<a href="/static?q=3">Link 3</a>',
+                                    '<a href="/static?q=4">Link 4</a>',
+                                    '<a href="/static?q=5">Link 5</a>',
+                                ].join(" ")
+                            }, 500)
                         </script>
                     </head>
                     <body>
@@ -63,37 +78,98 @@ describe('AdaptivePlaywrightCrawler', () => {
         await localStorageEmulator.destroy();
     });
 
+    // Test setup helpers
+    const makeOneshotCrawler = async (
+        requestHandler: AdaptivePlaywrightCrawlerOptions['requestHandler'],
+        renderingTypePredictor: AdaptivePlaywrightCrawlerOptions['renderingTypePredictor'],
+        sources: string[],
+    ) => new AdaptivePlaywrightCrawler({
+        renderingTypeDetectionRatio: 0.1,
+        renderingTypePredictor,
+        maxConcurrency: 1,
+        maxRequestRetries: 0,
+        maxRequestsPerCrawl: 1,
+        requestHandler,
+        requestList: await RequestList.open({ sources }),
+    });
+
+    const makeRiggedRenderingTypePredictor = (prediction: {detectionProbabilityRecommendation: number; renderingType: 'clientOnly' | 'static'}) => ({
+        predict: vi.fn((_url: URL) => prediction),
+        storeResult: vi.fn((_url: URL, _label: string | unknown, _renderingType: string) => {}),
+    });
+
     describe('should detect page rendering type', () => {
         test.each([['/static', 'static'], ['/dynamic', 'clientOnly']] as const)('for %s', async (path, expectedType) => {
-            // Set up a mock rendering type predictor that will check detection results
-            const renderingTypePredictor = {
-                predict: (_url: URL) => ({ detectionProbabilityRecommendation: 1, renderingType: 'clientOnly' } as const),
-                storeResult: (_url: URL, _label: string | unknown, _renderingType: string) => {},
-            };
-
-            const predictSpy = vi.spyOn(renderingTypePredictor, 'predict');
-            const storeResultSpy = vi.spyOn(renderingTypePredictor, 'storeResult');
-
+            const renderingTypePredictor = makeRiggedRenderingTypePredictor({ detectionProbabilityRecommendation: 1, renderingType: 'clientOnly' });
             const url = new URL(`http://${HOSTNAME}:${port}${path}`);
 
-            const crawler = new AdaptivePlaywrightCrawler({
-                renderingTypeDetectionRatio: 0.1,
-                renderingTypePredictor,
-                maxConcurrency: 1,
-                maxRequestRetries: 0,
-                maxRequestsPerCrawl: 1,
-                requestHandler: async ({ pushData, querySelector }) => {
-                    await pushData({
-                        heading: (await querySelector('h1')).text(),
-                    });
-                },
-                requestList: await RequestList.open({ sources: [url.toString()] }),
+            const requestHandler: AdaptivePlaywrightCrawlerOptions['requestHandler'] = vi.fn(async ({ pushData, querySelector }) => {
+                await pushData({
+                    heading: (await querySelector('h1')).text(),
+                });
             });
+
+            const crawler = await makeOneshotCrawler(
+                requestHandler,
+                renderingTypePredictor,
+                [url.toString()],
+            );
 
             await crawler.run();
 
-            expect(predictSpy).toHaveBeenCalledWith(url, undefined);
-            expect(storeResultSpy).toHaveBeenCalledWith(url, undefined, expectedType);
+            // Check the detection result
+            expect(renderingTypePredictor.predict).toHaveBeenCalledWith(url, undefined);
+            expect(renderingTypePredictor.storeResult).toHaveBeenCalledWith(url, undefined, expectedType);
+
+            // Check if the request handler was called twice
+            expect(requestHandler).toHaveBeenCalledTimes(2);
+
+            // Check if only one item was added to the dataset
+            expect(await localStorageEmulator.getDatasetItems()).toEqual([{ heading: 'Heading' }]);
+        });
+    });
+
+    test('should not store detection results on non-detection runs', async () => {
+        const renderingTypePredictor = makeRiggedRenderingTypePredictor({ detectionProbabilityRecommendation: 0, renderingType: 'static' });
+        const url = new URL(`http://${HOSTNAME}:${port}/static`);
+
+        const crawler = await makeOneshotCrawler(
+            async () => {},
+            renderingTypePredictor,
+            [url.toString()],
+        );
+
+        await crawler.run();
+
+        expect(renderingTypePredictor.predict).toHaveBeenCalledWith(url, undefined);
+        expect(renderingTypePredictor.storeResult).not.toHaveBeenCalled();
+    });
+
+    describe('should enqueue links correctly', () => {
+        test.each([['/static', 'static'], ['/dynamic', 'clientOnly']] as const)('for %s', async (path, renderingType) => {
+            const renderingTypePredictor = makeRiggedRenderingTypePredictor({ detectionProbabilityRecommendation: 0, renderingType });
+            const url = new URL(`http://${HOSTNAME}:${port}${path}`);
+
+            const requestHandler: AdaptivePlaywrightCrawlerOptions['requestHandler'] = vi.fn(async ({ enqueueLinks }) => {
+                await enqueueLinks();
+            });
+
+            const crawler = await makeOneshotCrawler(
+                requestHandler,
+                renderingTypePredictor,
+                [url.toString()],
+            );
+
+            await crawler.run();
+
+            const enqueuedUrls = (await localStorageEmulator.getRequestQueueItems()).map((item) => item.url);
+            expect(new Set(enqueuedUrls)).toEqual(new Set([
+                `http://${HOSTNAME}:${port}/static?q=1`,
+                `http://${HOSTNAME}:${port}/static?q=2`,
+                `http://${HOSTNAME}:${port}/static?q=3`,
+                `http://${HOSTNAME}:${port}/static?q=4`,
+                `http://${HOSTNAME}:${port}/static?q=5`,
+            ]));
         });
     });
 });

--- a/test/shared/MemoryStorageEmulator.ts
+++ b/test/shared/MemoryStorageEmulator.ts
@@ -11,19 +11,41 @@ import { StorageEmulator } from './StorageEmulator';
 const LOCAL_EMULATION_DIR = resolve(__dirname, '..', 'tmp', 'memory-emulation-dir');
 
 export class MemoryStorageEmulator extends StorageEmulator {
+    private storage: MemoryStorage;
+
     override async init({ dirName = cryptoRandomObjectId(10), persistStorage = false }: MemoryEmulatorOptions = {}) {
         await super.init();
         const localStorageDir = resolve(LOCAL_EMULATION_DIR, dirName);
         this.localStorageDirectories.push(localStorageDir);
         await ensureDir(localStorageDir);
 
-        const storage = new MemoryStorage({ localDataDirectory: localStorageDir, persistStorage, writeMetadata: false });
-        Configuration.getGlobalConfig().useStorageClient(storage);
+        this.storage = new MemoryStorage({ localDataDirectory: localStorageDir, persistStorage, writeMetadata: false });
+
+        Configuration.getGlobalConfig().useStorageClient(this.storage);
         log.debug(`Initialized emulated memory storage in folder ${localStorageDir}`);
     }
 
     static override toString() {
         return '@crawlee/memory-storage';
+    }
+
+    getDataset(id?: string) {
+        return this.storage.dataset(id ?? Configuration.getGlobalConfig().get('defaultDatasetId'));
+    }
+
+    async getDatasetItems(id?: string) {
+        const dataset = this.getDataset(id);
+        return (await dataset.listItems()).items;
+    }
+
+    getRequestQueue(id?: string) {
+        return this.storage.requestQueue(id ?? Configuration.getGlobalConfig().get('defaultRequestQueueId'));
+    }
+
+    async getRequestQueueItems(id?: string) {
+        const requestQueue = this.getRequestQueue(id);
+        const { items: heads } = await requestQueue.listHead();
+        return heads;
     }
 }
 

--- a/test/shared/MemoryStorageEmulator.ts
+++ b/test/shared/MemoryStorageEmulator.ts
@@ -47,6 +47,14 @@ export class MemoryStorageEmulator extends StorageEmulator {
         const { items: heads } = await requestQueue.listHead();
         return heads;
     }
+
+    getKeyValueStore(id?: string) {
+        return this.storage.keyValueStore(id ?? Configuration.getGlobalConfig().get('defaultKeyValueStoreId'));
+    }
+
+    async getState() {
+        return await this.getKeyValueStore().getRecord('CRAWLEE_STATE');
+    }
 }
 
 export interface MemoryEmulatorOptions {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2059,7 +2059,7 @@ __metadata:
   resolution: "@types/lodash.isequal@npm:4.5.8"
   dependencies:
     "@types/lodash": "npm:*"
-  checksum: 6db28cacf165d55421fbf2970ccfb1682a7b82b743bb7aba4398fa8ab98f1711fca2fe4afa1aa2b7b4afb3eff76c8aca13b22206f5efeb038d99e41300589bca
+  checksum: 10c0/6db28cacf165d55421fbf2970ccfb1682a7b82b743bb7aba4398fa8ab98f1711fca2fe4afa1aa2b7b4afb3eff76c8aca13b22206f5efeb038d99e41300589bca
   languageName: node
   linkType: hard
 
@@ -6738,7 +6738,7 @@ __metadata:
 "is-any-array@npm:^2.0.0, is-any-array@npm:^2.0.1":
   version: 2.0.1
   resolution: "is-any-array@npm:2.0.1"
-  checksum: f9807458a51e63ca1ac27fd6f3a3ace8200f077094e00d9b05b24cfbc9d5594d586d6ecf3416271f26939d5cb93fc52ca869cb5744e77318c3f53ec70b08d61f
+  checksum: 10c0/f9807458a51e63ca1ac27fd6f3a3ace8200f077094e00d9b05b24cfbc9d5594d586d6ecf3416271f26939d5cb93fc52ca869cb5744e77318c3f53ec70b08d61f
   languageName: node
   linkType: hard
 
@@ -8368,7 +8368,7 @@ __metadata:
   resolution: "ml-array-max@npm:1.2.4"
   dependencies:
     is-any-array: "npm:^2.0.0"
-  checksum: 05eacc44ccc182f6d191bc7cd233c97b55ebd695e423f0f07e2358831af7d7a2f64e2698fee4e1edc9bbcd962b8df2141f52b5403219bc2432a77b2bab8e25df
+  checksum: 10c0/05eacc44ccc182f6d191bc7cd233c97b55ebd695e423f0f07e2358831af7d7a2f64e2698fee4e1edc9bbcd962b8df2141f52b5403219bc2432a77b2bab8e25df
   languageName: node
   linkType: hard
 
@@ -8377,7 +8377,7 @@ __metadata:
   resolution: "ml-array-min@npm:1.2.3"
   dependencies:
     is-any-array: "npm:^2.0.0"
-  checksum: ba7aef2fd1bfe9f1937efa96242147c0ab30e5af4f22364b419a47f8c194b3c16b96b024fd6562eaddbf2d8648fcda3f54d3c2f394ec58beb756b9ed71c81593
+  checksum: 10c0/ba7aef2fd1bfe9f1937efa96242147c0ab30e5af4f22364b419a47f8c194b3c16b96b024fd6562eaddbf2d8648fcda3f54d3c2f394ec58beb756b9ed71c81593
   languageName: node
   linkType: hard
 
@@ -8388,7 +8388,7 @@ __metadata:
     is-any-array: "npm:^2.0.0"
     ml-array-max: "npm:^1.2.4"
     ml-array-min: "npm:^1.2.3"
-  checksum: 2b8fca33c38bee3c957e5e2f178d7f109d61acc2add924cc8a4a0eac30dfa2d0974642f25f2b4e46e82f9ac90de275268aca382bd644dac2960a83b349c7e706
+  checksum: 10c0/2b8fca33c38bee3c957e5e2f178d7f109d61acc2add924cc8a4a0eac30dfa2d0974642f25f2b4e46e82f9ac90de275268aca382bd644dac2960a83b349c7e706
   languageName: node
   linkType: hard
 
@@ -8397,7 +8397,7 @@ __metadata:
   resolution: "ml-logistic-regression@npm:2.0.0"
   dependencies:
     ml-matrix: "npm:^6.5.0"
-  checksum: 8713dc63d98e08038fba537afb2e9f675065ec6b8b02dbb5dd33b7823bfcf627dac10cad270650e23afb4fb7c14547a856d89306d588f075924970290d96039a
+  checksum: 10c0/8713dc63d98e08038fba537afb2e9f675065ec6b8b02dbb5dd33b7823bfcf627dac10cad270650e23afb4fb7c14547a856d89306d588f075924970290d96039a
   languageName: node
   linkType: hard
 
@@ -8407,7 +8407,7 @@ __metadata:
   dependencies:
     is-any-array: "npm:^2.0.1"
     ml-array-rescale: "npm:^1.3.7"
-  checksum: bf64bc5037568d8b2fddc3b2d90cb927868ed5f7894208b3e88b178645411c19ce25351a02f08dbf071a7a8a6c81370410c2692f0f800341be38670c23853df5
+  checksum: 10c0/bf64bc5037568d8b2fddc3b2d90cb927868ed5f7894208b3e88b178645411c19ce25351a02f08dbf071a7a8a6c81370410c2692f0f800341be38670c23853df5
   languageName: node
   linkType: hard
 
@@ -10980,7 +10980,7 @@ __metadata:
 "string-comparison@npm:^1.3.0":
   version: 1.3.0
   resolution: "string-comparison@npm:1.3.0"
-  checksum: 9118ea5d33cc3e9761b12b481e44a75a2e632564b33a511c24cc753105e844f2e0c5997ec5210d2a233a5669a635aaff65f74aa156a5205fba7cd0e81c53ceab
+  checksum: 10c0/9118ea5d33cc3e9761b12b481e44a75a2e632564b33a511c24cc753105e844f2e0c5997ec5210d2a233a5669a635aaff65f74aa156a5205fba7cd0e81c53ceab
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -610,6 +610,7 @@ __metadata:
     cheerio: "npm:^1.0.0-rc.12"
     idcac-playwright: "npm:^0.1.2"
     jquery: "npm:^3.6.0"
+    lodash.isequal: "npm:^4.5.0"
     ml-logistic-regression: "npm:^2.0.0"
     ow: "npm:^0.28.1"
     portadom: "npm:^1.0.4"
@@ -666,6 +667,7 @@ __metadata:
     "@types/htmlparser2": "npm:^3.10.3"
     "@types/inquirer": "npm:^8.2.1"
     "@types/is-ci": "npm:^3.0.1"
+    "@types/lodash.isequal": "npm:^4.5.8"
     "@types/lodash.merge": "npm:^4.6.7"
     "@types/mime-types": "npm:^2.1.1"
     "@types/node": "npm:^20.0.0"
@@ -2050,6 +2052,15 @@ __metadata:
   dependencies:
     "@types/node": "npm:*"
   checksum: 10c0/b12d068b021e4078f6ac4441353965769be87acf15326173e2aea9f3bf8ead41bd0ad29421df5bbeb0123ec3fc02eb0a734481d52903704a1454a1845896b9eb
+  languageName: node
+  linkType: hard
+
+"@types/lodash.isequal@npm:^4.5.8":
+  version: 4.5.8
+  resolution: "@types/lodash.isequal@npm:4.5.8"
+  dependencies:
+    "@types/lodash": "npm:*"
+  checksum: 6db28cacf165d55421fbf2970ccfb1682a7b82b743bb7aba4398fa8ab98f1711fca2fe4afa1aa2b7b4afb3eff76c8aca13b22206f5efeb038d99e41300589bca
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -114,7 +114,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@apify/timeout@npm:^0.3.0":
+"@apify/timeout@npm:^0.3.0, @apify/timeout@npm:^0.3.1":
   version: 0.3.1
   resolution: "@apify/timeout@npm:0.3.1"
   checksum: 10c0/3019f9ef14bad1e3675553e85032f87ef5a2552dcbb1d4b26305e00591647999000641a0660d30838ea1a6aaab558881bc9f5514e52614969bca9bdccaf96fa6
@@ -600,6 +600,7 @@ __metadata:
   dependencies:
     "@apify/datastructures": "npm:^2.0.0"
     "@apify/log": "npm:^2.4.0"
+    "@apify/timeout": "npm:^0.3.1"
     "@crawlee/browser": "npm:3.7.3"
     "@crawlee/browser-pool": "npm:3.7.3"
     "@crawlee/types": "npm:3.7.3"
@@ -607,8 +608,10 @@ __metadata:
     cheerio: "npm:^1.0.0-rc.12"
     idcac-playwright: "npm:^0.1.2"
     jquery: "npm:^3.6.0"
+    ml-logistic-regression: "npm:^2.0.0"
     ow: "npm:^0.28.1"
     portadom: "npm:^1.0.4"
+    string-comparison: "npm:^1.3.0"
     tslib: "npm:^2.4.0"
   peerDependencies:
     playwright: "*"
@@ -6720,6 +6723,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-any-array@npm:^2.0.0, is-any-array@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "is-any-array@npm:2.0.1"
+  checksum: f9807458a51e63ca1ac27fd6f3a3ace8200f077094e00d9b05b24cfbc9d5594d586d6ecf3416271f26939d5cb93fc52ca869cb5744e77318c3f53ec70b08d61f
+  languageName: node
+  linkType: hard
+
 "is-arguments@npm:^1.1.1":
   version: 1.1.1
   resolution: "is-arguments@npm:1.1.1"
@@ -8338,6 +8348,54 @@ __metadata:
   bin:
     mkdirp: bin/cmd.js
   checksum: 10c0/46ea0f3ffa8bc6a5bc0c7081ffc3907777f0ed6516888d40a518c5111f8366d97d2678911ad1a6882bf592fa9de6c784fea32e1687bb94e1f4944170af48a5cf
+  languageName: node
+  linkType: hard
+
+"ml-array-max@npm:^1.2.4":
+  version: 1.2.4
+  resolution: "ml-array-max@npm:1.2.4"
+  dependencies:
+    is-any-array: "npm:^2.0.0"
+  checksum: 05eacc44ccc182f6d191bc7cd233c97b55ebd695e423f0f07e2358831af7d7a2f64e2698fee4e1edc9bbcd962b8df2141f52b5403219bc2432a77b2bab8e25df
+  languageName: node
+  linkType: hard
+
+"ml-array-min@npm:^1.2.3":
+  version: 1.2.3
+  resolution: "ml-array-min@npm:1.2.3"
+  dependencies:
+    is-any-array: "npm:^2.0.0"
+  checksum: ba7aef2fd1bfe9f1937efa96242147c0ab30e5af4f22364b419a47f8c194b3c16b96b024fd6562eaddbf2d8648fcda3f54d3c2f394ec58beb756b9ed71c81593
+  languageName: node
+  linkType: hard
+
+"ml-array-rescale@npm:^1.3.7":
+  version: 1.3.7
+  resolution: "ml-array-rescale@npm:1.3.7"
+  dependencies:
+    is-any-array: "npm:^2.0.0"
+    ml-array-max: "npm:^1.2.4"
+    ml-array-min: "npm:^1.2.3"
+  checksum: 2b8fca33c38bee3c957e5e2f178d7f109d61acc2add924cc8a4a0eac30dfa2d0974642f25f2b4e46e82f9ac90de275268aca382bd644dac2960a83b349c7e706
+  languageName: node
+  linkType: hard
+
+"ml-logistic-regression@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "ml-logistic-regression@npm:2.0.0"
+  dependencies:
+    ml-matrix: "npm:^6.5.0"
+  checksum: 8713dc63d98e08038fba537afb2e9f675065ec6b8b02dbb5dd33b7823bfcf627dac10cad270650e23afb4fb7c14547a856d89306d588f075924970290d96039a
+  languageName: node
+  linkType: hard
+
+"ml-matrix@npm:^6.5.0":
+  version: 6.11.0
+  resolution: "ml-matrix@npm:6.11.0"
+  dependencies:
+    is-any-array: "npm:^2.0.1"
+    ml-array-rescale: "npm:^1.3.7"
+  checksum: bf64bc5037568d8b2fddc3b2d90cb927868ed5f7894208b3e88b178645411c19ce25351a02f08dbf071a7a8a6c81370410c2692f0f800341be38670c23853df5
   languageName: node
   linkType: hard
 
@@ -10913,6 +10971,13 @@ __metadata:
   version: 0.3.2
   resolution: "string-argv@npm:0.3.2"
   checksum: 10c0/75c02a83759ad1722e040b86823909d9a2fc75d15dd71ec4b537c3560746e33b5f5a07f7332d1e3f88319909f82190843aa2f0a0d8c8d591ec08e93d5b8dec82
+  languageName: node
+  linkType: hard
+
+"string-comparison@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "string-comparison@npm:1.3.0"
+  checksum: 9118ea5d33cc3e9761b12b481e44a75a2e632564b33a511c24cc753105e844f2e0c5997ec5210d2a233a5669a635aaff65f74aa156a5205fba7cd0e81c53ceab
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -463,6 +463,7 @@ __metadata:
     "@crawlee/utils": "npm:3.7.3"
     ow: "npm:^0.28.1"
     tslib: "npm:^2.4.0"
+    type-fest: "npm:^4.0.0"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -604,6 +604,7 @@ __metadata:
     "@apify/timeout": "npm:^0.3.1"
     "@crawlee/browser": "npm:3.7.3"
     "@crawlee/browser-pool": "npm:3.7.3"
+    "@crawlee/core": "npm:3.7.3"
     "@crawlee/types": "npm:3.7.3"
     "@crawlee/utils": "npm:3.7.3"
     cheerio: "npm:^1.0.0-rc.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -608,6 +608,7 @@ __metadata:
     idcac-playwright: "npm:^0.1.2"
     jquery: "npm:^3.6.0"
     ow: "npm:^0.28.1"
+    portadom: "npm:^1.0.4"
     tslib: "npm:^2.4.0"
   peerDependencies:
     playwright: "*"
@@ -9576,6 +9577,15 @@ __metadata:
   bin:
     playwright: cli.js
   checksum: 10c0/1b487387c1bc003291a9dbd098e8e3c6a31efbb4d7a2ce4f2bf9d5e7f9fbf4a406352ab70e5266eab9a2a858bd42d8955343ea30c0286c3912e81984aa0220a3
+  languageName: node
+  linkType: hard
+
+"portadom@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "portadom@npm:1.0.4"
+  bin:
+    portadom: dist/cjs/cli/index.js
+  checksum: 64637e7072e6a8b6d7ec9a94b6ace5c6ff24cea308bc4a8675a435af2224a341281878ab0d27af710227539976dd1db25c837b2c39cfda3430e2c24b34799fe7
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -613,7 +613,6 @@ __metadata:
     lodash.isequal: "npm:^4.5.0"
     ml-logistic-regression: "npm:^2.0.0"
     ow: "npm:^0.28.1"
-    portadom: "npm:^1.0.4"
     string-comparison: "npm:^1.3.0"
     tslib: "npm:^2.4.0"
   peerDependencies:
@@ -9648,15 +9647,6 @@ __metadata:
   bin:
     playwright: cli.js
   checksum: 10c0/1b487387c1bc003291a9dbd098e8e3c6a31efbb4d7a2ce4f2bf9d5e7f9fbf4a406352ab70e5266eab9a2a858bd42d8955343ea30c0286c3912e81984aa0220a3
-  languageName: node
-  linkType: hard
-
-"portadom@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "portadom@npm:1.0.4"
-  bin:
-    portadom: dist/cjs/cli/index.js
-  checksum: 64637e7072e6a8b6d7ec9a94b6ace5c6ff24cea308bc4a8675a435af2224a341281878ab0d27af710227539976dd1db25c837b2c39cfda3430e2c24b34799fe7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This uses the newly added restricted crawling contexts to execute request handlers. This allows us to compare browser and http-only request handler runs for a request and switch to http-only crawling on sites that we predict to be static. More information will be added here.

The intended usage is as follows:

```ts
import { AdaptivePlaywrightCrawler } from 'crawlee';

const startUrls = [{url: 'https://warehouse-theme-metal.myshopify.com/collections', label: 'START'}];

const crawler = new AdaptivePlaywrightCrawler({
    requestHandler: async ({ request, enqueueLinks, pushData, querySelector }) => {
        console.log(`Processing: ${request.url} (${request.label})`);

        if (request.label === 'DETAIL') {
            const urlPart = request.url.split('/').slice(-1); // ['sennheiser-mke-440-professional-stereo-shotgun-microphone-mke-440']
            const manufacturer = urlPart[0].split('-')[0]; // 'sennheiser'

            const title = (await querySelector('.product-meta h1')).text();
            const sku = (await querySelector('span.product-meta__sku-number')).text();

            const $prices = await querySelector('span.price')
            const currentPriceString = $prices.filter(':contains("$")').first().text()

            const rawPrice = currentPriceString.split('$')[1];
            const price = Number(rawPrice.replaceAll(',', ''));

            const inStockElements = await querySelector('span.product-form__inventory')
            const inStock = inStockElements.filter(':contains("In stock")').length > 0;

            const results = {
                url: request.url,
                manufacturer,
                title,
                sku,
                currentPrice: price,
                availableInStock: inStock,
            };

            await pushData(results);
        } else if (request.label === 'CATEGORY') {
            await enqueueLinks({
                selector: '.product-item > a',
                label: 'DETAIL', // <= note the different label
            });

            await enqueueLinks({
                selector: 'a.pagination__next',
                label: 'CATEGORY', // <= note the same label
            });
        } else if (request.label === 'START') {
            await enqueueLinks({
                selector: '.collection-block-item',
                label: 'CATEGORY',
            });
        }
    },
    renderingTypeDetectionRatio: 0.1,
    maxRequestsPerCrawl: 100,
    maxRequestRetries: 0,
    minConcurrency: 1,
    maxConcurrency: 1,
    headless: true,
});

await crawler.run(startUrls);

```

When handling a request from the queue, the crawler

1. tries to predict the rendering type (static/client only) based on URL, label and potentially other criteria (using a logistic regression model that gets updated on the fly)
2. for static pages, a HTTP-only scrape is done and the request handler works with Cheerio-based portadom
3. for client only pages, a playwright scrape is done and the request handler receives a portadom instance that uses Playwright locators (hence it waits for content to appear implicitly)
4. for a configurable percentage of requests, a detection is done (also if we're not confident about the prediction) - both HTTP-only and playwright scrapes are done and the results are compared. If (and only if) the HTTP-only scrape behaves the same, we conclude the page is static and update our logistic regression model.