### PR TITLE
fix: `createRequests` works correctly with `exclude` (and nothing else)

### DIFF
--- a/packages/core/src/enqueue_links/shared.ts
+++ b/packages/core/src/enqueue_links/shared.ts
@@ -153,49 +153,40 @@ export function createRequests(
     excludePatternObjects: UrlPatternObject[] = [],
     strategy?: EnqueueLinksOptions['strategy'],
 ): Request[] {
-    if (!urlPatternObjects || !urlPatternObjects.length) {
-        return requestOptions
-            .map((opts) => new Request(typeof opts === 'string' ? { url: opts, enqueueStrategy: strategy } : { ...opts }));
-    }
-
-    const requests: Request[] = [];
-
-    for (const opts of requestOptions) {
-        const urlToMatch = typeof opts === 'string' ? opts : opts.url;
-
-        let isExcluded = false;
-        for (const excludePatternObject of excludePatternObjects) {
-            const { regexp, glob } = excludePatternObject;
-
-            if (
-                (regexp && urlToMatch.match(regexp)) || // eslint-disable-line
-                (glob && minimatch(urlToMatch, glob, { nocase: true }))
-            ) {
-                isExcluded = true;
-                break;
+    return requestOptions
+        .map((opts) => ({ url: typeof opts === 'string' ? opts : opts.url, opts }))
+        .filter(({ url }) => {
+            return !excludePatternObjects.some((excludePatternObject) => {
+                const { regexp, glob } = excludePatternObject;
+                return (
+                        (regexp && url.match(regexp)) || // eslint-disable-line
+                        (glob && minimatch(url, glob, { nocase: true }))
+                );
+            });
+        })
+        .map(({ url, opts }) => {
+            if (!urlPatternObjects || !urlPatternObjects.length) {
+                return new Request(typeof opts === 'string' ? { url: opts, enqueueStrategy: strategy } : { ...opts });
             }
-        }
 
-        if (isExcluded) continue;
+            for (const urlPatternObject of urlPatternObjects) {
+                const { regexp, glob, ...requestRegExpOptions } = urlPatternObject;
+                if (
+                    (regexp && url.match(regexp)) || // eslint-disable-line
+                    (glob && minimatch(url, glob, { nocase: true }))
+                ) {
+                    const request = typeof opts === 'string'
+                        ? { url: opts, ...requestRegExpOptions, enqueueStrategy: strategy }
+                        : { ...opts, ...requestRegExpOptions, enqueueStrategy: strategy };
 
-        for (const urlPatternObject of urlPatternObjects) {
-            const { regexp, glob, ...requestRegExpOptions } = urlPatternObject;
-            if (
-                (regexp && urlToMatch.match(regexp)) || // eslint-disable-line
-                (glob && minimatch(urlToMatch, glob, { nocase: true }))
-            ) {
-                const request = typeof opts === 'string'
-                    ? { url: opts, ...requestRegExpOptions, enqueueStrategy: strategy }
-                    : { ...opts, ...requestRegExpOptions, enqueueStrategy: strategy };
-                requests.push(new Request(request));
-
-                // Stop checking other patterns for this request option as it was already matched
-                break;
+                    return new Request(request);
+                }
             }
-        }
-    }
 
-    return requests;
+            // didn't match any positive pattern
+            return null;
+        })
+        .filter((request) => request) as Request[];
 }
 
 export function filterRequestsByPatterns(requests: Request[], patterns?: UrlPatternObject[]): Request[] {

--- a/packages/core/test/enqueue_links/user-provided-patterns-with-enqueue-strategy.test.ts
+++ b/packages/core/test/enqueue_links/user-provided-patterns-with-enqueue-strategy.test.ts
@@ -140,4 +140,25 @@ describe('enqueueLinks() - combining user patterns with enqueue strategies', () 
 
         expect(enqueued).toHaveLength(0);
     });
+
+    test('works with exclude only', async () => {
+        const { enqueued, requestQueue } = createRequestQueueMock();
+
+        const exclude = ['**/second', '**/third', 'https://another.com/**'];
+
+        await cheerioCrawlerEnqueueLinks({
+            options: {
+                selector: '.click',
+                exclude,
+                strategy: EnqueueStrategy.All,
+            },
+            $,
+            requestQueue,
+            originalRequestUrl: 'https://example.com',
+        });
+
+        expect(enqueued).toHaveLength(2);
+        expect(enqueued[0].url).toBe('https://example.com/a/b/first');
+        expect(enqueued[1].url).toBe('http://cool.com/');
+    });
 });


### PR DESCRIPTION
`createRequests` - and, transitively, `enqueueLinks` didn't work (imo) correctly when supplied only with `exclude` patterns.

In this case, `enqueueLinks` simply discarded the `exclude` patterns, enqueueing all the links (e.g. from the `urls` option). This is easy to see when you take a look at the original implementation of `createRequests`. 

This PR fixes that (and streamlines the `createRequests` implementation) - for every new potential request, we now:
- get its URL
- filter it out if it matches any of the `excludePatterns`
- create a `Request` object out of it 
   - if there are no positive patterns supplied, just create a vanilla `Request` object
   - if there are some positive patterns supplied, create a flavoured `Request` object, based on the matching pattern
      - if the request didn't match any of the patterns, don't pass it further

