### PR TITLE
fix: declare missing dependencies on `csv-stringify` and `fs-extra`

### DIFF
--- a/packages/basic-crawler/package.json
+++ b/packages/basic-crawler/package.json
@@ -51,6 +51,8 @@
         "@crawlee/core": "3.7.3",
         "@crawlee/types": "3.7.3",
         "@crawlee/utils": "3.7.3",
+        "csv-stringify": "^6.2.0",
+        "fs-extra": "^11.0.0",
         "got-scraping": "^4.0.0",
         "ow": "^0.28.1",
         "tldts": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -412,6 +412,8 @@ __metadata:
     "@crawlee/core": "npm:3.7.3"
     "@crawlee/types": "npm:3.7.3"
     "@crawlee/utils": "npm:3.7.3"
+    csv-stringify: "npm:^6.2.0"
+    fs-extra: "npm:^11.0.0"
     got-scraping: "npm:^4.0.0"
     ow: "npm:^0.28.1"
     tldts: "npm:^6.0.0"


### PR DESCRIPTION
a quick win where this is the only thing that prevents crawlee from running via yarn pnp out of the box. the basic-crawler package was using two dependencies not specified in its package.json (`csv-stringify` and `fs-extra`) as also mentioned by running `yarn dlx @yarnpkg/doctor ./packages/basic`:
```
➤ YN0000: ┌ /home/reda/Documents/Projects/forks/crawlee/packages/basic-crawler/package.json
➤ YN0000: │ /home/reda/Documents/Projects/forks/crawlee/packages/basic-crawler/src/internals/basic-crawler.ts:54:1: Undeclared dependency on csv-stringify
➤ YN0000: │ /home/reda/Documents/Projects/forks/crawlee/packages/basic-crawler/src/internals/basic-crawler.ts:55:1: Undeclared dependency on fs-extra
➤ YN0000: │ /home/reda/Documents/Projects/forks/crawlee/packages/basic-crawler/src/internals/basic-crawler.ts:1441:93: Strings should avoid referencing the node_modules directory (prefer require.resolve)
```

there's the [`no-extraneous-dependencies`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-extraneous-dependencies.md) rule from `eslint-plugin-import` that helps to address these kinds of problems but i can see it's been [explicitly disabled in the main `.eslintrc.json` file](https://github.com/redabacha/crawlee/blob/2f05ed22b203f688095300400bb0e6d03a03283c/.eslintrc.json#L50) so i haven't opted to re-enable it here.