### PR TITLE
fix(puppeteer): add 'process' to the browser bound methods

### DIFF
--- a/packages/browser-pool/src/puppeteer/puppeteer-plugin.ts
+++ b/packages/browser-pool/src/puppeteer/puppeteer-plugin.ts
@@ -98,7 +98,7 @@ export class PuppeteerPlugin extends BrowserPlugin<
             }
         });
 
-        const boundMethods = (['newPage', 'close', 'userAgent', 'createIncognitoBrowserContext', 'version', 'on'] as const)
+        const boundMethods = (['newPage', 'close', 'userAgent', 'createIncognitoBrowserContext', 'version', 'on', 'process'] as const)
             .reduce((map, method) => {
                 map[method] = browser[method]?.bind(browser);
                 return map;


### PR DESCRIPTION
Fix [this bug](https://github.com/apify/crawlee/issues/2327) that caused the error "Could not kill browser: Cannot read private member #process from an object whose class did not declare it" when trying to close a Puppeteer browser (via `browserController.close();`).

Closes 2327