### PR TITLE
feat(core): add `userAgent` parameter to `RobotsFile.isAllowed()` + `RobotsFile.from()` helper

### DIFF
--- a/packages/utils/src/internals/robots.ts
+++ b/packages/utils/src/internals/robots.ts
@@ -35,7 +35,7 @@ export class RobotsFile {
     /**
      * Determine the location of a robots.txt file for a URL and fetch it.
      * @param url the URL to fetch robots.txt for
-     * @param proxyUrl a proxy to be used for fetching the robots.txt file
+     * @param [proxyUrl] a proxy to be used for fetching the robots.txt file
      */
     static async find(url: string, proxyUrl?: string): Promise<RobotsFile> {
         const robotsFileUrl = new URL(url);
@@ -43,6 +43,16 @@ export class RobotsFile {
         robotsFileUrl.search = '';
 
         return RobotsFile.load(robotsFileUrl.toString(), proxyUrl);
+    }
+
+    /**
+     * Allows providing the URL and robotx.txt content explicitly instead of loading it from the target site.
+     * @param url the URL for robots.txt file
+     * @param content contents of robots.txt
+     * @param [proxyUrl] a proxy to be used for fetching the robots.txt file
+     */
+    static from(url: string, content: string, proxyUrl?: string): RobotsFile {
+        return new RobotsFile(robotsParser(url, content), proxyUrl);
     }
 
     protected static async load(url: string, proxyUrl?: string): Promise<RobotsFile> {
@@ -70,9 +80,10 @@ export class RobotsFile {
     /**
      * Check if a URL should be crawled by robots.
      * @param url the URL to check against the rules in robots.txt
+     * @param [userAgent] relevant user agent, default to `*`
      */
-    isAllowed(url: string): boolean {
-        return this.robots.isAllowed(url, '*') ?? false;
+    isAllowed(url: string, userAgent = '*'): boolean {
+        return this.robots.isAllowed(url, userAgent) ?? false;
     }
 
     /**

--- a/packages/utils/src/internals/robots.ts
+++ b/packages/utils/src/internals/robots.ts
@@ -9,7 +9,7 @@ import { Sitemap } from './sitemap';
 let HTTPError: typeof HTTPErrorClass;
 
 /**
- * Loads and queries information from a robots.txt file.
+ * Loads and queries information from a [robots.txt file](https://en.wikipedia.org/wiki/Robots.txt).
  *
  * **Example usage:**
  * ```javascript

--- a/packages/utils/test/robots.test.ts
+++ b/packages/utils/test/robots.test.ts
@@ -48,4 +48,17 @@ describe('RobotsFile', () => {
         const robots = await RobotsFile.find('http://not-exists.com/robots.txt');
         expect(robots.getSitemaps()).toEqual(['http://not-exists.com/sitemap_1.xml', 'http://not-exists.com/sitemap_2.xml']);
     });
+
+    it('parses allow/deny directives from explicitly provided robots.txt contents', async () => {
+        const contents = `User-agent: *',
+Disallow: *deny_all/
+crawl-delay: 10
+User-agent: Googlebot
+Disallow: *deny_googlebot/`;
+        const robots = RobotsFile.from('http://not-exists.com/robots.txt', contents);
+        expect(robots.isAllowed('http://not-exists.com/something/page.html')).toBe(true);
+        expect(robots.isAllowed('http://not-exists.com/deny_googlebot/page.html')).toBe(true);
+        expect(robots.isAllowed('http://not-exists.com/deny_googlebot/page.html', 'Googlebot')).toBe(false);
+        expect(robots.isAllowed('http://not-exists.com/deny_all/page.html')).toBe(true);
+    });
 });


### PR DESCRIPTION
Previously, `RobotsFile.isAllowed()` always used the rules for `*` user agent, now this is configurable (keeping the `*` as default).

Also adds `RobotsFile.from()` helper to create the `RobotsFile` instance from the robots.txt content instead of querying the actual file.

Related: https://apifier.slack.com/archives/C0KRTKQD8/p1707985775359589