### PR TITLE
feat: `KeyValueStore.recordExists()`

### DIFF
--- a/packages/core/src/storages/key_value_store.ts
+++ b/packages/core/src/storages/key_value_store.ts
@@ -221,6 +221,17 @@ export class KeyValueStore {
         return record?.value as T ?? defaultValue ?? null;
     }
 
+    /**
+     * Tests whether a record with the given key exists in the key-value store without retrieving its value.
+     *
+     * @param key The queried record key.
+     * @returns `true` if the record exists, `false` if it does not.
+     */
+    async recordExists(key: string): Promise<boolean> {
+        ow(key, ow.string.nonEmpty);
+        return this.client.recordExists(key);
+    }
+
     async getAutoSavedValue<T extends Dictionary = Dictionary>(key: string, defaultValue = {} as T): Promise<T> {
         if (this.cache.has(key)) {
             return this.cache.get(key) as T;

--- a/packages/core/src/storages/key_value_store.ts
+++ b/packages/core/src/storages/key_value_store.ts
@@ -536,6 +536,16 @@ export class KeyValueStore {
         return store.getValue<T>(key, defaultValue as T);
     }
 
+    /**
+     * Tests whether a record with the given key exists in the default {@apilink KeyValueStore} associated with the current crawler run.
+     * @param key The queried record key.
+     * @returns `true` if the record exists, `false` if it does not.
+     */
+    static async recordExists(key: string): Promise<boolean> {
+        const store = await this.open();
+        return store.recordExists(key);
+    }
+
     static async getAutoSavedValue<T extends Dictionary = Dictionary>(key: string, defaultValue = {} as T): Promise<T> {
         const store = await this.open();
         return store.getAutoSavedValue(key, defaultValue);

--- a/packages/memory-storage/src/resource-clients/key-value-store.ts
+++ b/packages/memory-storage/src/resource-clients/key-value-store.ts
@@ -172,6 +172,25 @@ export class KeyValueStoreClient extends BaseClient {
         };
     }
 
+    /**
+     * Tests whether a record with the given key exists in the key-value store without retrieving its value.
+     *
+     * @param key The queried record key.
+     * @returns `true` if the record exists, `false` if it does not.
+     */
+    async recordExists(key: string): Promise<boolean> {
+        s.string.parse(key);
+
+        // Check by id
+        const existingStoreById = await findOrCacheKeyValueStoreByPossibleId(this.client, this.name ?? this.id);
+
+        if (!existingStoreById) {
+            this.throwOnNonExisting(StorageTypes.KeyValueStore);
+        }
+
+        return existingStoreById.keyValueEntries.has(key);
+    }
+
     async getRecord(key: string, options: storage.KeyValueStoreClientGetRecordOptions = {}): Promise<storage.KeyValueStoreRecord | undefined> {
         s.string.parse(key);
         s.object({

--- a/packages/types/src/storages.ts
+++ b/packages/types/src/storages.ts
@@ -162,6 +162,7 @@ export interface KeyValueStoreClient {
     update(newFields: KeyValueStoreClientUpdateOptions): Promise<Partial<KeyValueStoreInfo>>;
     delete(): Promise<void>;
     listKeys(options?: KeyValueStoreClientListOptions): Promise<KeyValueStoreClientListData>;
+    recordExists(key: string): Promise<boolean>;
     getRecord(key: string, options?: KeyValueStoreClientGetRecordOptions): Promise<KeyValueStoreRecord | undefined>;
     setRecord(record: KeyValueStoreRecord): Promise<void>;
     deleteRecord(key: string): Promise<void>;

--- a/test/core/storages/key_value_store.test.ts
+++ b/test/core/storages/key_value_store.test.ts
@@ -3,7 +3,6 @@ import { PassThrough } from 'stream';
 import { maybeStringify, Configuration, KeyValueStore } from '@crawlee/core';
 import type { Dictionary } from '@crawlee/utils';
 import { MemoryStorageEmulator } from 'test/shared/MemoryStorageEmulator';
-import e from 'express';
 
 const localStorageEmulator = new MemoryStorageEmulator();
 


### PR DESCRIPTION
Testing for record existence with `getValue()` puts an unnecessary load on the Apify Platform / the storage backend - the client has to load the value just to throw it away in the next step.

`recordExists()` tests for the existence of a KVS key-value pair without actually retrieving the value itself.

---

side note: we should probably bump the `apify-client` dependency in `apify-sdk`, release a new version(?) and have Crawlee depend on this (and greater) versions of `apify-sdk`, right? 

Also, it's been some time since I did something with the storages, what's the procedure there? Are we still maintaining the `apify-storage-local` package - if so, we should probably add this method there as well