### PR TITLE
feat(ci): snapshot docs automatically on minor/major publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,3 +169,55 @@ jobs:
                   token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
                   repository: apify/crawlee
                   event-type: crawlee-docker-image-bump
+    
+    version-docs:
+      needs: release
+      runs-on: ubuntu-latest
+      if: (github.event.inputs.version == 'minor' || github.event.inputs.version == 'major')
+
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@v4
+          with:
+              token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
+              fetch-depth: 0
+
+        - name: Use Node.js 20
+          uses: actions/setup-node@v4
+          with:
+              node-version: 20
+
+        - name: Install jq
+          run: sudo apt-get install jq
+
+        - name: Enable corepack
+          run: |
+              corepack enable
+              corepack prepare yarn@stable --activate
+
+        - name: Activate cache for Node.js 20
+          uses: actions/setup-node@v4
+          with:
+              cache: 'yarn'
+
+        - name: Install dependencies
+          run: |
+              # install project deps
+              yarn
+              # install website deps
+              cd website
+              yarn
+
+        - name: Snapshot the current version
+          run: |
+              cd website
+              yarn docusaurus docs:version $(jq .version ../lerna.json | sed s/\"//g | head -c 3)
+              yarn docusaurus api:version $(jq .version ../lerna.json | sed s/\"//g | head -c 3)
+        
+        - name: Commit and push the version snapshot
+          run: |
+              git config --global user.name "Apify Release Bot"
+              git config --global user.email "noreply@apify.com"
+              git add .
+              git diff-index --quiet HEAD || git commit -m 'chore(release): update docs for ${{ inputs.version }} version [skip ci]'
+              git push


### PR DESCRIPTION
Having to create docs version snapshots manually is a tedious chore. This PR proposes a CI script that only runs on minor/major publishes and snapshots the docs automatically.