### PR TITLE
chore: remove unused poolPromise property on AutoscaledPool

### DIFF
--- a/packages/core/src/autoscaling/autoscaled_pool.ts
+++ b/packages/core/src/autoscaling/autoscaled_pool.ts
@@ -203,7 +203,6 @@ export class AutoscaledPool {
     private reject: ((reason?: unknown) => void) | null = null;
     private snapshotter: Snapshotter;
     private systemStatus: SystemStatus;
-    private poolPromise!: Promise<unknown>;
     private autoscaleInterval!: BetterIntervalID;
     private maybeRunInterval!: BetterIntervalID;
     private queryingIsTaskReady!: boolean;
@@ -357,7 +356,7 @@ export class AutoscaledPool {
      * all the tasks are finished or one of them fails.
      */
     async run(): Promise<void> {
-        this.poolPromise = new Promise((resolve, reject) => {
+        const poolPromise = new Promise((resolve, reject) => {
             this.resolve = resolve;
             this.reject = reject;
         });
@@ -378,7 +377,7 @@ export class AutoscaledPool {
         }
 
         try {
-            await this.poolPromise;
+            await poolPromise;
         } finally {
             // If resolve is null, the pool is already destroyed.
             if (this.resolve) await this._destroy();


### PR DESCRIPTION
I found an unused private property while reading the code and couldn't figure out why it's there - can we get rid of it?