### PR TITLE
feat: `tieredProxyUrls` for ProxyConfiguration

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -1148,7 +1148,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
             this.log.debug(`Adding request ${request.url} (${request.id}) back to the queue`);
             // eslint-disable-next-line dot-notation
             source['inProgress'].add(request.id!);
-            await source.reclaimRequest(request);
+            await source.reclaimRequest(request, { forefront: request.userData?.__crawlee?.forefront });
         }, delay);
 
         return true;

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -1384,7 +1384,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
                     { id, url, retryCount },
                 );
 
-                await source.reclaimRequest(request);
+                await source.reclaimRequest(request, { forefront: request.userData?.__crawlee?.forefront });
                 return;
             }
         }

--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -495,7 +495,7 @@ export abstract class BrowserCrawler<
         if (this.proxyConfiguration && (useIncognitoPages || experimentalContainers)) {
             const { session } = crawlingContext;
 
-            const proxyInfo = await this.proxyConfiguration.newProxyInfo(session?.id);
+            const proxyInfo = await this.proxyConfiguration.newProxyInfo(session?.id, crawlingContext.request);
             crawlingContext.proxyInfo = proxyInfo;
 
             newPageOptions.proxyUrl = proxyInfo.url;

--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -492,22 +492,26 @@ export abstract class BrowserCrawler<
         const useIncognitoPages = this.launchContext?.useIncognitoPages;
         const experimentalContainers = this.launchContext?.experimentalContainers;
 
-        if (this.proxyConfiguration && (useIncognitoPages || experimentalContainers)) {
-            const { session } = crawlingContext;
+        if (this.proxyConfiguration) {
+            if (useIncognitoPages || experimentalContainers) {
+                const { session } = crawlingContext;
 
-            const proxyInfo = await this.proxyConfiguration.newProxyInfo(session?.id, crawlingContext.request);
-            crawlingContext.proxyInfo = proxyInfo;
+                const proxyInfo = await this.proxyConfiguration.newProxyInfo(session?.id, { request: crawlingContext.request });
+                crawlingContext.proxyInfo = proxyInfo;
 
-            newPageOptions.proxyUrl = proxyInfo.url;
+                newPageOptions.proxyUrl = proxyInfo.url;
 
-            if (this.proxyConfiguration.isManInTheMiddle) {
-                /**
-                 * @see https://playwright.dev/docs/api/class-browser/#browser-new-context
-                 * @see https://github.com/puppeteer/puppeteer/blob/main/docs/api.md
-                 */
-                newPageOptions.pageOptions = {
-                    ignoreHTTPSErrors: true,
-                };
+                if (this.proxyConfiguration.isManInTheMiddle) {
+                    /**
+                     * @see https://playwright.dev/docs/api/class-browser/#browser-new-context
+                     * @see https://github.com/puppeteer/puppeteer/blob/main/docs/api.md
+                     */
+                    newPageOptions.pageOptions = {
+                        ignoreHTTPSErrors: true,
+                    };
+                }
+            } else {
+                newPageOptions.proxyTier = this.proxyConfiguration.getProxyTier(crawlingContext.request);
             }
         }
 
@@ -702,7 +706,10 @@ export abstract class BrowserCrawler<
         }
 
         if (this.proxyConfiguration) {
-            const proxyInfo = await this.proxyConfiguration.newProxyInfo(launchContextExtends.session?.id);
+            const proxyInfo = await this.proxyConfiguration.newProxyInfo(
+                launchContextExtends.session?.id,
+                { proxyTier: (launchContext.proxyTier as number) ?? undefined },
+            );
             launchContext.proxyUrl = proxyInfo.url;
             launchContextExtends.proxyInfo = proxyInfo;
 

--- a/packages/browser-pool/src/abstract-classes/browser-controller.ts
+++ b/packages/browser-pool/src/abstract-classes/browser-controller.ts
@@ -55,6 +55,12 @@ export abstract class BrowserController<
      */
     launchContext: LaunchContext<Library, LibraryOptions, LaunchResult, NewPageOptions, NewPageResult> = undefined!;
 
+    /**
+     * The proxy tier tied to this browser controller.
+     * `undefined` if no tiered proxy is used.
+     */
+    proxyTier : number | undefined = undefined;
+
     isActive = false;
 
     activePages = 0;

--- a/packages/browser-pool/src/abstract-classes/browser-controller.ts
+++ b/packages/browser-pool/src/abstract-classes/browser-controller.ts
@@ -59,7 +59,7 @@ export abstract class BrowserController<
      * The proxy tier tied to this browser controller.
      * `undefined` if no tiered proxy is used.
      */
-    proxyTier : number | undefined = undefined;
+    proxyTier?: number;
 
     isActive = false;
 

--- a/packages/browser-pool/src/abstract-classes/browser-plugin.ts
+++ b/packages/browser-pool/src/abstract-classes/browser-plugin.ts
@@ -145,6 +145,7 @@ export abstract class BrowserPlugin<
             useIncognitoPages = this.useIncognitoPages,
             userDataDir = this.userDataDir,
             experimentalContainers = this.experimentalContainers,
+            proxyTier,
         } = options;
 
         return new LaunchContext({
@@ -155,6 +156,7 @@ export abstract class BrowserPlugin<
             useIncognitoPages,
             experimentalContainers,
             userDataDir,
+            proxyTier,
         });
     }
 

--- a/packages/browser-pool/src/browser-pool.ts
+++ b/packages/browser-pool/src/browser-pool.ts
@@ -700,7 +700,7 @@ export class BrowserPool<
             const hasCapacity = controller.activePages < this.maxOpenPagesPerBrowser;
             const isCorrectPlugin = controller.browserPlugin === browserPlugin;
 
-            return hasCapacity && isCorrectPlugin && (!options?.proxyTier || controller.proxyTier === options.proxyTier);
+            return hasCapacity && isCorrectPlugin && (typeof options?.proxyTier !== 'number' || controller.proxyTier === options.proxyTier);
         });
     }
 

--- a/packages/browser-pool/src/browser-pool.ts
+++ b/packages/browser-pool/src/browser-pool.ts
@@ -1,4 +1,5 @@
 import { addTimeoutToPromise, tryCancel } from '@apify/timeout';
+import { Request } from '@crawlee/core';
 import type { BrowserFingerprintWithHeaders } from 'fingerprint-generator';
 import { FingerprintGenerator } from 'fingerprint-generator';
 import { FingerprintInjector } from 'fingerprint-injector';
@@ -16,7 +17,6 @@ import type { FingerprintGeneratorOptions } from './fingerprinting/types';
 import type { LaunchContext } from './launch-context';
 import { log } from './logger';
 import type { InferBrowserPluginArray, UnwrapPromise } from './utils';
-import { Request } from '@crawlee/core';
 
 const PAGE_CLOSE_KILL_TIMEOUT_MILLIS = 1000;
 const BROWSER_KILLER_INTERVAL_MILLIS = 10 * 1000;

--- a/packages/browser-pool/src/browser-pool.ts
+++ b/packages/browser-pool/src/browser-pool.ts
@@ -726,28 +726,6 @@ export class BrowserPool<
                 closedBrowserIds,
             });
         }
-
-        // const retiredBrowserIds: string[] = [];
-
-        // for (const controller of this.activeBrowserControllers) {
-        //     const millisSinceLastPageOpened = Date.now() - controller.lastPageOpenedAt;
-        //     const isBrowserIdle = millisSinceLastPageOpened >= this.closeInactiveBrowserAfterMillis;
-        //     const isBrowserEmpty = controller.activePages === 0;
-
-        //     if (isBrowserIdle && isBrowserEmpty) {
-        //         const { id } = controller;
-        //         log.debug('Retiring idle browser.', { id });
-        //         this.retireBrowserController(controller);
-        //         retiredBrowserIds.push(id);
-        //     }
-        // }
-
-        // if (retiredBrowserIds.length) {
-        //     log.debug('Retired idle browsers.', {
-        //         count: retiredBrowserIds.length,
-        //         retiredBrowserIds,
-        //     });
-        // }
     }
 
     private _overridePageClose(page: PageReturn) {

--- a/packages/browser-pool/src/browser-pool.ts
+++ b/packages/browser-pool/src/browser-pool.ts
@@ -1,5 +1,4 @@
 import { addTimeoutToPromise, tryCancel } from '@apify/timeout';
-import { Request } from '@crawlee/core';
 import type { BrowserFingerprintWithHeaders } from 'fingerprint-generator';
 import { FingerprintGenerator } from 'fingerprint-generator';
 import { FingerprintInjector } from 'fingerprint-injector';

--- a/packages/browser-pool/src/launch-context.ts
+++ b/packages/browser-pool/src/launch-context.ts
@@ -50,6 +50,7 @@ export interface LaunchContextOptions<
      */
     userDataDir?: string;
     proxyUrl?: string;
+    proxyTier?: number;
 }
 
 export class LaunchContext<
@@ -65,6 +66,7 @@ export class LaunchContext<
     useIncognitoPages: boolean;
     experimentalContainers: boolean;
     userDataDir: string;
+    proxyTier?: number;
 
     private _proxyUrl?: string;
     private readonly _reservedFieldNames = [...Reflect.ownKeys(this), 'extend'];
@@ -81,6 +83,7 @@ export class LaunchContext<
             useIncognitoPages,
             experimentalContainers,
             userDataDir = '',
+            proxyTier,
         } = options;
 
         this.id = id;
@@ -89,6 +92,7 @@ export class LaunchContext<
         this.useIncognitoPages = useIncognitoPages ?? false;
         this.experimentalContainers = experimentalContainers ?? false;
         this.userDataDir = userDataDir;
+        this.proxyTier = proxyTier;
 
         this._proxyUrl = proxyUrl;
     }

--- a/packages/core/src/proxy_configuration.ts
+++ b/packages/core/src/proxy_configuration.ts
@@ -149,7 +149,7 @@ class ProxyTierTracker {
      * Returns the best proxy tier for the next request based on the error history for different proxy tiers.
      * @returns The proxy tier prediction
      */
-    getTier() {
+    predictTier() {
         this.processStep();
         return this.currentTier;
     }
@@ -311,7 +311,7 @@ export class ProxyConfiguration {
             tracker.addError(request.userData.__crawlee.lastProxyTier);
         }
 
-        const tierPrediction = tracker.getTier();
+        const tierPrediction = tracker.predictTier();
 
         request.userData.__crawlee.lastProxyTier = tierPrediction;
         request.userData.__crawlee.forefront = true;

--- a/packages/core/src/proxy_configuration.ts
+++ b/packages/core/src/proxy_configuration.ts
@@ -165,7 +165,7 @@ export class ProxyConfiguration {
 
         const { proxyUrls, newUrlFunction, tieredProxyUrls } = options;
 
-        if ([proxyUrls, newUrlFunction, tieredProxyUrls].filter(x => x).length > 1) this._throwCannotCombineCustomMethods();
+        if ([proxyUrls, newUrlFunction, tieredProxyUrls].filter((x) => x).length > 1) this._throwCannotCombineCustomMethods();
         if (!proxyUrls && !newUrlFunction && validateRequired) this._throwNoOptionsProvided();
 
         this.proxyUrls = proxyUrls;
@@ -211,7 +211,7 @@ export class ProxyConfiguration {
         if (!this.tieredProxyUrls) throw new Error('Tiered proxy URLs are not set');
 
         if (!request) {
-            const allProxyUrls = this.tieredProxyUrls.flatMap(x => x);
+            const allProxyUrls = this.tieredProxyUrls.flat();
             return allProxyUrls[this.nextCustomUrlIndex++ % allProxyUrls.length];
         }
 

--- a/packages/core/src/proxy_configuration.ts
+++ b/packages/core/src/proxy_configuration.ts
@@ -139,6 +139,8 @@ class ProxyTierTracker {
 
     /**
      * Increases the error score for the given proxy tier. This raises the chance of picking a different proxy tier for the subsequent requests.
+     *
+     * The error score is increased by 10 for the given tier. This means that this tier will be disadvantaged for the next 10 requests (every new request prediction decreases the error score by 1).
      * @param tier The proxy tier to mark as problematic.
      */
     addError(tier: number) {

--- a/packages/core/src/proxy_configuration.ts
+++ b/packages/core/src/proxy_configuration.ts
@@ -24,12 +24,11 @@ export interface ProxyConfigurationOptions {
     newUrlFunction?: ProxyConfigurationFunction;
 
     /**
-     * An array of custom proxy URLs tiers to be rotated.
-     * This is a more advanced version of `proxyUrls` that allows you to define
-     * a hierarchy of proxy URLs. If everything goes well, all the requests will be sent
-     * through the first proxy URL in the list.
-     * Whenever the crawler encounters a problem with the current proxy on the given domain, it will switch to the following proxy in the list.
-     * The crawler probes lower-level proxies at given intervals to check if it can make the downshift.
+     * An array of custom proxy URLs to be rotated stratified in tiers.
+     * This is a more advanced version of `proxyUrls` that allows you to define a hierarchy of proxy URLs
+     * If everything goes well, all the requests will be sent through the first proxy URL in the list.
+     * Whenever the crawler encounters a problem with the current proxy on the given domain, it will switch to the higher tier for this domain.
+     * The crawler probes lower-level proxies at intervals to check if it can make the tier downshift.
      *
      * This feature is useful when you have a set of proxies with different performance characteristics (speed, price, antibot performance etc.) and you want to use the best one for each domain.
      */

--- a/packages/core/src/proxy_configuration.ts
+++ b/packages/core/src/proxy_configuration.ts
@@ -260,7 +260,7 @@ export class ProxyConfiguration {
 
         let tierPrediction = options.proxyTier!;
 
-        if (tierPrediction === null) {
+        if (typeof tierPrediction !== 'number') {
             tierPrediction = this.getProxyTier(options.request!)!;
         }
 

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -47,6 +47,8 @@ export enum RequestState {
     SKIPPED,
 }
 
+type RequestEvent = 'sessionRotation';
+
 /**
  * Represents a URL to be crawled, optionally including HTTP method, headers, payload and other metadata.
  * The `Request` object also stores information about errors that occurred during processing of the request.
@@ -78,8 +80,6 @@ export enum RequestState {
  * ```
  * @category Sources
  */
-
-type RequestEvent = 'sessionRotation';
 export class Request<UserData extends Dictionary = Dictionary> {
     /** Request ID */
     id?: string;

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -47,8 +47,6 @@ export enum RequestState {
     SKIPPED,
 }
 
-type RequestEvent = 'sessionRotation';
-
 /**
  * Represents a URL to be crawled, optionally including HTTP method, headers, payload and other metadata.
  * The `Request` object also stores information about errors that occurred during processing of the request.
@@ -132,11 +130,6 @@ export class Request<UserData extends Dictionary = Dictionary> {
      * Is `null` if the request has not been crawled yet.
      */
     handledAt?: string;
-
-    /**
-     * Local hooks for the request. Note that the hooks are not persisted once the request is stored to a storage.
-     */
-    hooks: Partial<Record<RequestEvent, ((request: Request) => void)[]>> = {};
 
     /**
      * `Request` parameters including the URL, HTTP method and headers, and others.
@@ -288,8 +281,6 @@ export class Request<UserData extends Dictionary = Dictionary> {
         } else {
             this.userData.__crawlee.sessionRotationCount = value;
         }
-
-        this.hooks.sessionRotation?.forEach((hook) => hook(this));
     }
 
     /** shortcut for getting `request.userData.label` */
@@ -340,19 +331,6 @@ export class Request<UserData extends Dictionary = Dictionary> {
         } else {
             this.userData.__crawlee.enqueueStrategy = value;
         }
-    }
-
-    /**
-     * Adds a hook to the request. The hook is called on the specified `event`.
-     * The hooks are only useful for short-term modifications of the request - note that the hooks are not persisted once the request is stored to a storage.
-     * @param event The event to add the hook to.
-     * @param callable The hook to add.
-     */
-    addHook(event: RequestEvent, callable: (request: Request) => void | Promise<void>): void {
-        if (!this.hooks[event]) {
-            this.hooks[event] = [];
-        }
-        this.hooks[event]!.push(callable);
     }
 
     /**

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -133,7 +133,10 @@ export class Request<UserData extends Dictionary = Dictionary> {
      */
     handledAt?: string;
 
-    hooks: Map<RequestEvent, ((request: Request) => void)[]> = new Map();
+    /**
+     * Local hooks for the request. Note that the hooks are not persisted once the request is stored to a storage.
+     */
+    hooks: Partial<Record<RequestEvent, ((request: Request) => void)[]>> = {};
 
     /**
      * `Request` parameters including the URL, HTTP method and headers, and others.
@@ -286,7 +289,7 @@ export class Request<UserData extends Dictionary = Dictionary> {
             this.userData.__crawlee.sessionRotationCount = value;
         }
 
-        this.hooks.get('sessionRotation')?.forEach((hook) => hook(this));
+        this.hooks.sessionRotation?.forEach((hook) => hook(this));
     }
 
     /** shortcut for getting `request.userData.label` */
@@ -346,10 +349,10 @@ export class Request<UserData extends Dictionary = Dictionary> {
      * @param callable The hook to add.
      */
     addHook(event: RequestEvent, callable: (request: Request) => void | Promise<void>): void {
-        if (!this.hooks.has(event)) {
-            this.hooks.set(event, []);
+        if (!this.hooks[event]) {
+            this.hooks[event] = [];
         }
-        this.hooks.get(event)!.push(callable);
+        this.hooks[event]!.push(callable);
     }
 
     /**

--- a/packages/http-crawler/src/internals/http-crawler.ts
+++ b/packages/http-crawler/src/internals/http-crawler.ts
@@ -455,7 +455,7 @@ export class HttpCrawler<Context extends InternalHttpCrawlingContext<any, any, H
 
         if (this.proxyConfiguration) {
             const sessionId = session ? session.id : undefined;
-            crawlingContext.proxyInfo = await this.proxyConfiguration.newProxyInfo(sessionId, request);
+            crawlingContext.proxyInfo = await this.proxyConfiguration.newProxyInfo(sessionId, { request });
         }
 
         if (!request.skipNavigation) {

--- a/packages/http-crawler/src/internals/http-crawler.ts
+++ b/packages/http-crawler/src/internals/http-crawler.ts
@@ -455,7 +455,7 @@ export class HttpCrawler<Context extends InternalHttpCrawlingContext<any, any, H
 
         if (this.proxyConfiguration) {
             const sessionId = session ? session.id : undefined;
-            crawlingContext.proxyInfo = await this.proxyConfiguration.newProxyInfo(sessionId);
+            crawlingContext.proxyInfo = await this.proxyConfiguration.newProxyInfo(sessionId, request);
         }
 
         if (!request.skipNavigation) {

--- a/test/core/crawlers/basic_crawler.test.ts
+++ b/test/core/crawlers/basic_crawler.test.ts
@@ -695,7 +695,7 @@ describe('BasicCrawler', () => {
 
         // 1st try
 
-        expect(reclaimReq).toBeCalledWith(request1);
+        expect(reclaimReq).toBeCalledWith(request1, expect.objectContaining({}));
         expect(reclaimReq).toBeCalledTimes(3);
 
         expect(processed['http://example.com/0'].userData.foo).toBe('bar');

--- a/test/core/crawlers/cheerio_crawler.test.ts
+++ b/test/core/crawlers/cheerio_crawler.test.ts
@@ -1174,7 +1174,7 @@ describe('CheerioCrawler', () => {
                 // localhost proxy causes proxy errors, session rotations and finally throws, but we don't care
             }
 
-            expect(newUrlSpy).toBeCalledWith(usedSession.id, expect.any(Request));
+            expect(newUrlSpy).toBeCalledWith(usedSession.id, expect.objectContaining({ request: expect.any(Request) }));
         });
     });
 

--- a/test/core/crawlers/cheerio_crawler.test.ts
+++ b/test/core/crawlers/cheerio_crawler.test.ts
@@ -1174,7 +1174,7 @@ describe('CheerioCrawler', () => {
                 // localhost proxy causes proxy errors, session rotations and finally throws, but we don't care
             }
 
-            expect(newUrlSpy).toBeCalledWith(usedSession.id);
+            expect(newUrlSpy).toBeCalledWith(usedSession.id, expect.any(Request));
         });
     });
 

--- a/test/core/proxy_configuration.test.ts
+++ b/test/core/proxy_configuration.test.ts
@@ -195,7 +195,7 @@ describe('ProxyConfiguration', () => {
             expect(await proxyConfiguration.newUrl()).toEqual(tieredProxyUrls[0][0]);
         });
 
-        test('rotating request session results in higher-level proxies', async () => {
+        test('rotating a request results in higher-level proxies', async () => {
             const proxyConfiguration = new ProxyConfiguration({
                 tieredProxyUrls: [
                     ['http://proxy.com:1111'],
@@ -211,11 +211,7 @@ describe('ProxyConfiguration', () => {
             // @ts-expect-error protected property
             const { tieredProxyUrls } = proxyConfiguration;
             expect(await proxyConfiguration.newUrl('session-id', { request })).toEqual(tieredProxyUrls[0][0]);
-
-            request.sessionRotationCount++;
             expect(await proxyConfiguration.newUrl('session-id', { request })).toEqual(tieredProxyUrls[1][0]);
-
-            request.sessionRotationCount++;
             expect(await proxyConfiguration.newUrl('session-id', { request })).toEqual(tieredProxyUrls[2][0]);
 
             // we still get the same (higher) proxy tier even with a new request
@@ -223,7 +219,7 @@ describe('ProxyConfiguration', () => {
                 url: 'http://example.com/another-resource',
             });
 
-            expect(await proxyConfiguration.newUrl('session-id', { request })).toEqual(tieredProxyUrls[2][0]);
+            expect(await proxyConfiguration.newUrl('session-id', { request: request2 })).toEqual(tieredProxyUrls[2][0]);
         });
 
         test('upshifts and downshifts properly', async () => {
@@ -262,7 +258,7 @@ describe('ProxyConfiguration', () => {
                     gotToTheLowestProxy = true;
                     break;
                 }
-                // we don't need to increment the session rotation count here - we say that the proxies are good, so we promote the lower tier proxy prediction
+                // We don't increment the sessionRotationCount here - this causes the proxy tier to go down (current proxy is ok, so it tries to downshift in some time)
             }
 
             expect(gotToTheLowestProxy).toBe(true);

--- a/test/core/proxy_configuration.test.ts
+++ b/test/core/proxy_configuration.test.ts
@@ -1,5 +1,4 @@
 import { ProxyConfiguration, Request } from '@crawlee/core';
-import got from 'got';
 
 const sessionId = 538909250932;
 


### PR DESCRIPTION
Introduces the `tieredProxyUrls` option for `ProxyConfigration`, allowing the user to pass proxy URL groups. 

The `newProxyInfo` now takes an optional `request` parameter, which can be used for picking the correct proxy tier. Because of this, the proxy tiering doesn't work properly in browser crawlers without `useIncogintoPages` (as the proxy is tied to the launched browser instance and can be used for multiple requests).

To do:
- maybe figure out the tiers for `useIncognitoPages: false`
- use `sessionId` with the `tieredProxyUrls` - would require tracking the `session - URL - proxyTier` mapping, which might be a lot of data for large crawls... still worth trying out.