### PR TITLE
fix: correctly report gzip decompression errors

### DIFF
--- a/packages/utils/src/internals/sitemap.ts
+++ b/packages/utils/src/internals/sitemap.ts
@@ -162,7 +162,7 @@ export class Sitemap {
                     await new Promise((resolve, reject) => {
                         let stream: Duplex = sitemapStream;
                         if (sitemapUrl.endsWith('.gz')) {
-                            stream = stream.pipe(createGunzip());
+                            stream = stream.pipe(createGunzip()).on('error', reject);
                             sitemapUrl = sitemapUrl.substring(0, sitemapUrl.length - 3);
                         }
 

--- a/packages/utils/test/sitemap.test.ts
+++ b/packages/utils/test/sitemap.test.ts
@@ -46,6 +46,11 @@ describe('Sitemap', () => {
                 'nr/w/Eb2Ll2RVWLcvwrWMlWtWLWJcBIl6TdW/R/ZZp3soAdV/Yy2w1mOUI63tz4itCRd3Cz9882y',
                 'NfMGy9bJ8CfTZkU4fXUavAGtDs17GwMAAA==',
             ].join('\n'), 'base64'))
+            .get('/invalid_sitemap_child.xml.gz')
+            .reply(200, Buffer.from([
+                'H4sIAAAAAAAAA62S306DMBTG73kK0gtvDLSFLSKWcucTzOulKR00QottGZtPbxfQEEWXqElzkvMv',
+                'NfMGy9bJ8CfTZkU4fXUavAGtDs17GwMAAA==',
+            ].join('\n'), 'base64'))
             .get('/sitemap_parent.xml')
             .reply(200, [
                 '<?xml version="1.0" encoding="UTF-8"?>',
@@ -113,6 +118,13 @@ describe('Sitemap', () => {
             'http://not-exists.com/catalog?item=74&desc=vacation_newfoundland',
             'http://not-exists.com/catalog?item=83&desc=vacation_usa',
         ]));
+    });
+
+    it('identifies incorrect gzipped sitemaps as malformed', async () => {
+        const sitemap = await Sitemap.load(
+            'http://not-exists.com/invalid_sitemap_child.xml.gz',
+        );
+        expect(new Set(sitemap.urls)).toEqual(new Set([]));
     });
 
     it('follows links in sitemap indexes', async () => {


### PR DESCRIPTION
I have encountered an issue when trying to decompress an invalid gzip sitemap file with the `RobotsFile` util provided by crawlee. When the gzip file is malformed, an error occurs, that crashes the entire node process. This error cannot be catched by consumers of the library.

A reproduction and more information about this issue can be found here: https://github.com/CakeWithDivinity/crawlee-sitemap-error

This is the error reporting the crash of the node process from my reproduction repo:
![error thrown](https://github.com/apify/crawlee/assets/29003122/1159515b-99e1-4aeb-97b7-92e3e42d3179)

This is what it looks like after implementing my fix:
![Screenshot from 2024-02-27 20-23-25](https://github.com/apify/crawlee/assets/29003122/16123f0d-a575-4d59-9714-55bb8e3fe99f)
