### PR TITLE
Fix `EnqueueStrategy.All` erroring with `mailto:` links

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -1623,7 +1623,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
             }
             case EnqueueStrategy.All:
             default: {
-                return true;
+                return baseUrl.protocol === 'http:' || baseUrl.protocol === 'https:';
             }
         }
     }


### PR DESCRIPTION
This changes `EnqueueStrategy.All` to filter out non-http and non-https URLs (`mailto:` links were causing the crawler to error).

Let me know if there's a better fix or if you want me to change something.

Thanks!