### PR TITLE
test: circumvent ORB in `blockRequests` tests

### DIFF
--- a/test/core/playwright_utils.test.ts
+++ b/test/core/playwright_utils.test.ts
@@ -173,13 +173,12 @@ describe('playwrightUtils', () => {
 
                 const page = await browser.newPage();
                 await playwrightUtils.blockRequests(page);
-                page.on('response', (response) => loadedUrls.push(response.url()));
-                await page.setContent(`<html><body>
-                <link rel="stylesheet" type="text/css" href="${serverAddress}/style.css">
-                <img src="${serverAddress}/image.png">
-                <img src="${serverAddress}/image.gif">
-                <script src="${serverAddress}/script.js" defer="defer">></script>
-            </body></html>`, { waitUntil: 'load' });
+                page.on('response', (response) => {
+                    if (response.url() !== `${serverAddress}/special/resources`) {
+                        loadedUrls.push(response.url());
+                    }
+                });
+                await page.goto(`${serverAddress}/special/resources`, { waitUntil: 'networkidle' });
                 expect(loadedUrls).toEqual([`${serverAddress}/script.js`]);
             });
 
@@ -191,12 +190,7 @@ describe('playwrightUtils', () => {
                     urlPatterns: ['.css'],
                 });
                 page.on('response', (response) => loadedUrls.push(response.url()));
-                await page.setContent(`<html><body>
-                <link rel="stylesheet" type="text/css" href="${serverAddress}/style.css">
-                <img src="${serverAddress}/image.png">
-                <img src="${serverAddress}/image.gif">
-                <script src="${serverAddress}/script.js" defer="defer">></script>
-            </body></html>`, { waitUntil: 'load' });
+                await page.goto(`${serverAddress}/special/resources`, { waitUntil: 'networkidle' });
                 expect(loadedUrls).toEqual(expect.arrayContaining([
                     `${serverAddress}/image.png`,
                     `${serverAddress}/script.js`,


### PR DESCRIPTION
I remember dealing with this once already - when injecting HTML using `setContent` to `about:blank`, you confuse the browser into thinking that some weird CORS (more precisely, ORB) situation is going on. Loading the page on the correct domain (same as the subresources) mitigates this issue. 