### PR TITLE
feat: expand #shadow-root elements automatically in `parseWithCheerio` helper

### DIFF
--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -252,6 +252,12 @@ export interface BrowserCrawlerOptions<
      * Can be also set via {@apilink Configuration}.
      */
     headless?: boolean | 'new' | 'old'; // `new`/`old` are for puppeteer only
+
+    /**
+     * Whether to ignore custom elements (and their #shadow-roots) when processing the page content via `parseWithCheerio` helper.
+     * By default, they are expanded automatically. Use this option to disable this behavior.
+     */
+    ignoreShadowRoots?: boolean;
 }
 
 /**

--- a/packages/playwright-crawler/src/internals/playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/playwright-crawler.ts
@@ -197,7 +197,7 @@ export class PlaywrightCrawler extends BrowserCrawler<{ browserPlugins: [Playwri
     /**
      * All `PlaywrightCrawler` parameters are passed via an options object.
      */
-    constructor(options: PlaywrightCrawlerOptions = {}, override readonly config = Configuration.getGlobalConfig()) {
+    constructor(private readonly options: PlaywrightCrawlerOptions = {}, override readonly config = Configuration.getGlobalConfig()) {
         ow(options, 'PlaywrightCrawlerOptions', ow.object.exactShape(PlaywrightCrawler.optionsShape));
 
         const {
@@ -236,7 +236,7 @@ export class PlaywrightCrawler extends BrowserCrawler<{ browserPlugins: [Playwri
     }
 
     protected override async _runRequestHandler(context: PlaywrightCrawlingContext) {
-        registerUtilsToContext(context);
+        registerUtilsToContext(context, this.options);
         await super._runRequestHandler(context);
     }
 

--- a/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
+++ b/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
@@ -565,8 +565,7 @@ export async function saveSnapshot(page: Page, options: SaveSnapshotOptions = {}
 export async function parseWithCheerio(page: Page): Promise<CheerioRoot> {
     ow(page, ow.object.validate(validators.browserPage));
 
-    // eslint-disable-next-line no-new-func
-    const html = await page.evaluate(new Function(`return ${expandShadowRoots.toString()}(document)`) as any) as string;
+    const html = await page.evaluate(`(${expandShadowRoots.toString()})(document)`) as string;
     const pageContent = html || await page.content();
 
     return cheerio.load(pageContent);

--- a/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
+++ b/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
@@ -26,7 +26,7 @@ import log_ from '@apify/log';
 import type { Request } from '@crawlee/browser';
 import { validators, KeyValueStore, RequestState, Configuration } from '@crawlee/browser';
 import type { BatchAddRequestsResult } from '@crawlee/types';
-import type { CheerioRoot, Dictionary } from '@crawlee/utils';
+import { type CheerioRoot, type Dictionary, expandShadowRoots } from '@crawlee/utils';
 import * as cheerio from 'cheerio';
 import { getInjectableScript as getCookieClosingScript } from 'idcac-playwright';
 import ow from 'ow';
@@ -564,7 +564,11 @@ export async function saveSnapshot(page: Page, options: SaveSnapshotOptions = {}
  */
 export async function parseWithCheerio(page: Page): Promise<CheerioRoot> {
     ow(page, ow.object.validate(validators.browserPage));
-    const pageContent = await page.content();
+
+    // eslint-disable-next-line no-new-func
+    const html = await page.evaluate(new Function(`return ${expandShadowRoots.toString()}(document)`) as any) as string;
+    const pageContent = html || await page.content();
+
     return cheerio.load(pageContent);
 }
 

--- a/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
+++ b/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
@@ -35,7 +35,7 @@ import type { Page, Response, Route } from 'playwright';
 import { RenderingTypePredictor } from './rendering-type-prediction';
 import type { EnqueueLinksByClickingElementsOptions } from '../enqueue-links/click-elements';
 import { enqueueLinksByClickingElements } from '../enqueue-links/click-elements';
-import type { PlaywrightCrawlingContext } from '../playwright-crawler';
+import type { PlaywrightCrawlerOptions, PlaywrightCrawlingContext } from '../playwright-crawler';
 
 const log = log_.child({ prefix: 'Playwright Utils' });
 
@@ -561,11 +561,12 @@ export async function saveSnapshot(page: Page, options: SaveSnapshotOptions = {}
  * ```
  *
  * @param page Playwright [`Page`](https://playwright.dev/docs/api/class-page) object.
+ * @param ignoreShadowRoots
  */
-export async function parseWithCheerio(page: Page): Promise<CheerioRoot> {
+export async function parseWithCheerio(page: Page, ignoreShadowRoots = false): Promise<CheerioRoot> {
     ow(page, ow.object.validate(validators.browserPage));
 
-    const html = await page.evaluate(`(${expandShadowRoots.toString()})(document)`) as string;
+    const html = ignoreShadowRoots ? null : await page.evaluate(`(${expandShadowRoots.toString()})(document)`) as string;
     const pageContent = html || await page.content();
 
     return cheerio.load(pageContent);
@@ -755,7 +756,7 @@ export interface PlaywrightContextUtils {
     closeCookieModals(): Promise<void>;
 }
 
-export function registerUtilsToContext(context: PlaywrightCrawlingContext): void {
+export function registerUtilsToContext(context: PlaywrightCrawlingContext, crawlerOptions: PlaywrightCrawlerOptions): void {
     context.injectFile = async (filePath: string, options?: InjectFileOptions) => injectFile(context.page, filePath, options);
     context.injectJQuery = (async () => {
         if (context.request.state === RequestState.BEFORE_NAV) {
@@ -766,7 +767,7 @@ export function registerUtilsToContext(context: PlaywrightCrawlingContext): void
         await injectJQuery(context.page, { surviveNavigations: false });
     });
     context.blockRequests = async (options?: BlockRequestsOptions) => blockRequests(context.page, options);
-    context.parseWithCheerio = async () => parseWithCheerio(context.page);
+    context.parseWithCheerio = async () => parseWithCheerio(context.page, crawlerOptions.ignoreShadowRoots);
     context.infiniteScroll = async (options?: InfiniteScrollOptions) => infiniteScroll(context.page, options);
     context.saveSnapshot = async (options?: SaveSnapshotOptions) => saveSnapshot(context.page, { ...options, config: context.crawler.config });
     // eslint-disable-next-line max-len

--- a/packages/puppeteer-crawler/src/internals/puppeteer-crawler.ts
+++ b/packages/puppeteer-crawler/src/internals/puppeteer-crawler.ts
@@ -141,7 +141,7 @@ export class PuppeteerCrawler extends BrowserCrawler<{ browserPlugins: [Puppetee
     /**
      * All `PuppeteerCrawler` parameters are passed via an options object.
      */
-    constructor(options: PuppeteerCrawlerOptions = {}, override readonly config = Configuration.getGlobalConfig()) {
+    constructor(private readonly options: PuppeteerCrawlerOptions = {}, override readonly config = Configuration.getGlobalConfig()) {
         ow(options, 'PuppeteerCrawlerOptions', ow.object.exactShape(PuppeteerCrawler.optionsShape));
 
         const {
@@ -181,7 +181,7 @@ export class PuppeteerCrawler extends BrowserCrawler<{ browserPlugins: [Puppetee
     }
 
     protected override async _runRequestHandler(context: PuppeteerCrawlingContext) {
-        registerUtilsToContext(context);
+        registerUtilsToContext(context, this.options);
         await super._runRequestHandler(context);
     }
 

--- a/packages/puppeteer-crawler/src/internals/utils/puppeteer_utils.ts
+++ b/packages/puppeteer-crawler/src/internals/utils/puppeteer_utils.ts
@@ -185,8 +185,7 @@ export async function injectJQuery(page: Page, options?: { surviveNavigations?: 
 export async function parseWithCheerio(page: Page): Promise<CheerioRoot> {
     ow(page, ow.object.validate(validators.browserPage));
 
-    // eslint-disable-next-line no-new-func
-    const html = await page.evaluate(new Function(`return ${expandShadowRoots.toString()}(document)`) as any) as string;
+    const html = await page.evaluate(`(${expandShadowRoots.toString()})(document)`) as string;
     const pageContent = html || await page.content();
 
     return cheerio.load(pageContent);

--- a/packages/puppeteer-crawler/src/internals/utils/puppeteer_utils.ts
+++ b/packages/puppeteer-crawler/src/internals/utils/puppeteer_utils.ts
@@ -26,7 +26,7 @@ import log_ from '@apify/log';
 import type { Request } from '@crawlee/browser';
 import { KeyValueStore, RequestState, validators, Configuration } from '@crawlee/browser';
 import type { Dictionary, BatchAddRequestsResult } from '@crawlee/types';
-import { type CheerioRoot, sleep } from '@crawlee/utils';
+import { type CheerioRoot, expandShadowRoots, sleep } from '@crawlee/utils';
 import * as cheerio from 'cheerio';
 import type { ProtocolMapping } from 'devtools-protocol/types/protocol-mapping.js';
 import { getInjectableScript } from 'idcac-playwright';
@@ -184,7 +184,11 @@ export async function injectJQuery(page: Page, options?: { surviveNavigations?: 
  */
 export async function parseWithCheerio(page: Page): Promise<CheerioRoot> {
     ow(page, ow.object.validate(validators.browserPage));
-    const pageContent = await page.content();
+
+    // eslint-disable-next-line no-new-func
+    const html = await page.evaluate(new Function(`return ${expandShadowRoots.toString()}(document)`) as any) as string;
+    const pageContent = html || await page.content();
+
     return cheerio.load(pageContent);
 }
 

--- a/packages/utils/src/internals/general.ts
+++ b/packages/utils/src/internals/general.ts
@@ -94,7 +94,7 @@ export function snakeCaseToCamelCase(snakeCaseStr: string): string {
  * Traverses DOM and expands shadow-root elements (created by custom components).
  * @ignore
  */
-export async function expandShadowRoots(document: Document) {
+export function expandShadowRoots(document: Document): string {
     // Returns HTML of given shadow DOM.
     function getShadowDomHtml(shadowRoot: any) {
         let shadowHTML = '';

--- a/packages/utils/src/internals/general.ts
+++ b/packages/utils/src/internals/general.ts
@@ -89,3 +89,34 @@ export function snakeCaseToCamelCase(snakeCaseStr: string): string {
         })
         .join('');
 }
+
+/**
+ * Traverses DOM and expands shadow-root elements (created by custom components).
+ * @ignore
+ */
+export async function expandShadowRoots(document: Document) {
+    // Returns HTML of given shadow DOM.
+    function getShadowDomHtml(shadowRoot: any) {
+        let shadowHTML = '';
+
+        for (const el of shadowRoot.childNodes) {
+            shadowHTML += el.nodeValue ?? el.outerHTML ?? '';
+        }
+
+        return shadowHTML;
+    }
+
+    // Recursively replaces shadow DOMs with their HTML.
+    function replaceShadowDomsWithHtml(rootElement: any) {
+        for (const el of rootElement.querySelectorAll('*')) {
+            if (el.shadowRoot) {
+                replaceShadowDomsWithHtml(el.shadowRoot);
+                el.innerHTML += getShadowDomHtml(el.shadowRoot) ?? '';
+            }
+        }
+    }
+
+    replaceShadowDomsWithHtml(document.body);
+
+    return document.documentElement.outerHTML;
+}

--- a/test/core/playwright_utils.test.ts
+++ b/test/core/playwright_utils.test.ts
@@ -12,6 +12,8 @@ let serverAddress = 'http://localhost:';
 let port: number;
 let server: Server;
 
+const launchContext = { launchOptions: { headless: true } };
+
 beforeAll(async () => {
     [server, port] = await runExampleComServer();
     serverAddress += port;
@@ -39,288 +41,283 @@ describe('playwrightUtils', () => {
         await localStorageEmulator.destroy();
     });
 
-    describe.each([
-        [launchPlaywright, { launchOptions: { headless: true } }],
-    ] as const)('with %s', (launchName, launchContext) => {
-        test('injectFile()', async () => {
-            const browser2 = await launchName(launchContext);
-            const survive = async (browser: Browser) => {
-                // Survive navigations
-                const page = await browser.newPage();
-                // @ts-expect-error
-                let result = await page.evaluate(() => window.injectedVariable === 42);
-                expect(result).toBe(false);
-                await playwrightUtils.injectFile(page, path.join(__dirname, '..', 'shared', 'data', 'inject_file.txt'), { surviveNavigations: true });
-                // @ts-expect-error
-                result = await page.evaluate(() => window.injectedVariable);
-                expect(result).toBe(42);
-                await page.goto('about:chrome');
-                // @ts-expect-error
-                result = await page.evaluate(() => window.injectedVariable);
-                expect(result).toBe(42);
-                await page.goto(serverAddress);
-                // @ts-expect-error
-                result = await page.evaluate(() => window.injectedVariable);
-                expect(result).toBe(42);
-            };
-            const remove = async (browser: Browser) => {
-                // Remove with navigations
-                const page = await browser.newPage();
-                // @ts-expect-error
-                let result = await page.evaluate(() => window.injectedVariable === 42);
-                expect(result).toBe(false);
-                await page.goto('about:chrome');
-                // @ts-expect-error
-                result = await page.evaluate(() => window.injectedVariable === 42);
-                expect(result).toBe(false);
-                await playwrightUtils.injectFile(page, path.join(__dirname, '..', 'shared', 'data', 'inject_file.txt'));
-                // @ts-expect-error
-                result = await page.evaluate(() => window.injectedVariable);
-                expect(result).toBe(42);
-                await page.goto(serverAddress);
-                // @ts-expect-error
-                result = await page.evaluate(() => window.injectedVariable === 42);
-                expect(result).toBe(false);
-            };
-            try {
-                await Promise.all([survive(browser2), remove(browser2)]);
-            } finally {
-                await browser2.close();
-            }
+    test('injectFile()', async () => {
+        const browser2 = await launchPlaywright(launchContext);
+        const survive = async (browser: Browser) => {
+            // Survive navigations
+            const page = await browser.newPage();
+            // @ts-expect-error
+            let result = await page.evaluate(() => window.injectedVariable === 42);
+            expect(result).toBe(false);
+            await playwrightUtils.injectFile(page, path.join(__dirname, '..', 'shared', 'data', 'inject_file.txt'), { surviveNavigations: true });
+            // @ts-expect-error
+            result = await page.evaluate(() => window.injectedVariable);
+            expect(result).toBe(42);
+            await page.goto('about:chrome');
+            // @ts-expect-error
+            result = await page.evaluate(() => window.injectedVariable);
+            expect(result).toBe(42);
+            await page.goto(serverAddress);
+            // @ts-expect-error
+            result = await page.evaluate(() => window.injectedVariable);
+            expect(result).toBe(42);
+        };
+        const remove = async (browser: Browser) => {
+            // Remove with navigations
+            const page = await browser.newPage();
+            // @ts-expect-error
+            let result = await page.evaluate(() => window.injectedVariable === 42);
+            expect(result).toBe(false);
+            await page.goto('about:chrome');
+            // @ts-expect-error
+            result = await page.evaluate(() => window.injectedVariable === 42);
+            expect(result).toBe(false);
+            await playwrightUtils.injectFile(page, path.join(__dirname, '..', 'shared', 'data', 'inject_file.txt'));
+            // @ts-expect-error
+            result = await page.evaluate(() => window.injectedVariable);
+            expect(result).toBe(42);
+            await page.goto(serverAddress);
+            // @ts-expect-error
+            result = await page.evaluate(() => window.injectedVariable === 42);
+            expect(result).toBe(false);
+        };
+        try {
+            await Promise.all([survive(browser2), remove(browser2)]);
+        } finally {
+            await browser2.close();
+        }
+    });
+
+    test('injectJQuery()', async () => {
+        const browser = await launchPlaywright(launchContext);
+
+        try {
+            const page = await browser.newPage();
+            await page.goto('about:blank');
+
+            // NOTE: Chrome already defines window.$ as alias to document.querySelector(),
+            // (https://developers.google.com/web/tools/chrome-devtools/console/command-line-reference#queryselector)
+            const result1 = await page.evaluate(() => {
+                return {
+                    // @ts-expect-error
+                    isDefined: window.jQuery !== undefined,
+                };
+            });
+            expect(result1).toEqual({
+                isDefined: false,
+            });
+
+            await playwrightUtils.injectJQuery(page);
+
+            const result2 = await page.evaluate(() => {
+                /* global $ */
+                return {
+                    // @ts-expect-error
+                    isDefined: window.jQuery === window.$,
+                    // @ts-expect-error
+                    text: $('h1').text(),
+                };
+            });
+            expect(result2).toEqual({
+                isDefined: true,
+                text: '',
+            });
+
+            await page.reload();
+
+            const result3 = await page.evaluate(() => {
+                return {
+                    // @ts-expect-error
+                    isDefined: window.jQuery === window.$,
+                    // @ts-expect-error
+                    text: $('h1').text(),
+                };
+            });
+            expect(result3).toEqual({
+                isDefined: true,
+                text: '',
+            });
+        } finally {
+            await browser.close();
+        }
+    });
+
+    test('parseWithCheerio() works', async () => {
+        const browser = await launchPlaywright(launchContext);
+
+        try {
+            const page = await browser.newPage();
+            await page.goto(serverAddress);
+            const $ = await playwrightUtils.parseWithCheerio(page);
+
+            const title = $('h1').text().trim();
+            expect(title).toBe('Example Domain');
+        } finally {
+            await browser.close();
+        }
+    });
+
+    describe('blockRequests()', () => {
+        let browser: Browser = null;
+        beforeAll(async () => {
+            browser = await launchPlaywright(launchContext);
+        });
+        afterAll(async () => {
+            await browser.close();
         });
 
-        test('injectJQuery()', async () => {
-            const browser = await launchName(launchContext);
+        test('works with default values', async () => {
+            const loadedUrls: string[] = [];
 
-            try {
-                const page = await browser.newPage();
-                await page.goto('about:blank');
-
-                // NOTE: Chrome already defines window.$ as alias to document.querySelector(),
-                // (https://developers.google.com/web/tools/chrome-devtools/console/command-line-reference#queryselector)
-                const result1 = await page.evaluate(() => {
-                    return {
-                        // @ts-expect-error
-                        isDefined: window.jQuery !== undefined,
-                    };
-                });
-                expect(result1).toEqual({
-                    isDefined: false,
-                });
-
-                await playwrightUtils.injectJQuery(page);
-
-                const result2 = await page.evaluate(() => {
-                    /* global $ */
-                    return {
-                        // @ts-expect-error
-                        isDefined: window.jQuery === window.$,
-                        // @ts-expect-error
-                        text: $('h1').text(),
-                    };
-                });
-                expect(result2).toEqual({
-                    isDefined: true,
-                    text: '',
-                });
-
-                await page.reload();
-
-                const result3 = await page.evaluate(() => {
-                    return {
-                        // @ts-expect-error
-                        isDefined: window.jQuery === window.$,
-                        // @ts-expect-error
-                        text: $('h1').text(),
-                    };
-                });
-                expect(result3).toEqual({
-                    isDefined: true,
-                    text: '',
-                });
-            } finally {
-                await browser.close();
-            }
+            const page = await browser.newPage();
+            await playwrightUtils.blockRequests(page);
+            page.on('response', (response) => {
+                if (response.url() !== `${serverAddress}/special/resources`) {
+                    loadedUrls.push(response.url());
+                }
+            });
+            await page.goto(`${serverAddress}/special/resources`, { waitUntil: 'networkidle' });
+            expect(loadedUrls).toEqual([`${serverAddress}/script.js`]);
         });
 
-        test('parseWithCheerio() works', async () => {
-            const browser = await launchName(launchContext);
+        test('works with overridden values', async () => {
+            const loadedUrls: string[] = [];
 
-            try {
-                const page = await browser.newPage();
-                await page.goto(serverAddress);
+            const page = await browser.newPage();
+            await playwrightUtils.blockRequests(page, {
+                urlPatterns: ['.css'],
+            });
+            page.on('response', (response) => loadedUrls.push(response.url()));
+            await page.goto(`${serverAddress}/special/resources`, { waitUntil: 'networkidle' });
+            expect(loadedUrls).toEqual(expect.arrayContaining([
+                `${serverAddress}/image.png`,
+                `${serverAddress}/script.js`,
+                `${serverAddress}/image.gif`,
+            ]));
+        });
+    });
 
-                const $ = await playwrightUtils.parseWithCheerio(page);
+    test('gotoExtended() works', async () => {
+        const browser = await chromium.launch({ headless: true });
 
-                const title = $('h1').text().trim();
-                expect(title).toBe('Example Domain');
-            } finally {
-                await browser.close();
-            }
+        try {
+            const page = await browser.newPage();
+            const request = new Request({
+                url: `${serverAddress}/special/getDebug`,
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json; charset=utf-8',
+                },
+                payload: '{ "foo": "bar" }',
+            });
+
+            const response = await playwrightUtils.gotoExtended(page, request);
+
+            const { method, headers, bodyLength } = JSON.parse(await response.text());
+            expect(method).toBe('POST');
+            expect(bodyLength).toBe(16);
+            expect(headers['content-type']).toBe('application/json; charset=utf-8');
+        } finally {
+            await browser.close();
+        }
+    }, 60_000);
+
+    describe('infiniteScroll()', () => {
+        function isAtBottom() {
+            return (window.innerHeight + window.pageYOffset) >= document.body.offsetHeight;
+        }
+
+        let browser: Browser;
+        beforeAll(async () => {
+            browser = await chromium.launch({ headless: true });
+        });
+        afterAll(async () => {
+            await browser.close();
         });
 
-        describe('blockRequests()', () => {
-            let browser: Browser = null;
-            beforeAll(async () => {
-                browser = await launchName(launchContext);
+        let page: Page;
+        beforeEach(async () => {
+            page = await browser.newPage();
+            let count = 0;
+            const content = Array(1000).fill(null).map(() => {
+                return `<div style="border: 1px solid black">Div number: ${count++}</div>`;
             });
-            afterAll(async () => {
-                await browser.close();
-            });
-
-            test('works with default values', async () => {
-                const loadedUrls: string[] = [];
-
-                const page = await browser.newPage();
-                await playwrightUtils.blockRequests(page);
-                page.on('response', (response) => {
-                    if (response.url() !== `${serverAddress}/special/resources`) {
-                        loadedUrls.push(response.url());
-                    }
-                });
-                await page.goto(`${serverAddress}/special/resources`, { waitUntil: 'networkidle' });
-                expect(loadedUrls).toEqual([`${serverAddress}/script.js`]);
-            });
-
-            test('works with overridden values', async () => {
-                const loadedUrls: string[] = [];
-
-                const page = await browser.newPage();
-                await playwrightUtils.blockRequests(page, {
-                    urlPatterns: ['.css'],
-                });
-                page.on('response', (response) => loadedUrls.push(response.url()));
-                await page.goto(`${serverAddress}/special/resources`, { waitUntil: 'networkidle' });
-                expect(loadedUrls).toEqual(expect.arrayContaining([
-                    `${serverAddress}/image.png`,
-                    `${serverAddress}/script.js`,
-                    `${serverAddress}/image.gif`,
-                ]));
-            });
+            const contentHTML = `<html><body>${content}</body></html>`;
+            await page.setContent(contentHTML);
+        });
+        afterEach(async () => {
+            await page.close();
         });
 
-        test('gotoExtended() works', async () => {
-            const browser = await chromium.launch({ headless: true });
+        test('works', async () => {
+            const before = await page.evaluate(isAtBottom);
+            expect(before).toBe(false);
 
-            try {
-                const page = await browser.newPage();
-                const request = new Request({
-                    url: `${serverAddress}/special/getDebug`,
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json; charset=utf-8',
-                    },
-                    payload: '{ "foo": "bar" }',
-                });
+            await playwrightUtils.infiniteScroll(page, { waitForSecs: 0 });
 
-                const response = await playwrightUtils.gotoExtended(page, request);
-
-                const { method, headers, bodyLength } = JSON.parse(await response.text());
-                expect(method).toBe('POST');
-                expect(bodyLength).toBe(16);
-                expect(headers['content-type']).toBe('application/json; charset=utf-8');
-            } finally {
-                await browser.close();
-            }
-        }, 60_000);
-
-        describe('infiniteScroll()', () => {
-            function isAtBottom() {
-                return (window.innerHeight + window.pageYOffset) >= document.body.offsetHeight;
-            }
-
-            let browser: Browser;
-            beforeAll(async () => {
-                browser = await chromium.launch({ headless: true });
-            });
-            afterAll(async () => {
-                await browser.close();
-            });
-
-            let page: Page;
-            beforeEach(async () => {
-                page = await browser.newPage();
-                let count = 0;
-                const content = Array(1000).fill(null).map(() => {
-                    return `<div style="border: 1px solid black">Div number: ${count++}</div>`;
-                });
-                const contentHTML = `<html><body>${content}</body></html>`;
-                await page.setContent(contentHTML);
-            });
-            afterEach(async () => {
-                await page.close();
-            });
-
-            test('works', async () => {
-                const before = await page.evaluate(isAtBottom);
-                expect(before).toBe(false);
-
-                await playwrightUtils.infiniteScroll(page, { waitForSecs: 0 });
-
-                const after = await page.evaluate(isAtBottom);
-                expect(after).toBe(true);
-            });
-
-            test('maxScrollHeight works', async () => {
-                const before = await page.evaluate(isAtBottom);
-                expect(before).toBe(false);
-
-                await playwrightUtils.infiniteScroll(page, {
-                    waitForSecs: Infinity,
-                    maxScrollHeight: 1000,
-                    stopScrollCallback: async () => true,
-                });
-
-                const after = await page.evaluate(isAtBottom);
-                // It scrolls to the bottom in the first scroll so this is correct.
-                // The test passes because the Infinite waitForSecs is broken by the height requirement.
-                // If it didn't, the test would time out.
-                expect(after).toBe(true);
-            });
-
-            test('stopScrollCallback works', async () => {
-                const before = await page.evaluate(isAtBottom);
-                expect(before).toBe(false);
-
-                await playwrightUtils.infiniteScroll(page, {
-                    waitForSecs: Infinity,
-                    stopScrollCallback: async () => true,
-                });
-
-                const after = await page.evaluate(isAtBottom);
-                expect(after).toBe(true);
-            });
+            const after = await page.evaluate(isAtBottom);
+            expect(after).toBe(true);
         });
 
-        test('saveSnapshot() works', async () => {
-            const openKVSSpy = vitest.spyOn(KeyValueStore, 'open');
-            const browser = await chromium.launch({ headless: true });
+        test('maxScrollHeight works', async () => {
+            const before = await page.evaluate(isAtBottom);
+            expect(before).toBe(false);
 
-            try {
-                const page = await browser.newPage();
-                const contentHTML = '<html><head></head><body><div style="border: 1px solid black">Div number: 1</div></body></html>';
-                await page.setContent(contentHTML);
+            await playwrightUtils.infiniteScroll(page, {
+                waitForSecs: Infinity,
+                maxScrollHeight: 1000,
+                stopScrollCallback: async () => true,
+            });
 
-                const screenshot = await page.screenshot({ fullPage: true, type: 'jpeg', quality: 60 });
-
-                // Test saving both image and html
-                const object = { setValue: vitest.fn() };
-                openKVSSpy.mockResolvedValue(object as any);
-                await playwrightUtils.saveSnapshot(page, { key: 'TEST', keyValueStoreName: 'TEST-STORE', screenshotQuality: 60 });
-
-                expect(object.setValue).toBeCalledWith('TEST.jpg', screenshot, { contentType: 'image/jpeg' });
-                expect(object.setValue).toBeCalledWith('TEST.html', contentHTML, { contentType: 'text/html' });
-                object.setValue.mockReset();
-
-                // Test saving only image
-                await playwrightUtils.saveSnapshot(page, { saveHtml: false });
-
-                // Default quality is 50
-                const screenshot2 = await page.screenshot({ fullPage: true, type: 'jpeg', quality: 50 });
-                expect(object.setValue).toBeCalledWith('SNAPSHOT.jpg', screenshot2, { contentType: 'image/jpeg' });
-            } finally {
-                await browser.close();
-            }
+            const after = await page.evaluate(isAtBottom);
+            // It scrolls to the bottom in the first scroll so this is correct.
+            // The test passes because the Infinite waitForSecs is broken by the height requirement.
+            // If it didn't, the test would time out.
+            expect(after).toBe(true);
         });
+
+        test('stopScrollCallback works', async () => {
+            const before = await page.evaluate(isAtBottom);
+            expect(before).toBe(false);
+
+            await playwrightUtils.infiniteScroll(page, {
+                waitForSecs: Infinity,
+                stopScrollCallback: async () => true,
+            });
+
+            const after = await page.evaluate(isAtBottom);
+            expect(after).toBe(true);
+        });
+    });
+
+    test('saveSnapshot() works', async () => {
+        const openKVSSpy = vitest.spyOn(KeyValueStore, 'open');
+        const browser = await chromium.launch({ headless: true });
+
+        try {
+            const page = await browser.newPage();
+            const contentHTML = '<html><head></head><body><div style="border: 1px solid black">Div number: 1</div></body></html>';
+            await page.setContent(contentHTML);
+
+            const screenshot = await page.screenshot({ fullPage: true, type: 'jpeg', quality: 60 });
+
+            // Test saving both image and html
+            const object = { setValue: vitest.fn() };
+            openKVSSpy.mockResolvedValue(object as any);
+            await playwrightUtils.saveSnapshot(page, { key: 'TEST', keyValueStoreName: 'TEST-STORE', screenshotQuality: 60 });
+
+            expect(object.setValue).toBeCalledWith('TEST.jpg', screenshot, { contentType: 'image/jpeg' });
+            expect(object.setValue).toBeCalledWith('TEST.html', contentHTML, { contentType: 'text/html' });
+            object.setValue.mockReset();
+
+            // Test saving only image
+            await playwrightUtils.saveSnapshot(page, { saveHtml: false });
+
+            // Default quality is 50
+            const screenshot2 = await page.screenshot({ fullPage: true, type: 'jpeg', quality: 50 });
+            expect(object.setValue).toBeCalledWith('SNAPSHOT.jpg', screenshot2, { contentType: 'image/jpeg' });
+        } finally {
+            await browser.close();
+        }
     });
 });

--- a/test/core/puppeteer_utils.test.ts
+++ b/test/core/puppeteer_utils.test.ts
@@ -8,6 +8,8 @@ import type { Browser, Page, ResponseForRequest } from 'puppeteer';
 import { runExampleComServer } from 'test/shared/_helper';
 import { MemoryStorageEmulator } from 'test/shared/MemoryStorageEmulator';
 
+const launchContext = { launchOptions: { headless: true } };
+
 let port: number;
 let server: Server;
 let serverAddress = 'http://localhost:';
@@ -39,11 +41,9 @@ describe('puppeteerUtils', () => {
         await localStorageEmulator.destroy();
     });
 
-    describe.each([
-        [launchPuppeteer, { launchOptions: { headless: true } }],
-    ] as const)('with %s', (method, launchContext) => {
+    describe('with %s', () => {
         test('injectFile()', async () => {
-            const browser2 = await method(launchContext);
+            const browser2 = await launchPuppeteer(launchContext);
             const survive = async (browser: Browser) => {
                 // Survive navigations
                 const page = await browser.newPage();
@@ -90,7 +90,7 @@ describe('puppeteerUtils', () => {
         });
 
         test('injectJQuery()', async () => {
-            const browser = await method(launchContext);
+            const browser = await launchPuppeteer(launchContext);
 
             try {
                 const page = await browser.newPage();
@@ -143,7 +143,7 @@ describe('puppeteerUtils', () => {
         });
 
         test('parseWithCheerio() works', async () => {
-            const browser = await method(launchContext);
+            const browser = await launchPuppeteer(launchContext);
 
             try {
                 const page = await browser.newPage();
@@ -161,7 +161,7 @@ describe('puppeteerUtils', () => {
         describe('blockRequests()', () => {
             let browser: Browser = null;
             beforeAll(async () => {
-                browser = await method(launchContext);
+                browser = await launchPuppeteer(launchContext);
             });
             afterAll(async () => {
                 await browser.close();
@@ -226,13 +226,13 @@ describe('puppeteerUtils', () => {
         });
 
         test('supports cacheResponses()', async () => {
-            const browser = await method(launchContext);
+            const browser = await launchPuppeteer(launchContext);
             const cache: Dictionary<Partial<ResponseForRequest>> = {};
 
             const getResourcesLoadedFromWiki = async () => {
                 let downloadedBytes = 0;
                 const page = await browser.newPage();
-                await page.setDefaultNavigationTimeout(0);
+                page.setDefaultNavigationTimeout(0);
                 // Cache all javascript files, png files and svg files
                 await puppeteerUtils.cacheResponses(page, cache, ['.js', /.+\.png/i, /.+\.svg/i]);
                 page.on('response', async (response) => {
@@ -304,7 +304,7 @@ describe('puppeteerUtils', () => {
                 // TODO figure out why the err.message comes out empty in the logs.
                 expect((err as Error).message).toMatch(/Unexpected token '?const'?/);
             }
-            const browser = await method(launchContext);
+            const browser = await launchPuppeteer(launchContext);
             try {
                 const page = await browser.newPage();
                 const content = await script({ page } as any);
@@ -316,7 +316,7 @@ describe('puppeteerUtils', () => {
         });
 
         test('gotoExtended() works', async () => {
-            const browser = await method(launchContext);
+            const browser = await launchPuppeteer(launchContext);
 
             try {
                 const page = await browser.newPage();
@@ -331,7 +331,6 @@ describe('puppeteerUtils', () => {
 
                 const response = await puppeteerUtils.gotoExtended(page, request, { waitUntil: 'networkidle' });
 
-                // eslint-disable-next-line @typescript-eslint/no-shadow
                 const { method, headers, bodyLength } = JSON.parse(await response.text());
                 expect(method).toBe('POST');
                 expect(bodyLength).toBe(16);
@@ -411,7 +410,7 @@ describe('puppeteerUtils', () => {
 
         it('saveSnapshot() works', async () => {
             const openKVSSpy = vitest.spyOn(KeyValueStore, 'open');
-            const browser = await method(launchContext);
+            const browser = await launchPuppeteer(launchContext);
 
             try {
                 const page = await browser.newPage();


### PR DESCRIPTION
Custom HTML elements have their content isolated under a `#shadow-root` property, this PR handles its expansion by traversing the DOM and looking for all custom components with a shadow root, inlining its contents. This way, we can traverse the inside of a custom component via cheerio, as well as get the text content later on.

The behavior is enabled by default and can be disabled via `ignoreShadowRoots: true` in the crawler options.