### PR TITLE
fix: notify autoscaled pool about newly added requests

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -955,8 +955,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
         // Notify AutoscaledPool, if it exists, the method is called after the crawler started, and we don't want to wait
         // this is important for crawlers in `keepAlive` mode that might have an empty queue and we don't want to wait till
         // the next scheduled check (which might come in as much as 500ms by default).
-        // eslint-disable-next-line dot-notation
-        await this.autoscaledPool?.['_maybeRunTask']();
+        await this.autoscaledPool?.notify();
 
         return res;
     }

--- a/packages/core/src/autoscaling/autoscaled_pool.ts
+++ b/packages/core/src/autoscaling/autoscaled_pool.ts
@@ -449,6 +449,14 @@ export class AutoscaledPool {
     }
 
     /**
+     * Explicitly check the queue for new tasks. The AutoscaledPool checks the queue for new tasks periodically,
+     * every `maybeRunIntervalSecs` seconds. If you want to trigger the processing immediately, use this method.
+     */
+    async notify(): Promise<void> {
+        await this._maybeRunTask();
+    }
+
+    /**
      * Starts a new task
      * if the number of running tasks (current concurrency) is lower than desired concurrency
      * and the system is not currently overloaded


### PR DESCRIPTION
Notify AutoscaledPool when calling `crawler.addRequests()`. This is important for crawlers in `keepAlive` mode that might have an empty queue and we don't want to wait till the next scheduled check (which might come in as much as 500ms by default).

Related: https://apify.slack.com/archives/CD0SF6KD4/p1711660060498849