### PR TITLE
fix: sitemaps support `application/xml`

### DIFF
--- a/packages/utils/src/internals/robots.ts
+++ b/packages/utils/src/internals/robots.ts
@@ -14,7 +14,7 @@ let HTTPError: typeof HTTPErrorClass;
  * **Example usage:**
  * ```javascript
  * // Load the robots.txt file
- * const robots = await RobotsFile.load('https://crawlee.dev/docs/introduction/first-crawler');
+ * const robots = await RobotsFile.find('https://crawlee.dev/docs/introduction/first-crawler');
  *
  * // Check if a URL should be crawled according to robots.txt
  * const url = 'https://crawlee.dev/api/puppeteer-crawler/class/PuppeteerCrawler';
@@ -46,7 +46,7 @@ export class RobotsFile {
     }
 
     /**
-     * Allows providing the URL and robotx.txt content explicitly instead of loading it from the target site.
+     * Allows providing the URL and robots.txt content explicitly instead of loading it from the target site.
      * @param url the URL for robots.txt file
      * @param content contents of robots.txt
      * @param [proxyUrl] a proxy to be used for fetching the robots.txt file

--- a/packages/utils/src/internals/sitemap.ts
+++ b/packages/utils/src/internals/sitemap.ts
@@ -169,7 +169,7 @@ export class Sitemap {
                         const parser = (() => {
                             const contentType = sitemapStream.response!.headers['content-type'];
 
-                            if (contentType === 'text/xml' || sitemapUrl.endsWith('.xml')) {
+                            if (['text/xml', 'application/xml'].includes(contentType ?? '') || sitemapUrl.endsWith('.xml')) {
                                 return Sitemap.createXmlParser(parsingState, () => resolve(undefined), reject);
                             }
 


### PR DESCRIPTION
Some websites (e.g. https://www.topprodukte.at/xml_sitemap) return sitemaps with `application/xml` MIME type. 

According to [StackOverflow](https://stackoverflow.com/questions/4832357/whats-the-difference-between-text-xml-vs-application-xml-for-webservice-respons), this should be interchangeable with `text/xml` and we should therefore support it.

Also fixes some small typos in the `RobotsFile` jsdoc.