### PR TITLE
feat: `createAdaptivePlaywrightRouter` utility

### DIFF
--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -7,7 +7,7 @@ import type { Awaitable } from './typedefs';
 
 const defaultRoute = Symbol('default-route');
 
-export interface RouterHandler<Context extends RestrictedCrawlingContext = RestrictedCrawlingContext> extends Router<Context> {
+export interface RouterHandler<Context extends Omit<RestrictedCrawlingContext, "enqueueLinks"> = RestrictedCrawlingContext> extends Router<Context> {
     (ctx: Context): Awaitable<void>;
 }
 
@@ -82,7 +82,7 @@ export type RouterRoutes<Context, UserData extends Dictionary> = {
  * });
  * ```
  */
-export class Router<Context extends RestrictedCrawlingContext> {
+export class Router<Context extends Omit<RestrictedCrawlingContext, "enqueueLinks">> {
     private readonly routes: Map<string | symbol, (ctx: Context) => Awaitable<void>> = new Map();
     private readonly middlewares: ((ctx: Context) => Awaitable<void>)[] = [];
 
@@ -173,7 +173,7 @@ export class Router<Context extends RestrictedCrawlingContext> {
      * ```
      */
     static create<
-        Context extends RestrictedCrawlingContext = RestrictedCrawlingContext,
+        Context extends Omit<RestrictedCrawlingContext, "enqueueLinks"> = RestrictedCrawlingContext,
         UserData extends Dictionary = GetUserDataFromRequest<Context['request']>,
     >(routes?: RouterRoutes<Context, UserData>): RouterHandler<Context> {
         const router = new Router<Context>();

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -7,7 +7,7 @@ import type { Awaitable } from './typedefs';
 
 const defaultRoute = Symbol('default-route');
 
-export interface RouterHandler<Context extends Omit<RestrictedCrawlingContext, "enqueueLinks"> = RestrictedCrawlingContext> extends Router<Context> {
+export interface RouterHandler<Context extends Omit<RestrictedCrawlingContext, 'enqueueLinks'> = RestrictedCrawlingContext> extends Router<Context> {
     (ctx: Context): Awaitable<void>;
 }
 
@@ -82,7 +82,7 @@ export type RouterRoutes<Context, UserData extends Dictionary> = {
  * });
  * ```
  */
-export class Router<Context extends Omit<RestrictedCrawlingContext, "enqueueLinks">> {
+export class Router<Context extends Omit<RestrictedCrawlingContext, 'enqueueLinks'>> {
     private readonly routes: Map<string | symbol, (ctx: Context) => Awaitable<void>> = new Map();
     private readonly middlewares: ((ctx: Context) => Awaitable<void>)[] = [];
 
@@ -173,7 +173,7 @@ export class Router<Context extends Omit<RestrictedCrawlingContext, "enqueueLink
      * ```
      */
     static create<
-        Context extends Omit<RestrictedCrawlingContext, "enqueueLinks"> = RestrictedCrawlingContext,
+        Context extends Omit<RestrictedCrawlingContext, 'enqueueLinks'> = RestrictedCrawlingContext,
         UserData extends Dictionary = GetUserDataFromRequest<Context['request']>,
     >(routes?: RouterRoutes<Context, UserData>): RouterHandler<Context> {
         const router = new Router<Context>();

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -1,13 +1,13 @@
 import type { Dictionary } from '@crawlee/types';
 
-import type { CrawlingContext } from './crawlers/crawler_commons';
+import type { RestrictedCrawlingContext } from './crawlers/crawler_commons';
 import { MissingRouteError } from './errors';
 import type { Request } from './request';
 import type { Awaitable } from './typedefs';
 
 const defaultRoute = Symbol('default-route');
 
-export interface RouterHandler<Context extends CrawlingContext = CrawlingContext> extends Router<Context> {
+export interface RouterHandler<Context extends RestrictedCrawlingContext = RestrictedCrawlingContext> extends Router<Context> {
     (ctx: Context): Awaitable<void>;
 }
 
@@ -82,7 +82,7 @@ export type RouterRoutes<Context, UserData extends Dictionary> = {
  * });
  * ```
  */
-export class Router<Context extends CrawlingContext> {
+export class Router<Context extends RestrictedCrawlingContext> {
     private readonly routes: Map<string | symbol, (ctx: Context) => Awaitable<void>> = new Map();
     private readonly middlewares: ((ctx: Context) => Awaitable<void>)[] = [];
 
@@ -173,7 +173,7 @@ export class Router<Context extends CrawlingContext> {
      * ```
      */
     static create<
-        Context extends CrawlingContext = CrawlingContext,
+        Context extends RestrictedCrawlingContext = RestrictedCrawlingContext,
         UserData extends Dictionary = GetUserDataFromRequest<Context['request']>,
     >(routes?: RouterRoutes<Context, UserData>): RouterHandler<Context> {
         const router = new Router<Context>();

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -1,13 +1,13 @@
 import type { Dictionary } from '@crawlee/types';
 
-import type { RestrictedCrawlingContext } from './crawlers/crawler_commons';
+import type { CrawlingContext, RestrictedCrawlingContext } from './crawlers/crawler_commons';
 import { MissingRouteError } from './errors';
 import type { Request } from './request';
 import type { Awaitable } from './typedefs';
 
 const defaultRoute = Symbol('default-route');
 
-export interface RouterHandler<Context extends Omit<RestrictedCrawlingContext, 'enqueueLinks'> = RestrictedCrawlingContext> extends Router<Context> {
+export interface RouterHandler<Context extends Omit<RestrictedCrawlingContext, 'enqueueLinks'> = CrawlingContext> extends Router<Context> {
     (ctx: Context): Awaitable<void>;
 }
 
@@ -173,7 +173,7 @@ export class Router<Context extends Omit<RestrictedCrawlingContext, 'enqueueLink
      * ```
      */
     static create<
-        Context extends Omit<RestrictedCrawlingContext, 'enqueueLinks'> = RestrictedCrawlingContext,
+        Context extends Omit<RestrictedCrawlingContext, 'enqueueLinks'> = CrawlingContext,
         UserData extends Dictionary = GetUserDataFromRequest<Context['request']>,
     >(routes?: RouterRoutes<Context, UserData>): RouterHandler<Context> {
         const router = new Router<Context>();

--- a/packages/playwright-crawler/src/internals/adaptive-playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/adaptive-playwright-crawler.ts
@@ -1,7 +1,7 @@
 import { addTimeoutToPromise } from '@apify/timeout';
 import { extractUrlsFromPage } from '@crawlee/browser';
-import type { RestrictedCrawlingContext, StatisticState, StatisticPersistedState } from '@crawlee/core';
-import { Configuration, RequestHandlerResult, Statistics, withCheckedStorageAccess } from '@crawlee/core';
+import type { RestrictedCrawlingContext, StatisticState, StatisticPersistedState, GetUserDataFromRequest, RouterRoutes } from '@crawlee/core';
+import { Configuration, RequestHandlerResult, Router, Statistics, withCheckedStorageAccess } from '@crawlee/core';
 import type { Awaitable, Dictionary } from '@crawlee/types';
 import { extractUrlsFromCheerio } from '@crawlee/utils';
 import { load, type Cheerio, type Element } from 'cheerio';
@@ -64,7 +64,7 @@ class AdaptivePlaywrightCrawlerStatistics extends Statistics {
     }
 }
 
-interface AdaptivePlaywrightCrawlerContext extends RestrictedCrawlingContext {
+export interface AdaptivePlaywrightCrawlerContext extends RestrictedCrawlingContext {
     /**
      * Wait for an element matching the selector to appear and return a Cheerio object of matched elements.
      */
@@ -355,4 +355,11 @@ export class AdaptivePlaywrightCrawler extends PlaywrightCrawler {
             return { error, ok: false };
         }
     }
+}
+
+export function createAdaptivePlaywrightRouter<
+    Context extends AdaptivePlaywrightCrawlerContext = AdaptivePlaywrightCrawlerContext,
+    UserData extends Dictionary = GetUserDataFromRequest<Context['request']>,
+>(routes?: RouterRoutes<Context, UserData>) {
+    return Router.create<Context>(routes);
 }


### PR DESCRIPTION
- closes #2407
- the function itself makes it easier to use a Router for
structured adaptive crawling
- in this PR, we also export the `AdaptivePlaywrightCrawlerContext` type
and relax the type parameter constraint on `Router` to `RestrictedCrawlingContext`
