### PR TITLE
feat: `browserPerProxy` browser launch option

### DIFF
--- a/packages/browser-crawler/src/internals/browser-launcher.ts
+++ b/packages/browser-crawler/src/internals/browser-launcher.ts
@@ -32,6 +32,14 @@ export interface BrowserLaunchContext<TOptions, Launcher> extends BrowserPluginO
     useChrome?: boolean;
 
     /**
+     * If set to `true`, the crawler respects the proxy url generated for the given request.
+     * This aligns the browser-based crawlers with the `HttpCrawler`.
+     *
+     * Might cause performance issues, as Crawlee might launch too many browser instances.
+     */
+    browserPerProxy?: boolean;
+
+    /**
     * With this option selected, all pages will be opened in a new incognito browser context.
     * This means they will not share cookies nor cache and their resources will not be throttled by one another.
     * @default false
@@ -98,6 +106,7 @@ export abstract class BrowserLauncher<
         proxyUrl: ow.optional.string.url,
         useChrome: ow.optional.boolean,
         useIncognitoPages: ow.optional.boolean,
+        browserPerProxy: ow.optional.boolean,
         experimentalContainers: ow.optional.boolean,
         userDataDir: ow.optional.string,
         launchOptions: ow.optional.object,

--- a/packages/browser-pool/src/abstract-classes/browser-plugin.ts
+++ b/packages/browser-pool/src/abstract-classes/browser-plugin.ts
@@ -75,6 +75,13 @@ export interface BrowserPluginOptions<LibraryOptions> {
      * Path to a User Data Directory, which stores browser session data like cookies and local storage.
      */
     userDataDir?: string;
+    /**
+     * If set to `true`, the crawler respects the proxy url generated for the given request.
+     * This aligns the browser-based crawlers with the `HttpCrawler`.
+     *
+     * Might cause performance issues, as Crawlee might launch too many browser instances.
+     */
+    browserPerProxy?: boolean;
 }
 
 export interface CreateLaunchContextOptions<
@@ -112,6 +119,8 @@ export abstract class BrowserPlugin<
 
     experimentalContainers: boolean;
 
+    browserPerProxy?: boolean;
+
     constructor(library: Library, options: BrowserPluginOptions<LibraryOptions> = {}) {
         const {
             launchOptions = {} as LibraryOptions,
@@ -119,6 +128,7 @@ export abstract class BrowserPlugin<
             userDataDir,
             useIncognitoPages = false,
             experimentalContainers = false,
+            browserPerProxy = false,
         } = options;
 
         this.library = library;
@@ -127,6 +137,7 @@ export abstract class BrowserPlugin<
         this.userDataDir = userDataDir;
         this.useIncognitoPages = useIncognitoPages;
         this.experimentalContainers = experimentalContainers;
+        this.browserPerProxy = browserPerProxy;
     }
 
     /**
@@ -145,6 +156,7 @@ export abstract class BrowserPlugin<
             useIncognitoPages = this.useIncognitoPages,
             userDataDir = this.userDataDir,
             experimentalContainers = this.experimentalContainers,
+            browserPerProxy = this.browserPerProxy,
             proxyTier,
         } = options;
 
@@ -156,6 +168,7 @@ export abstract class BrowserPlugin<
             useIncognitoPages,
             experimentalContainers,
             userDataDir,
+            browserPerProxy,
             proxyTier,
         });
     }

--- a/packages/browser-pool/src/launch-context.ts
+++ b/packages/browser-pool/src/launch-context.ts
@@ -35,6 +35,13 @@ export interface LaunchContextOptions<
      */
     launchOptions: LibraryOptions;
     /**
+     * If set to `true`, the crawler respects the proxy url generated for the given request.
+     * This aligns the browser-based crawlers with the `HttpCrawler`.
+     *
+     * Might cause performance issues, as Crawlee might launch too many browser instances.
+     */
+    browserPerProxy?: boolean;
+    /**
      * By default pages share the same browser context.
      * If set to `true` each page uses its own context that is destroyed once the page is closed or crashes.
      */
@@ -64,6 +71,7 @@ export class LaunchContext<
     browserPlugin: BrowserPlugin<Library, LibraryOptions, LaunchResult, NewPageOptions, NewPageResult>;
     launchOptions: LibraryOptions;
     useIncognitoPages: boolean;
+    browserPerProxy?: boolean;
     experimentalContainers: boolean;
     userDataDir: string;
     proxyTier?: number;
@@ -81,6 +89,7 @@ export class LaunchContext<
             launchOptions,
             proxyUrl,
             useIncognitoPages,
+            browserPerProxy,
             experimentalContainers,
             userDataDir = '',
             proxyTier,
@@ -89,6 +98,7 @@ export class LaunchContext<
         this.id = id;
         this.browserPlugin = browserPlugin;
         this.launchOptions = launchOptions;
+        this.browserPerProxy = browserPerProxy ?? false;
         this.useIncognitoPages = useIncognitoPages ?? false;
         this.experimentalContainers = experimentalContainers ?? false;
         this.userDataDir = userDataDir;


### PR DESCRIPTION
Fixes the performance issues with the new proxy handling in browser crawlers reported by @AndreyBykov 's team.

Reduces the proxy antiblocking performance, though. Consider the following snippet: 

```typescript
  const proxyConfiguration = new ProxyConfiguration({
    newUrlFunction: async () => {
      return `http://session-${Math.random().toString().slice(2,6)}:password@proxy.apify.com:8000`;
    }
  })

  const crawler = new PuppeteerCrawler({
    proxyConfiguration,
    requestHandler: async ({ response, proxyInfo }) => {
      console.log((await response?.json()).ip);
    },
    headless: false,
    // browser per proxy = `false` by default
  });
  
  await crawler.run([
    'https://api.ipify.org/?format=json&q=qnom',
    'https://api.ipify.org/?format=json&q=bugt',
    'https://api.ipify.org/?format=json&q=qfju',
    'https://api.ipify.org/?format=json&q=utbb',
    'https://api.ipify.org/?format=json&q=ekqu',
  ]);

```

```
INFO  System info {"apifyVersion":"3.1.16","apifyClientVersion":"2.9.3","crawleeVersion":"3.9.0","osType":"Linux","nodeVersion":"v20.2.0"}
INFO  PuppeteerCrawler: Starting the crawler.
139.28.120.90
139.28.120.90
139.28.120.90
139.28.120.90
139.28.120.90
INFO  PuppeteerCrawler: All requests from the queue have been processed, the crawler will shut down.
INFO  PuppeteerCrawler: Final request statistics: {"requestsFinished":5,"requestsFailed":0,"retryHistogram":[5],"requestAvgFailedDurationMillis":null,"requestAvgFinishedDurationMillis":1189,"requestsFinishedPerMinute":86,"requestsFailedPerMinute":0,"requestTotalDurationMillis":5946,"requestsTotal":5,"crawlerRuntimeMillis":3489}
INFO  PuppeteerCrawler: Finished! Total 5 requests: 5 succeeded, 0 failed. {"terminal":true}

real    0m6,358s
user    0m6,097s
sys     0m0,929s
```

-------

With `browserPerProxy` enabled, the same code snippet runs twice as slow... but correct.
```diff
  const proxyConfiguration = new ProxyConfiguration({
    newUrlFunction: async () => {
      return `http://session-${Math.random().toString().slice(2,6)}:password@proxy.apify.com:8000`;
    }
  })

  const crawler = new PuppeteerCrawler({
    proxyConfiguration,
    requestHandler: async ({ response, proxyInfo }) => {
      console.log((await response?.json()).ip);
    },
    headless: false,
+    launchContext: {
+      browserPerProxy: true,
+    }
  });
  
  await crawler.run([
    'https://api.ipify.org/?format=json&q=qnom',
    'https://api.ipify.org/?format=json&q=bugt',
    'https://api.ipify.org/?format=json&q=qfju',
    'https://api.ipify.org/?format=json&q=utbb',
    'https://api.ipify.org/?format=json&q=ekqu',
  ]);
```
```
INFO  PuppeteerCrawler: Starting the crawler.
119.13.197.92
43.228.238.111
107.175.80.114
104.165.1.67
192.3.93.50
INFO  PuppeteerCrawler: All requests from the queue have been processed, the crawler will shut down.
INFO  PuppeteerCrawler: Final request statistics: {"requestsFinished":5,"requestsFailed":0,"retryHistogram":[5],"requestAvgFailedDurationMillis":null,"requestAvgFinishedDurationMillis":2263,"requestsFinishedPerMinute":34,"requestsFailedPerMinute":0,"requestTotalDurationMillis":11317,"requestsTotal":5,"crawlerRuntimeMillis":8765}
INFO  PuppeteerCrawler: Finished! Total 5 requests: 5 succeeded, 0 failed. {"terminal":true}

real    0m11,610s
user    0m12,990s
sys     0m3,295s
```