### PR TITLE
fix: break up growing stack in `AutoscaledPool.notify`

### DIFF
--- a/packages/core/src/autoscaling/autoscaled_pool.ts
+++ b/packages/core/src/autoscaling/autoscaled_pool.ts
@@ -453,7 +453,7 @@ export class AutoscaledPool {
      * every `maybeRunIntervalSecs` seconds. If you want to trigger the processing immediately, use this method.
      */
     async notify(): Promise<void> {
-        await this._maybeRunTask();
+        setImmediate(this._maybeRunTask);
     }
 
     /**


### PR DESCRIPTION
fixes #2421 