### PR TITLE
feat(sitemap): Support CDATA in sitemaps

### DIFF
--- a/packages/utils/src/internals/sitemap.ts
+++ b/packages/utils/src/internals/sitemap.ts
@@ -95,7 +95,7 @@ export class Sitemap {
             }
         });
 
-        parser.on('text', (text) => {
+        const onText = (text: string) => {
             if (parsingState.loc) {
                 if (parsingState.context === 'sitemapindex') {
                     if (!parsingState.visitedSitemapUrls.includes(text)) {
@@ -106,7 +106,9 @@ export class Sitemap {
                     parsingState.urls.push(text);
                 }
             }
-        });
+        };
+        parser.on('text', onText);
+        parser.on('cdata', onText);
 
         parser.on('end', onEnd);
         parser.on('error', onError);

--- a/packages/utils/test/sitemap.test.ts
+++ b/packages/utils/test/sitemap.test.ts
@@ -152,7 +152,7 @@ describe('Sitemap', () => {
         expect(sitemap.urls).toEqual([]);
     });
 
-    it.only('handles CDATA in loc tags', async () => {
+    it('handles CDATA in loc tags', async () => {
         const sitemap = await Sitemap.load('http://not-exists.com/sitemap_cdata.xml');
         expect(new Set(sitemap.urls)).toEqual(new Set([
             'http://not-exists.com/catalog',

--- a/packages/utils/test/sitemap.test.ts
+++ b/packages/utils/test/sitemap.test.ts
@@ -70,6 +70,15 @@ describe('Sitemap', () => {
                 '<A HREF="https://ads.google.com/home/">here</A>.',
                 '</BODY></HTML>',
             ].join('\n'))
+            .get('/sitemap_cdata.xml')
+            .reply(200, [
+                '<?xml version="1.0" encoding="UTF-8"?>',
+                '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+                '<url>',
+                '<loc><![CDATA[http://not-exists.com/catalog]]></loc>',
+                '</url>',
+                '</urlset>',
+            ].join('\n'))
             .get('/sitemap.xml')
             .reply(200, [
                 '<?xml version="1.0" encoding="UTF-8"?>',
@@ -141,6 +150,13 @@ describe('Sitemap', () => {
     it('does not break on invalid xml', async () => {
         const sitemap = await Sitemap.load('http://not-exists.com/not_actual_xml.xml');
         expect(sitemap.urls).toEqual([]);
+    });
+
+    it.only('handles CDATA in loc tags', async () => {
+        const sitemap = await Sitemap.load('http://not-exists.com/sitemap_cdata.xml');
+        expect(new Set(sitemap.urls)).toEqual(new Set([
+            'http://not-exists.com/catalog',
+        ]));
     });
 
     it('autodetects sitemaps', async () => {


### PR DESCRIPTION
During [fixing](https://github.com/topmonks/hlidac-shopu/pull/2109) Mironet actor for HlidacShopu, I've encountered CDATA in sitemap for the first time in my life. Not sure how common it is in real world.

https://www.mironet.cz/sm/sitemap_kategorie_p_1.xml.gz

```
<?xml version="1.0" encoding="UTF-8"?>
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
	<url>
		<loc><![CDATA[https://www.mironet.cz]]></loc>
		<lastmod>2024-04-16</lastmod>
		<changefreq>daily</changefreq>
		<priority>0.9</priority>
	</url>
``` 

This PR is just a quickest implementation I could come up with. Feel free to make any changes or to disagree that it should be included in crawlee core :)  