### PR TITLE
docs: mitigate logotype "aliasing" on homepage

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -26,9 +26,6 @@ function Hero() {
                             <h1 className={styles.tagline}>
                                 Crawlee is a <span>web<br /> scraping</span> and <span>browser<br /> automation</span> library
                             </h1>
-                            <h1 className={styles.tagline}>
-                                Crawlee is a web<br /> scraping and browser<br /> automation library
-                            </h1>
                         </div>
                     </div>
                     <div className="row">

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -26,6 +26,9 @@ function Hero() {
                             <h1 className={styles.tagline}>
                                 Crawlee is a <span>web<br /> scraping</span> and <span>browser<br /> automation</span> library
                             </h1>
+                            <h1 className={styles.tagline}>
+                                Crawlee is a web<br /> scraping and browser<br /> automation library
+                            </h1>
                         </div>
                     </div>
                     <div className="row">

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -40,7 +40,8 @@
 }
 
 .heroBanner h1:nth-child(1) {
-    background: linear-gradient(225deg, #FFB200 0.1%, #FFB100 8.15%, #FFAF02 15.6%, #FEAB04 22.55%, #FDA606 29.08%, #FCA00A 35.28%, #FB980E 41.26%, #FA9013 47.1%, #F98618 52.89%, #F77B1E 58.73%, #F56F24 64.71%, #F3632B 70.91%, #F25532 77.44%, #EF473A 84.39%, #ED3842 91.84%, #EB284B 99.9%);
+    background: linear-gradient(225deg, #FFB200 0.1%, #FFB100 8.15%, #FFAF02 15.6%, #FEAB04 22.55%, #FDA606 29.08%, #FCA00A 35.28%, #FB980E 41.26%, #FA9013 47.1%, #F98618 52.89%, #F77B1E 58.73%, #F56F24 64.71%, #F3632B 70.91%, #F25532 77.44%, #EF473A 84.39%, #ED3842 91.84%, #EB284B 99.9%), 
+        #FCA000;
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
@@ -51,19 +52,6 @@
     top: 0;
     z-index: 1;
     width: calc(100% - 2rem);
-}
-
-.heroBanner h1:nth-child(3) {
-    position: absolute;
-    top: 0;
-    z-index: -1;
-    width: calc(100% - 2rem);
-
-    -webkit-text-stroke: 1px white;
-}
-
-html[data-theme='dark'] .heroBanner h1:nth-child(3) {
-    -webkit-text-stroke: 1px var(--ifm-background-color);
 }
 
 .heroBanner h1::selection,

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -53,6 +53,19 @@
     width: calc(100% - 2rem);
 }
 
+.heroBanner h1:nth-child(3) {
+    position: absolute;
+    top: 0;
+    z-index: -1;
+    width: calc(100% - 2rem);
+
+    -webkit-text-stroke: 1px white;
+}
+
+html[data-theme='dark'] .heroBanner h1:nth-child(3) {
+    -webkit-text-stroke: 1px var(--ifm-background-color);
+}
+
 .heroBanner h1::selection,
 .heroBanner h1 span::selection {
     color: rgb(36, 39, 54) !important;

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -40,8 +40,7 @@
 }
 
 .heroBanner h1:nth-child(1) {
-    background: linear-gradient(225deg, #FFB200 0.1%, #FFB100 8.15%, #FFAF02 15.6%, #FEAB04 22.55%, #FDA606 29.08%, #FCA00A 35.28%, #FB980E 41.26%, #FA9013 47.1%, #F98618 52.89%, #F77B1E 58.73%, #F56F24 64.71%, #F3632B 70.91%, #F25532 77.44%, #EF473A 84.39%, #ED3842 91.84%, #EB284B 99.9%),
-    linear-gradient(0deg, #41465D, #41465D);
+    background: linear-gradient(225deg, #FFB200 0.1%, #FFB100 8.15%, #FFAF02 15.6%, #FEAB04 22.55%, #FDA606 29.08%, #FCA00A 35.28%, #FB980E 41.26%, #FA9013 47.1%, #F98618 52.89%, #F77B1E 58.73%, #F56F24 64.71%, #F3632B 70.91%, #F25532 77.44%, #EF473A 84.39%, #ED3842 91.84%, #EB284B 99.9%);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;


### PR DESCRIPTION
Before:
![obrazek](https://github.com/apify/crawlee/assets/61918049/346e56a4-830d-4927-bed5-acacddc1cfe5)

After:
![obrazek](https://github.com/apify/crawlee/assets/61918049/e887d97b-fb97-405d-9703-f3c501bdd5a4)

Switching:
![Peek 2024-04-25 14-47](https://github.com/apify/crawlee/assets/61918049/39bd24b9-8951-40b6-9ed1-6ddd6c80d1a7)


The antialiasing on the font seems to be calculated from the final `background` layer(?) - in the case of the gradient-colored text, the lowest layer was gray(?), the fringe didn't match the font/background color and was causing unappealing results.

As a bonus, the users still get the text highlight, even if their browser couldn't render the gradient for some reason.