### PR TITLE
fix: return true when robots.isAllowed returns undefined

### DIFF
--- a/packages/utils/src/internals/robots.ts
+++ b/packages/utils/src/internals/robots.ts
@@ -83,7 +83,7 @@ export class RobotsFile {
      * @param [userAgent] relevant user agent, default to `*`
      */
     isAllowed(url: string, userAgent = '*'): boolean {
-        return this.robots.isAllowed(url, userAgent) ?? true;
+        return this.robots.isAllowed(url, userAgent) ?? true; // `undefined` means that there is no explicit rule for the requested URL - assume it's allowed
     }
 
     /**

--- a/packages/utils/src/internals/robots.ts
+++ b/packages/utils/src/internals/robots.ts
@@ -83,7 +83,7 @@ export class RobotsFile {
      * @param [userAgent] relevant user agent, default to `*`
      */
     isAllowed(url: string, userAgent = '*'): boolean {
-        return this.robots.isAllowed(url, userAgent) ?? false;
+        return this.robots.isAllowed(url, userAgent) ?? true;
     }
 
     /**


### PR DESCRIPTION
`undefined` means that there is no explicit rule for the requested route. No rules means no disallow, therefore it's allowed.

Fixes #2437