### PR TITLE
fix(core): use createSessionFunction when loading Session from persisted state

### DIFF
--- a/packages/core/src/session_pool/session_pool.ts
+++ b/packages/core/src/session_pool/session_pool.ts
@@ -65,7 +65,7 @@ export interface SessionPoolOptions {
     /**
      * Control how and when to persist the state of the session pool.
      */
-     persistenceOptions?: PersistenceOptions;
+    persistenceOptions?: PersistenceOptions;
 }
 
 /**
@@ -472,7 +472,7 @@ export class SessionPool extends EventEmitter {
             sessionObject.sessionPool = this;
             sessionObject.createdAt = new Date(sessionObject.createdAt as string);
             sessionObject.expiresAt = new Date(sessionObject.expiresAt as string);
-            const recreatedSession = new Session(sessionObject);
+            const recreatedSession = await this.createSessionFunction(this, { sessionOptions: sessionObject });
 
             if (recreatedSession.isUsable()) {
                 this._addSession(recreatedSession);


### PR DESCRIPTION
Changes SessionPool's new Session loading behavior in the core module to utilize the configured createSessionFunction if specified. This ensures that new Sessions are instantiated using the custom session creation logic provided by the user, improving flexibility and adherence to user configurations.