### PR TITLE
docs: Should be "Same Domain" not "Same Subdomain"

### DIFF
--- a/website/versioned_docs/version-3.9/examples/crawl_relative_links.mdx
+++ b/website/versioned_docs/version-3.9/examples/crawl_relative_links.mdx
@@ -69,7 +69,7 @@ For instance, hyperlinks like `https://example.com/some/path`, `/absolute/exampl
 
 </TabItem>
 
-<TabItem value="same-subdomain" label="Same Subdomain" default>
+<TabItem value="same-domain" label="Same Domain" default>
 
 :::note Example domains
 


### PR DESCRIPTION
The docs appear to be a bit misleading. If people want "Same Subdomain" they should actually use "Same Hostname".
![image](https://github.com/apify/crawlee/assets/10026538/2b5452c5-e313-404b-812d-811e0764bd2d)
