### PR TITLE
fix(core): fire local `SystemInfo` events every second

### DIFF
--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -264,7 +264,7 @@ export class Configuration {
         purgeOnStart: true,
         headless: true,
         persistStateIntervalMillis: 60_000,
-        systemInfoIntervalMillis: 60_000,
+        systemInfoIntervalMillis: 1_000,
         persistStorage: true,
     };
 


### PR DESCRIPTION
During local development, we are firing events for the AutoscaledPool about current system resources like memory or CPU. We were firing them once a minute by default, but we remove those snapshots older than 30s, so we never had anything to compare and always used only the very last piece of information.

This PR changes the interval to 1s, aligning this with how the Apify platform fires events.