### PR TITLE
fix: do not drop statistics on migration/resurrection/resume

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -830,11 +830,11 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
 
         const purgeRequestQueue = options?.purgeRequestQueue ?? true;
 
-        // When executing the run method for the second time explicitly,
-        // we need to purge the default RQ to allow processing the same requests again - this is important so users can
-        // pass in failed requests back to the `crawler.run()`, otherwise they would be considered as handled and
-        // ignored - as a failed requests is still handled.
-        if (this.hasFinishedBefore && this.requestQueue?.name === 'default' && purgeRequestQueue) {
+        if (this.hasFinishedBefore) {
+            // When executing the run method for the second time explicitly,
+            // we need to purge the default RQ to allow processing the same requests again - this is important so users can
+            // pass in failed requests back to the `crawler.run()`, otherwise they would be considered as handled and
+            // ignored - as a failed requests is still handled.
             if (this.requestQueue?.name === 'default' && purgeRequestQueue) {
                 await this.requestQueue.drop();
                 this.requestQueue = await this._getRequestQueue();

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -470,8 +470,8 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
      */
     readonly router: RouterHandler<Context> = Router.create<Context>();
 
-    running: boolean = false;
-    hasFinishedBefore: boolean = false;
+    running = false;
+    hasFinishedBefore = false;
 
     protected log: Log;
     protected requestHandler!: RequestHandler<Context>;

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -835,8 +835,10 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
         // pass in failed requests back to the `crawler.run()`, otherwise they would be considered as handled and
         // ignored - as a failed requests is still handled.
         if (this.hasFinishedBefore && this.requestQueue?.name === 'default' && purgeRequestQueue) {
-            await this.requestQueue.drop();
-            this.requestQueue = await this._getRequestQueue();
+            if (this.requestQueue?.name === 'default' && purgeRequestQueue) {
+                await this.requestQueue.drop();
+                this.requestQueue = await this._getRequestQueue();
+            }
 
             this.stats.reset();
             await this.stats.resetStore();

--- a/packages/playwright-crawler/src/internals/adaptive-playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/adaptive-playwright-crawler.ts
@@ -1,6 +1,13 @@
 import { addTimeoutToPromise } from '@apify/timeout';
 import { extractUrlsFromPage } from '@crawlee/browser';
-import type { RestrictedCrawlingContext, StatisticState, StatisticPersistedState, GetUserDataFromRequest, RouterRoutes } from '@crawlee/core';
+import type {
+    RestrictedCrawlingContext,
+    StatisticState,
+    StatisticsOptions,
+    StatisticPersistedState,
+    GetUserDataFromRequest,
+    RouterRoutes,
+} from '@crawlee/core';
 import { Configuration, RequestHandlerResult, Router, Statistics, withCheckedStorageAccess } from '@crawlee/core';
 import type { Awaitable, Dictionary } from '@crawlee/types';
 import { extractUrlsFromCheerio } from '@crawlee/utils';
@@ -27,6 +34,11 @@ interface AdaptivePlaywrightCrawlerPersistedStatisticState extends StatisticPers
 
 class AdaptivePlaywrightCrawlerStatistics extends Statistics {
     override state: AdaptivePlaywrightCrawlerStatisticState = null as any; // this needs to be assigned for a valid override, but the initialization is done by a reset() call from the parent constructor
+
+    constructor(options: StatisticsOptions = {}) {
+        super(options);
+        this.reset();
+    }
 
     override reset(): void {
         super.reset();


### PR DESCRIPTION
This fixes a bug that was introduced with https://github.com/apify/crawlee/pull/1844 and https://github.com/apify/crawlee/pull/2083 - we reset the persisted state for statistics and session pool each time a crawler is started, which prevents their restoration.