### PR TITLE
fix: double tier decrement in tiered proxy

### DIFF
--- a/packages/core/src/proxy_configuration.ts
+++ b/packages/core/src/proxy_configuration.ts
@@ -142,9 +142,7 @@ class ProxyTierTracker {
 
         if (this.histogram[this.currentTier] > Math.min(left, right)) {
             this.currentTier = left <= right ? this.currentTier - 1 : this.currentTier + 1;
-        }
-
-        if (this.histogram[this.currentTier] === left) {
+        } else if (this.histogram[this.currentTier] === left) {
             this.currentTier--;
         }
     }


### PR DESCRIPTION
Mitigates an index-out-of-bounds error that happens in a certain scenario of tier switching.

![obrazek](https://github.com/apify/crawlee/assets/61918049/9f62c7bb-1d7e-4fcb-b1a1-ee7c1bdda892)
Repro by @VojtaM39

```typescript
import { Actor } from 'apify';
import { CheerioCrawler } from 'crawlee';

await Actor.init();

const proxyConfiguration = await Actor.createProxyConfiguration({
    tieredProxyConfig: [
        { groups: [] },
        { groups: ['RESIDENTIAL'] },
    ],
});

const crawler = new CheerioCrawler({
    proxyConfiguration,
    maxRequestRetries: 3,
    requestHandler: async () => {
        throw new Error('test');
    },
});

await crawler.run([{ url: 'http://example.com/', skipNavigation: true }]);

await Actor.exit();
```

