### PR TITLE
refactor: Remove redundant fields from `StatisticsPersistedState`

### DIFF
--- a/packages/core/src/crawlers/statistics.ts
+++ b/packages/core/src/crawlers/statistics.ts
@@ -464,11 +464,8 @@ export interface StatisticPersistedState extends Omit<StatisticState, 'statsPers
     statsId: number;
     requestAvgFailedDurationMillis: number;
     requestAvgFinishedDurationMillis: number;
-    requestsFinishedPerMinute: number;
-    requestsFailedPerMinute: number;
     requestTotalDurationMillis: number;
     requestsTotal: number;
-    crawlerRuntimeMillis: number;
     crawlerLastStartTimestamp: number;
     statsPersistedAt: string;
 }


### PR DESCRIPTION
Those fields are duplicated in the base class anyway.