### PR TITLE
fix: provide URLs to the error snapshot

### DIFF
--- a/packages/core/src/crawlers/error_snapshotter.ts
+++ b/packages/core/src/crawlers/error_snapshotter.ts
@@ -18,6 +18,13 @@ export interface SnapshotResult {
     htmlFileName?: string;
 }
 
+interface ErrorSnapshot {
+    screenshotFileName?: string;
+    screenshotFileUrl?: string;
+    htmlFileName?: string;
+    htmlFileUrl?: string;
+}
+
 /**
  * ErrorSnapshotter class is used to capture a screenshot of the page and a snapshot of the HTML when an error occurs during web crawling.
  *
@@ -42,7 +49,7 @@ export class ErrorSnapshotter {
     /**
      * Capture a snapshot of the error context.
      */
-    async captureSnapshot(error: ErrnoException, context: CrawlingContext): Promise<{ screenshotFileName?: string; htmlFileName?: string }> {
+    async captureSnapshot(error: ErrnoException, context: CrawlingContext): Promise<ErrorSnapshot> {
         try {
             const page = context?.page as BrowserPage | undefined;
             const body = context?.body;
@@ -80,7 +87,9 @@ export class ErrorSnapshotter {
 
             return {
                 screenshotFileName,
+                screenshotFileUrl: screenshotFileName && keyValueStore.getPublicUrl(screenshotFileName),
                 htmlFileName,
+                htmlFileUrl: htmlFileName && keyValueStore.getPublicUrl(htmlFileName),
             };
         } catch {
             return {};

--- a/packages/core/src/crawlers/error_tracker.ts
+++ b/packages/core/src/crawlers/error_tracker.ts
@@ -407,10 +407,12 @@ export class ErrorTracker {
             return;
         }
 
-        const { screenshotFileName, htmlFileName } = await this.errorSnapshotter.captureSnapshot(error, context);
+        const { screenshotFileName, htmlFileName, screenshotFileUrl, htmlFileUrl } = await this.errorSnapshotter.captureSnapshot(error, context);
 
         storage.firstErrorScreenshot = screenshotFileName;
+        storage.firstErrorScreenshotUrl = screenshotFileUrl;
         storage.firstErrorHtml = htmlFileName;
+        storage.firstErrorHtmlUrl = htmlFileUrl;
     }
 
     reset() {

--- a/packages/core/src/crawlers/error_tracker.ts
+++ b/packages/core/src/crawlers/error_tracker.ts
@@ -407,11 +407,9 @@ export class ErrorTracker {
             return;
         }
 
-        const { screenshotFileName, htmlFileName, screenshotFileUrl, htmlFileUrl } = await this.errorSnapshotter.captureSnapshot(error, context);
+        const { screenshotFileUrl, htmlFileUrl } = await this.errorSnapshotter.captureSnapshot(error, context);
 
-        storage.firstErrorScreenshot = screenshotFileName;
         storage.firstErrorScreenshotUrl = screenshotFileUrl;
-        storage.firstErrorHtml = htmlFileName;
         storage.firstErrorHtmlUrl = htmlFileUrl;
     }
 

--- a/packages/core/src/storages/key_value_store.ts
+++ b/packages/core/src/storages/key_value_store.ts
@@ -429,6 +429,14 @@ export class KeyValueStore {
     }
 
     /**
+     * Returns a file URL for the given key.
+     */
+    getPublicUrl(key: string): string {
+        const name = this.name ?? this.config.get('defaultKeyValueStoreId');
+        return `file://${process.cwd()}/storage/key_value_stores/${name}/${key}`;
+    }
+
+    /**
      * Opens a key-value store and returns a promise resolving to an instance of the {@apilink KeyValueStore} class.
      *
      * Key-value stores are used to store records or files, along with their MIME content type.

--- a/test/e2e/cheerio-error-snapshot/test.mjs
+++ b/test/e2e/cheerio-error-snapshot/test.mjs
@@ -10,7 +10,7 @@ await expect(stats.requestsFailed === 4, 'All requests failed');
 
 let totalErrorHtmlFiles = 0;
 for (const error of Object.values(stats.errors)) {
-    if (hasNestedKey(error, 'firstErrorHtml')) {
+    if (hasNestedKey(error, 'firstErrorHtmlUrl')) {
         totalErrorHtmlFiles++;
     }
 }

--- a/test/e2e/puppeteer-error-snapshot/test.mjs
+++ b/test/e2e/puppeteer-error-snapshot/test.mjs
@@ -11,13 +11,13 @@ await expect(stats.requestsFailed === 4, 'All requests failed');
 let totalErrorHtmlFiles = 0;
 let totalErrorScreenshotFiles = 0;
 for (const error of Object.values(stats.errors)) {
-    if (hasNestedKey(error, 'firstErrorHtml')) {
+    if (hasNestedKey(error, 'firstErrorHtmlUrl')) {
         totalErrorHtmlFiles++;
     }
 }
 
 for (const error of Object.values(stats.errors)) {
-    if (hasNestedKey(error, 'firstErrorScreenshot')) {
+    if (hasNestedKey(error, 'firstErrorScreenshotUrl')) {
         totalErrorScreenshotFiles++;
     }
 }


### PR DESCRIPTION
This will respect the Actor SDK override automatically since importing the SDK will fire this side effect: 

https://github.com/apify/apify-sdk-js/blob/master/packages/apify/src/key_value_store.ts#L25