### PR TITLE
fix: utils.parseOpenGraph() can parse arrays of images with properties.

### DIFF
--- a/packages/utils/src/internals/open_graph_parser.ts
+++ b/packages/utils/src/internals/open_graph_parser.ts
@@ -2,13 +2,195 @@ import type { Dictionary } from '@crawlee/types';
 import type { CheerioAPI } from 'cheerio';
 import { load } from 'cheerio';
 
+// TODO: Finish generalizing or specializing this module.
+
+/**
+ * To turn your web pages into graph objects, you need to add basic metadata to your page. We've based the initial version
+ * of the protocol on RDFa which means that you'll place additional <meta> tags in the <head> of your web page. The four
+ * required properties for every page are:
+ *
+ * - `og:title` - The title of your object as it should appear within the graph, e.g., "The Rock".
+ * - `og:type` - The type of your object, e.g., "video.movie". Depending on the type you specify, other properties may also be required.
+ * - `og:image` - An image URL which should represent your object within the graph.
+ * - `og:url` - The canonical URL of your object that will be used as its permanent ID in the graph, e.g., "https://www.imdb.com/title/tt0117500/".
+ */
+export interface OpenGraphBasicMetadata {
+    /**
+     * `og:title` - The title of your object as it should appear within the graph, e.g., "The Rock".
+     */
+    title?: string;
+    /**
+     * `og:type` - The type of your object, e.g., "video.movie". Depending on the type you specify, other properties may also be required.
+     */
+    type?: string;
+    /**
+     * `og:image` - An image URL which should represent your object within the graph.
+     */
+    image?: OpenGraphImageMetadataUnion;
+    /**
+     * `og:url` - The canonical URL of your object that will be used as its permanent ID in the graph, e.g., "https://www.imdb.com/title/tt0117500/".
+     */
+    url?: string;
+}
+
+/**
+ * The `og:image` or `OpenGraphBasicMetadata::image` property can be any of the following:
+ *
+ * 1. String: An image URL which should represent your object within the graph.
+ * 2. Array of Strings: If a tag can have multiple values, just put multiple versions of the same `<meta>` tag on your page. The first tag (from top
+ *    to bottom) is given preference during conflicts.
+ * 3. OpenGraphImageMetadata: The `OpenGraphImageMetadata` class has some optional structured properties.
+ * 4. Array of OpenGraphImageMetadatas: Put structured properties after you declare their root tag. Whenever another root element is parsed, that structured
+ *    property is considered to be done and another one is started.
+ * 5. Array of Strings or OpenGraphImageMetadatas: Some images may be specified without any properties, including the `og:image:url` property, which
+ *    can be inferred from the
+ */
+export type OpenGraphImageMetadataUnion =
+    | OpenGraphImageMetadata
+    | string
+    | [OpenGraphImageMetadata]
+    | [string]
+    | [OpenGraphImageMetadata | string];
+
+/**
+ * The `OpenGraphImageMetadata` class has some optional structured properties.
+ */
+export interface OpenGraphImageMetadata {
+    /**
+     * Identical to `OpenGraphBasicMetadata::image`.
+     */
+    url?: string;
+    /**
+     * An alternate url to use if the webpage requires HTTPS.
+     */
+    secureUrl?: string;
+    /**
+     * A MIME type for this image.
+     */
+    type?: string;
+    /**
+     * The number of pixels wide.
+     */
+    width?: number;
+    /**
+     * The number of pixels high.
+     */
+    height?: number;
+    /**
+     * A description of what is in the image (not a caption). If the page specifies an og:image it should specify `og:image:alt`.
+     */
+    alt?: string;
+}
+
 export interface OpenGraphProperty {
     name: string;
     outputName: string;
     children: OpenGraphProperty[];
+    // This may be useful in figuring out whether or not to treat it like an array (or an array of dictionaries)
+    // cardinality?: Number;
 }
 
-type OpenGraphResult = string | string[] | Dictionary<string | Dictionary>;
+export type OpenGraphResult = string | string[] | Dictionary<string | Dictionary>;
+
+export type OpenGraphMetadataUnion = OpenGraphBasicMetadata;
+
+/**
+ * This will read the first `<meta>` tag whose `property` attribute matches the value in the `propertyName` argument.
+ * Per the protocol, the first tag (from top to bottom) is given preference during conflicts.
+ * @param $ A `CheerioAPI` object.
+ * @param propertyName
+ */
+function parseFirstOpenGraphMetaTagContentString($: CheerioAPI, propertyName: string): string | undefined {
+    const cssSelector = `meta[property="${propertyName}"]`;
+    const result = $(cssSelector);
+    if (result.length > 0) {
+        return result.attr('content');
+    }
+    return undefined;
+}
+
+function parseOpenGraphImageMetaTags($: CheerioAPI): OpenGraphImageMetadataUnion | undefined {
+    const cssSelector = `meta[property="og:image"]`;
+    let queryResult = $(cssSelector);
+    const result: OpenGraphImageMetadataUnion | [] = [];
+    if (queryResult.length > 0) {
+        // let's track the most recent root element
+        let mostRecentImage: string | OpenGraphImageMetadata | undefined;
+
+        do {
+            // re-read the property, it does match everything starting with og:image
+            const property = queryResult.attr('property');
+            const content = queryResult.attr('content');
+
+            // this is a new image root tag with a url value
+            if (property === 'og:image') {
+                // if there was a previous image root tag, add it to the result
+                if (mostRecentImage) {
+                    result.push(mostRecentImage as never);
+                }
+                mostRecentImage = content;
+            }
+            // this is an image metadata tag
+            else {
+                // convert any image root tags with only a url value into structures with a url field
+                if (typeof mostRecentImage === 'string') {
+                    mostRecentImage = { url: mostRecentImage };
+                } else if (typeof mostRecentImage === 'undefined') {
+                    mostRecentImage = {};
+                }
+                // read further image metadata
+                switch (property) {
+                    case 'og:image:url':
+                        mostRecentImage = { url: content, ...(mostRecentImage as OpenGraphImageMetadata) };
+                        break;
+                    case 'og:image:secure_url':
+                        mostRecentImage = { secureUrl: content, ...(mostRecentImage as OpenGraphImageMetadata) };
+                        break;
+                    case 'og:image:type':
+                        mostRecentImage = { type: content, ...(mostRecentImage as OpenGraphImageMetadata) };
+                        break;
+                    case 'og:image:width':
+                        mostRecentImage = {
+                            width: parseFloat(content?.replaceAll(/[\D]/g, '') || '') || undefined,
+                            ...(mostRecentImage as OpenGraphImageMetadata),
+                        };
+                        break;
+                    case 'og:image:height':
+                        mostRecentImage = {
+                            height: parseFloat(content?.replaceAll(/[\D]/g, '') || '') || undefined,
+                            ...(mostRecentImage as OpenGraphImageMetadata),
+                        };
+                        break;
+                    case 'og:image:alt':
+                        mostRecentImage = { alt: content, ...(mostRecentImage as OpenGraphImageMetadata) };
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            // read the next result
+            queryResult = queryResult.next();
+
+            // loop until there are no more results
+        } while (queryResult.length > 0);
+
+        // if there was a previous image root tag, add it to the result
+        if (mostRecentImage) {
+            result.push(mostRecentImage as never);
+        }
+    }
+    return result.length ? (result as OpenGraphImageMetadataUnion) : undefined;
+}
+
+function parseOpenGraphBasicMetadata($: CheerioAPI): OpenGraphBasicMetadata {
+    return {
+        image: parseOpenGraphImageMetaTags($),
+        title: parseFirstOpenGraphMetaTagContentString($, 'og:title'),
+        type: parseFirstOpenGraphMetaTagContentString($, 'og:type'),
+        url: parseFirstOpenGraphMetaTagContentString($, 'og:url'),
+    };
+}
 
 /**
  * To be used with the spread operator. Ensures that the item is defined, and is not empty.
@@ -21,57 +203,58 @@ const optionalSpread = (key: string, item: any) =>
     item !== undefined && !!Object.values(item)?.length ? { [key]: item } : {};
 
 const OPEN_GRAPH_PROPERTIES: OpenGraphProperty[] = [
-    {
-        name: 'og:title',
-        outputName: 'title',
-        children: [],
-    },
-    {
-        name: 'og:type',
-        outputName: 'type',
-        children: [],
-    },
-    {
-        name: 'og:image',
-        outputName: 'image',
-        children: [
-            {
-                name: 'og:image:url',
-                outputName: 'url',
-                children: [],
-            },
-            {
-                name: 'og:image:secure_url',
-                outputName: 'secureUrl',
-                children: [],
-            },
-            {
-                name: 'og:image:type',
-                outputName: 'type',
-                children: [],
-            },
-            {
-                name: 'og:image:width',
-                outputName: 'width',
-                children: [],
-            },
-            {
-                name: 'og:image:height',
-                outputName: 'height',
-                children: [],
-            },
-            {
-                name: 'og:image:alt',
-                outputName: 'alt',
-                children: [],
-            },
-        ],
-    },
-    {
-        name: 'og:url',
-        outputName: 'url',
-        children: [],
-    },
+    // disabled these for now:
+    // {
+    //     name: 'og:title',
+    //     outputName: 'title',
+    //     children: [],
+    // },
+    // {
+    //     name: 'og:type',
+    //     outputName: 'type',
+    //     children: [],
+    // },
+    // {
+    //     name: 'og:image',
+    //     outputName: 'image',
+    //     children: [
+    //         {
+    //             name: 'og:image:url',
+    //             outputName: 'url',
+    //             children: [],
+    //         },
+    //         {
+    //             name: 'og:image:secure_url',
+    //             outputName: 'secureUrl',
+    //             children: [],
+    //         },
+    //         {
+    //             name: 'og:image:type',
+    //             outputName: 'type',
+    //             children: [],
+    //         },
+    //         {
+    //             name: 'og:image:width',
+    //             outputName: 'width',
+    //             children: [],
+    //         },
+    //         {
+    //             name: 'og:image:height',
+    //             outputName: 'height',
+    //             children: [],
+    //         },
+    //         {
+    //             name: 'og:image:alt',
+    //             outputName: 'alt',
+    //             children: [],
+    //         },
+    //     ],
+    // },
+    // {
+    //     name: 'og:url',
+    //     outputName: 'url',
+    //     children: [],
+    // },
     {
         name: 'og:audio',
         outputName: 'audio',
@@ -400,13 +583,29 @@ export function parseOpenGraph($: CheerioAPI, additionalProperties?: OpenGraphPr
 export function parseOpenGraph(item: CheerioAPI | string, additionalProperties?: OpenGraphProperty[]) {
     const $ = typeof item === 'string' ? load(item) : item;
 
-    return [...(additionalProperties || []), ...OPEN_GRAPH_PROPERTIES].reduce(
-        (acc, curr) => {
-            return {
-                ...acc,
-                ...optionalSpread(curr.outputName, parseOpenGraphProperty(curr, $)),
-            };
-        },
-        {} as Dictionary<OpenGraphResult>,
+    let ogrDict: Dictionary<OpenGraphResult> = {};
+
+    // Parse basic metadata
+    const basicMetaData: OpenGraphBasicMetadata = parseOpenGraphBasicMetadata($);
+    ogrDict = Object.assign(ogrDict, basicMetaData);
+
+    // // Assemble open graph properties to search for
+    // let props = [...(additionalProperties || []), ...OPEN_GRAPH_PROPERTIES];
+
+    // Determine cardinality of each element
+    // props = props.map((prop) => {
+    // });
+    ogrDict = Object.assign(
+        ogrDict,
+        [...(additionalProperties || []), ...OPEN_GRAPH_PROPERTIES].reduce(
+            (acc, curr) => {
+                return {
+                    ...acc,
+                    ...optionalSpread(curr.outputName, parseOpenGraphProperty(curr, $)),
+                };
+            },
+            {} as Dictionary<OpenGraphResult>,
+        ),
     );
+    return ogrDict;
 }

--- a/test/utils/open_graph_parser.test.ts
+++ b/test/utils/open_graph_parser.test.ts
@@ -21,6 +21,28 @@ describe('parseOpenGraph', () => {
     const case6 = `<meta property="og:title" content="My Website"/>
     <meta property="og:type" content="website"/>`;
 
+    const case7 = `<!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <!-- Example taken from https://ogp.me/ -->
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Document</title>
+        <meta property="og:title" content="The Rock" />
+        <meta property="og:type" content="video.movie" />
+        <meta property="og:url" content="https://www.imdb.com/title/tt0117500/" />
+        <meta property="og:image" content="https://ia.media-imdb.com/images/rock.jpg" />
+        <meta property="og:image" content="https://example.com/rock2.jpg" />
+        <meta property="og:image:width" content="300" />
+        <meta property="og:image:height" content="300" />
+        <meta property="og:image" content="https://example.com/rock3.jpg" />
+        <meta property="og:image:height" content="1000" />
+    </head>
+    <body>
+        <!-- Not important for this test. -->
+    </body>
+    </html>`;
+
     it('Should scrape properties', () => {
         expect(parseOpenGraph(case1)).toEqual({
             title: 'Under Pressure',
@@ -75,6 +97,33 @@ describe('parseOpenGraph', () => {
         expect(parseOpenGraph(case6)).toEqual({
             title: 'My Website',
             type: 'website',
+        });
+    });
+
+    it('Should parse arrays of images with props', () => {
+        const parsed = parseOpenGraph(case7);
+
+        expect(parsed).toEqual({
+            title: 'The Rock',
+            type: 'video.movie',
+            url: 'https://www.imdb.com/title/tt0117500/',
+            image: [
+                // Either this:
+                'https://ia.media-imdb.com/images/rock.jpg',
+                // Or this:
+                // {
+                //     url: "https://ia.media-imdb.com/images/rock.jpg",
+                // },
+                {
+                    url: 'https://example.com/rock2.jpg',
+                    width: 300,
+                    height: 300,
+                },
+                {
+                    url: 'https://example.com/rock3.jpg',
+                    height: 1000,
+                },
+            ],
         });
     });
 });


### PR DESCRIPTION
I updated the Open Graph Parser so that it can parse arrays of images with properties and present them as arrays of image objects with properties. There are other Open Graph meta tags which can also contain arrays of objects with properties, and this update does not address those (e.g. video, etc.), but it provides a template which works more specifically than the simpler code which is still featured. This update is neither fully generalized nor fully specialized but presents another way to do it. This new code still passes the old tests and the new test, but I can imagine many other test cases which will still fail without additional work on this module. As long as everyone is okay with this approach I can work on it further.