### PR TITLE
feat: add `waitForSelector` context helper + `parseWithCheerio` in adaptive crawler

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -13,7 +13,7 @@
 		"formatter": {
 			"quoteStyle": "single",
 			"semicolons": "always",
-			"trailingComma": "all",
+			"trailingCommas": "all",
 			"lineWidth": 120,
 			"indentStyle": "space",
 			"indentWidth": 4,

--- a/packages/core/src/crawlers/crawler_commons.ts
+++ b/packages/core/src/crawlers/crawler_commons.ts
@@ -15,6 +15,15 @@ import { KeyValueStore } from '../storages';
 export interface RestrictedCrawlingContext<UserData extends Dictionary = Dictionary>
     // we need `Record<string & {}, unknown>` here, otherwise `Omit<Context>` is resolved badly
     extends Record<string & {}, unknown> {
+    id: string;
+    session?: Session;
+
+    /**
+     * An object with information about currently used proxy by the crawler
+     * and configured by the {@apilink ProxyConfiguration} class.
+     */
+    proxyInfo?: ProxyInfo;
+
     /**
      * The original {@apilink Request} object.
      */
@@ -86,15 +95,6 @@ export interface RestrictedCrawlingContext<UserData extends Dictionary = Diction
 
 export interface CrawlingContext<Crawler = unknown, UserData extends Dictionary = Dictionary>
     extends RestrictedCrawlingContext<UserData> {
-    id: string;
-    session?: Session;
-
-    /**
-     * An object with information about currently used proxy by the crawler
-     * and configured by the {@apilink ProxyConfiguration} class.
-     */
-    proxyInfo?: ProxyInfo;
-
     crawler: Crawler;
 
     /**

--- a/packages/http-crawler/src/internals/http-crawler.ts
+++ b/packages/http-crawler/src/internals/http-crawler.ts
@@ -28,7 +28,7 @@ import {
     SessionError,
 } from '@crawlee/basic';
 import type { Awaitable, Dictionary } from '@crawlee/types';
-import { RETRY_CSS_SELECTORS, gotScraping } from '@crawlee/utils';
+import { RETRY_CSS_SELECTORS, gotScraping, type CheerioRoot } from '@crawlee/utils';
 import * as cheerio from 'cheerio';
 import type { RequestLike, ResponseLike } from 'content-type';
 import contentTypeParser from 'content-type';
@@ -215,7 +215,33 @@ export interface InternalHttpCrawlingContext<
     contentType: { type: string; encoding: BufferEncoding };
     response: PlainResponse;
 
-    parseWithCheerio(): Promise<cheerio.CheerioAPI>;
+    /**
+     * Wait for an element matching the selector to appear. Timeout is ignored.
+     *
+     * **Example usage:**
+     * ```ts
+     * async requestHandler({ waitForSelector, parseWithCheerio }) {
+     *     await waitForSelector('article h1');
+     *     const $ = await parseWithCheerio();
+     *     const title = $('title').text();
+     * });
+     * ```
+     */
+    waitForSelector(selector: string, timeoutMs?: number): Promise<void>;
+
+    /**
+     * Returns Cheerio handle for `page.content()`, allowing to work with the data same way as with {@apilink CheerioCrawler}.
+     * When provided with the `selector` argument, it will throw if it's not available.
+     *
+     * **Example usage:**
+     * ```ts
+     * async requestHandler({ parseWithCheerio }) {
+     *     const $ = await parseWithCheerio();
+     *     const title = $('title').text();
+     * });
+     * ```
+     */
+    parseWithCheerio(selector?: string, timeoutMs?: number): Promise<CheerioRoot>;
 }
 
 export interface HttpCrawlingContext<UserData extends Dictionary = any, JSONData extends JsonValue = any>
@@ -488,7 +514,22 @@ export class HttpCrawler<
             tryCancel();
 
             // `??=` because descendant classes may already set optimized version
-            crawlingContext.parseWithCheerio ??= async () => cheerio.load(parsed.body!.toString());
+            crawlingContext.waitForSelector ??= async (selector?: string, _timeoutMs?: number) => {
+                const $ = cheerio.load(parsed.body!.toString());
+
+                if ($(selector).get().length === 0) {
+                    throw new Error(`Selector '${selector}' not found.`);
+                }
+            };
+            crawlingContext.parseWithCheerio ??= async (selector?: string, timeoutMs?: number) => {
+                const $ = cheerio.load(parsed.body!.toString());
+
+                if (selector) {
+                    await crawlingContext.waitForSelector(selector, timeoutMs);
+                }
+
+                return $;
+            };
 
             if (this.useSessionPool) {
                 this._throwOnBlockedRequest(crawlingContext.session!, response.statusCode!);

--- a/packages/jsdom-crawler/src/internals/jsdom-crawler.ts
+++ b/packages/jsdom-crawler/src/internals/jsdom-crawler.ts
@@ -311,7 +311,7 @@ export class JSDOMCrawler extends HttpCrawler<JSDOMCrawlingContext> {
     }
 
     override async _runRequestHandler(context: JSDOMCrawlingContext) {
-        context.waitForSelector = async (selector: string, timeoutMs?: number) => {
+        context.waitForSelector = async (selector: string, timeoutMs = 5_000) => {
             const $ = cheerio.load(context.body);
 
             if ($(selector).get().length === 0) {
@@ -323,7 +323,7 @@ export class JSDOMCrawler extends HttpCrawler<JSDOMCrawlingContext> {
                 throw new Error(`Selector '${selector}' not found.`);
             }
         };
-        context.parseWithCheerio = async (selector?: string, _timeoutMs?: number) => {
+        context.parseWithCheerio = async (selector?: string, _timeoutMs = 5_000) => {
             const $ = cheerio.load(context.body);
 
             if (selector && $(selector).get().length === 0) {

--- a/packages/jsdom-crawler/src/internals/jsdom-crawler.ts
+++ b/packages/jsdom-crawler/src/internals/jsdom-crawler.ts
@@ -22,6 +22,7 @@ import {
     tryAbsoluteURL,
 } from '@crawlee/http';
 import type { Dictionary } from '@crawlee/types';
+import { type CheerioRoot, sleep } from '@crawlee/utils';
 import * as cheerio from 'cheerio';
 import type { DOMWindow } from 'jsdom';
 import { JSDOM, ResourceLoader, VirtualConsole } from 'jsdom';
@@ -59,7 +60,23 @@ export interface JSDOMCrawlingContext<
     document: Document;
 
     /**
+     * Wait for an element matching the selector to appear. Timeout is ignored.
+     * Timeout defaults to 5s.
+     *
+     * **Example usage:**
+     * ```ts
+     * async requestHandler({ waitForSelector, parseWithCheerio }) {
+     *     await waitForSelector('article h1');
+     *     const $ = await parseWithCheerio();
+     *     const title = $('title').text();
+     * });
+     * ```
+     */
+    waitForSelector(selector: string, timeoutMs?: number): Promise<void>;
+
+    /**
      * Returns Cheerio handle, allowing to work with the data same way as with {@apilink CheerioCrawler}.
+     * When provided with the `selector` argument, it will first look for the selector with a 5s timeout.
      *
      * **Example usage:**
      * ```javascript
@@ -69,7 +86,7 @@ export interface JSDOMCrawlingContext<
      * });
      * ```
      */
-    parseWithCheerio(): Promise<cheerio.CheerioAPI>;
+    parseWithCheerio(selector?: string, timeoutMs?: number): Promise<CheerioRoot>;
 }
 
 export type JSDOMRequestHandler<
@@ -294,7 +311,28 @@ export class JSDOMCrawler extends HttpCrawler<JSDOMCrawlingContext> {
     }
 
     override async _runRequestHandler(context: JSDOMCrawlingContext) {
-        context.parseWithCheerio = async () => Promise.resolve(cheerio.load(context.body));
+        context.waitForSelector = async (selector: string, timeoutMs?: number) => {
+            const $ = cheerio.load(context.body);
+
+            if ($(selector).get().length === 0) {
+                if (timeoutMs) {
+                    await sleep(50);
+                    return context.waitForSelector(selector, Math.max(timeoutMs - 50, 0));
+                }
+
+                throw new Error(`Selector '${selector}' not found.`);
+            }
+        };
+        context.parseWithCheerio = async (selector?: string, _timeoutMs?: number) => {
+            const $ = cheerio.load(context.body);
+
+            if (selector && $(selector).get().length === 0) {
+                throw new Error(`Selector '${selector}' not found.`);
+            }
+
+            return $;
+        };
+
         await super._runRequestHandler(context);
     }
 }

--- a/packages/linkedom-crawler/src/internals/linkedom-crawler.ts
+++ b/packages/linkedom-crawler/src/internals/linkedom-crawler.ts
@@ -194,7 +194,7 @@ export class LinkeDOMCrawler extends HttpCrawler<LinkeDOMCrawlingContext> {
     }
 
     override async _runRequestHandler(context: LinkeDOMCrawlingContext) {
-        context.waitForSelector = async (selector: string, timeoutMs?: number) => {
+        context.waitForSelector = async (selector: string, timeoutMs = 5_000) => {
             const $ = cheerio.load(context.body);
 
             if ($(selector).get().length === 0) {
@@ -206,7 +206,7 @@ export class LinkeDOMCrawler extends HttpCrawler<LinkeDOMCrawlingContext> {
                 throw new Error(`Selector '${selector}' not found.`);
             }
         };
-        context.parseWithCheerio = async (selector?: string, _timeoutMs?: number) => {
+        context.parseWithCheerio = async (selector?: string, _timeoutMs = 5_000) => {
             const $ = cheerio.load(context.body);
 
             if (selector && $(selector).get().length === 0) {

--- a/packages/playwright-crawler/src/internals/adaptive-playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/adaptive-playwright-crawler.ts
@@ -369,7 +369,10 @@ export class AdaptivePlaywrightCrawler extends PlaywrightCrawler {
                                                 const locator = playwrightContext.page.locator(selector).first();
                                                 await locator.waitFor({ timeout: timeoutMs, state: 'attached' });
                                             },
-                                            async parseWithCheerio(selector?: string, timeoutMs = 5_000): Promise<CheerioRoot> {
+                                            async parseWithCheerio(
+                                                selector?: string,
+                                                timeoutMs = 5_000,
+                                            ): Promise<CheerioRoot> {
                                                 if (selector) {
                                                     const locator = playwrightContext.page.locator(selector).first();
                                                     await locator.waitFor({ timeout: timeoutMs, state: 'attached' });
@@ -433,7 +436,7 @@ export class AdaptivePlaywrightCrawler extends PlaywrightCrawler {
                                 request: crawlingContext.request,
                                 log: crawlingContext.log,
                                 async querySelector(selector, _timeoutMs?: number) {
-                                    return $(selector) as Cheerio<Element>
+                                    return $(selector) as Cheerio<Element>;
                                 },
                                 async waitForSelector(selector, _timeoutMs?: number) {
                                     if ($(selector).get().length === 0) {
@@ -447,7 +450,9 @@ export class AdaptivePlaywrightCrawler extends PlaywrightCrawler {
 
                                     return $;
                                 },
-                                async enqueueLinks(options: Parameters<RestrictedCrawlingContext['enqueueLinks']>[0] = {}) {
+                                async enqueueLinks(
+                                    options: Parameters<RestrictedCrawlingContext['enqueueLinks']>[0] = {},
+                                ) {
                                     const urls = extractUrlsFromCheerio(
                                         $,
                                         options.selector,

--- a/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
+++ b/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
@@ -691,17 +691,33 @@ export interface PlaywrightContextUtils {
     blockRequests(options?: BlockRequestsOptions): Promise<void>;
 
     /**
-     * Returns Cheerio handle for `page.content()`, allowing to work with the data same way as with {@apilink CheerioCrawler}.
+     * Wait for an element matching the selector to appear.
+     * Timeout defaults to 5s.
      *
      * **Example usage:**
-     * ```javascript
+     * ```ts
+     * async requestHandler({ waitForSelector, parseWithCheerio }) {
+     *     await waitForSelector('article h1');
+     *     const $ = await parseWithCheerio();
+     *     const title = $('title').text();
+     * });
+     * ```
+     */
+    waitForSelector(selector: string, timeoutMs?: number): Promise<void>;
+
+    /**
+     * Returns Cheerio handle for `page.content()`, allowing to work with the data same way as with {@apilink CheerioCrawler}.
+     * When provided with the `selector` argument, it waits for it to be available first.
+     *
+     * **Example usage:**
+     * ```ts
      * async requestHandler({ parseWithCheerio }) {
      *     const $ = await parseWithCheerio();
      *     const title = $('title').text();
      * });
      * ```
      */
-    parseWithCheerio(): Promise<CheerioRoot>;
+    parseWithCheerio(selector?: string, timeoutMs?: number): Promise<CheerioRoot>;
 
     /**
      * Scrolls to the bottom of a page, or until it times out.
@@ -811,7 +827,17 @@ export function registerUtilsToContext(
         await injectJQuery(context.page, { surviveNavigations: false });
     };
     context.blockRequests = async (options?: BlockRequestsOptions) => blockRequests(context.page, options);
-    context.parseWithCheerio = async () => parseWithCheerio(context.page, crawlerOptions.ignoreShadowRoots);
+    context.waitForSelector = async (selector: string, timeoutMs?: number) => {
+        const locator = context.page.locator(selector).first();
+        await locator.waitFor({ timeout: timeoutMs, state: 'attached' });
+    };
+    context.parseWithCheerio = async (selector?: string, timeoutMs?: number) => {
+        if (selector) {
+            await context.waitForSelector(selector, timeoutMs);
+        }
+
+        return parseWithCheerio(context.page, crawlerOptions.ignoreShadowRoots);
+    };
     context.infiniteScroll = async (options?: InfiniteScrollOptions) => infiniteScroll(context.page, options);
     context.saveSnapshot = async (options?: SaveSnapshotOptions) =>
         saveSnapshot(context.page, { ...options, config: context.crawler.config });

--- a/packages/puppeteer-crawler/src/internals/utils/puppeteer_utils.ts
+++ b/packages/puppeteer-crawler/src/internals/utils/puppeteer_utils.ts
@@ -781,17 +781,33 @@ export interface PuppeteerContextUtils {
     injectJQuery(): Promise<unknown>;
 
     /**
-     * Returns Cheerio handle for `page.content()`, allowing to work with the data same way as with {@apilink CheerioCrawler}.
+     * Wait for an element matching the selector to appear.
+     * Timeout defaults to 5s.
      *
      * **Example usage:**
-     * ```javascript
+     * ```ts
+     * async requestHandler({ waitForSelector, parseWithCheerio }) {
+     *     await waitForSelector('article h1');
+     *     const $ = await parseWithCheerio();
+     *     const title = $('title').text();
+     * });
+     * ```
+     */
+    waitForSelector(selector: string, timeoutMs?: number): Promise<void>;
+
+    /**
+     * Returns Cheerio handle for `page.content()`, allowing to work with the data same way as with {@apilink CheerioCrawler}.
+     * When provided with the `selector` argument, it waits for it to be available first.
+     *
+     * **Example usage:**
+     * ```ts
      * async requestHandler({ parseWithCheerio }) {
      *     const $ = await parseWithCheerio();
      *     const title = $('title').text();
      * });
      * ```
      */
-    parseWithCheerio(): Promise<CheerioRoot>;
+    parseWithCheerio(selector?: string, timeoutMs?: number): Promise<CheerioRoot>;
 
     /**
      * The function finds elements matching a specific CSS selector in a Puppeteer page,
@@ -1022,7 +1038,16 @@ export function registerUtilsToContext(
         }
         await injectJQuery(context.page, { surviveNavigations: false });
     };
-    context.parseWithCheerio = async () => parseWithCheerio(context.page, crawlerOptions.ignoreShadowRoots);
+    context.waitForSelector = async (selector: string, timeoutMs?: number) => {
+        await context.page.waitForSelector(selector, { timeout: timeoutMs });
+    };
+    context.parseWithCheerio = async (selector?: string, timeoutMs?: number) => {
+        if (selector) {
+            await context.waitForSelector(selector, timeoutMs);
+        }
+
+        return parseWithCheerio(context.page, crawlerOptions.ignoreShadowRoots);
+    };
     context.enqueueLinksByClickingElements = async (
         options: Omit<EnqueueLinksByClickingElementsOptions, 'page' | 'requestQueue'>,
     ) =>

--- a/packages/puppeteer-crawler/src/internals/utils/puppeteer_utils.ts
+++ b/packages/puppeteer-crawler/src/internals/utils/puppeteer_utils.ts
@@ -1038,10 +1038,10 @@ export function registerUtilsToContext(
         }
         await injectJQuery(context.page, { surviveNavigations: false });
     };
-    context.waitForSelector = async (selector: string, timeoutMs?: number) => {
+    context.waitForSelector = async (selector: string, timeoutMs = 5_000) => {
         await context.page.waitForSelector(selector, { timeout: timeoutMs });
     };
-    context.parseWithCheerio = async (selector?: string, timeoutMs?: number) => {
+    context.parseWithCheerio = async (selector?: string, timeoutMs = 5_000) => {
         if (selector) {
             await context.waitForSelector(selector, timeoutMs);
         }

--- a/scripts/typescript_fixes.mjs
+++ b/scripts/typescript_fixes.mjs
@@ -23,6 +23,8 @@ for (const filepath of files) {
             line.match(/: Puppeteer\.\w+/) ||
             // don't ask me why, but this one is needed too ¯\_(ツ)_/¯
             line.match(/^export interface (PlaywrightHook|PuppeteerHook)/) ||
+            // adaptive crawler needs router override that is incompatible with the base type
+            line.match(/readonly router: RouterHandler<AdaptivePlaywrightCrawlerContext>/) ||
             // /// <reference types="something" /> from newer nodenext resolutions
             line.match(/^\/\/\/ <reference types="[^"]+" \/>/) ||
             // import("something") from compatibility with ES2022 module -.-

--- a/test/core/crawlers/adaptive_playwright_crawler.test.ts
+++ b/test/core/crawlers/adaptive_playwright_crawler.test.ts
@@ -112,9 +112,10 @@ describe('AdaptivePlaywrightCrawler', () => {
             const url = new URL(`http://${HOSTNAME}:${port}${path}`);
 
             const requestHandler: AdaptivePlaywrightCrawlerOptions['requestHandler'] = vi.fn(
-                async ({ pushData, querySelector }) => {
+                async ({ pushData, parseWithCheerio }) => {
+                    const $ = await parseWithCheerio('h1');
                     await pushData({
-                        heading: (await querySelector('h1')).text(),
+                        heading: $('h1').text(),
                     });
                 },
             );

--- a/test/core/crawlers/http_crawler.test.ts
+++ b/test/core/crawlers/http_crawler.test.ts
@@ -114,7 +114,7 @@ test('parseWithCheerio works', async () => {
     const crawler = new HttpCrawler({
         maxRequestRetries: 0,
         requestHandler: async ({ parseWithCheerio }) => {
-            const $ = await parseWithCheerio();
+            const $ = await parseWithCheerio('title');
             results.push($('title').text());
         },
     });

--- a/test/e2e/playwright-enqueue-links-base/actor/main.js
+++ b/test/e2e/playwright-enqueue-links-base/actor/main.js
@@ -16,7 +16,7 @@ await Actor.main(async () => {
         async requestHandler({ parseWithCheerio, enqueueLinks, request, log }) {
             const { url, loadedUrl } = request;
 
-            const $ = await parseWithCheerio();
+            const $ = await parseWithCheerio('title', 1_000);
             const pageTitle = $('title').first().text();
             log.info(`URL: ${url}; LOADED_URL: ${loadedUrl}; TITLE: ${pageTitle}`);
             await Dataset.pushData({ url, loadedUrl, pageTitle });


### PR DESCRIPTION
This introduces a new `waitForSelector` context helper to all the crawler types. In browser based crawlers, it will wait for the element, in HTTP crawlers it will check if the selector can be found in the HTML and throw otherwise.

Also, the `parseWithCheerio` is now in adaptive crawler too, and it has a new parameter that allows waiting for a selector via `waitForSelector`.