### PR TITLE
fix: make `crawler.log` publicly accessible

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -477,7 +477,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
     running = false;
     hasFinishedBefore = false;
 
-    protected log: Log;
+    readonly log: Log;
     protected requestHandler!: RequestHandler<Context>;
     protected errorHandler?: ErrorHandler<Context>;
     protected failedRequestHandler?: ErrorHandler<Context>;

--- a/packages/http-crawler/src/internals/http-crawler.ts
+++ b/packages/http-crawler/src/internals/http-crawler.ts
@@ -694,6 +694,7 @@ export class HttpCrawler<
         gotOptions,
     }: RequestFunctionOptions): Promise<PlainResponse> {
         if (!TimeoutError) {
+            // @ts-ignore
             ({ TimeoutError } = await import('got-scraping'));
         }
 


### PR DESCRIPTION
This is important for being able to easily change log level for the crawler.

```ts
crawler.log.setLevel(LogLevel.DEBUG);
```