### PR TITLE
fix: declare missing peer dependencies in `@crawlee/browser` package

### DIFF
--- a/packages/browser-crawler/package.json
+++ b/packages/browser-crawler/package.json
@@ -61,5 +61,17 @@
         "ow": "^0.28.1",
         "tslib": "^2.4.0",
         "type-fest": "^4.0.0"
+    },
+    "peerDependencies": {
+        "playwright": "*",
+        "puppeteer": "*"
+    },
+    "peerDependenciesMeta": {
+        "playwright": {
+            "optional": true
+        },
+        "puppeteer": {
+            "optional": true
+        }
     }
 }

--- a/packages/jsdom-crawler/package.json
+++ b/packages/jsdom-crawler/package.json
@@ -57,6 +57,7 @@
         "@apify/utilities": "^2.7.10",
         "@crawlee/http": "3.10.4",
         "@crawlee/types": "3.10.4",
+        "@crawlee/utils": "3.10.4",
         "@types/jsdom": "^21.0.0",
         "cheerio": "^1.0.0-rc.12",
         "jsdom": "^24.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -545,6 +545,7 @@ __metadata:
     "@crawlee/types": "npm:3.10.4"
     "@crawlee/utils": "npm:3.10.4"
     ow: "npm:^0.28.1"
+    playwright: "npm:1.44.1"
     tslib: "npm:^2.4.0"
     type-fest: "npm:^4.0.0"
   languageName: unknown
@@ -639,6 +640,7 @@ __metadata:
     "@apify/utilities": "npm:^2.7.10"
     "@crawlee/http": "npm:3.10.4"
     "@crawlee/types": "npm:3.10.4"
+    "@crawlee/utils": "npm:3.10.4"
     "@types/jsdom": "npm:^21.0.0"
     cheerio: "npm:^1.0.0-rc.12"
     jsdom: "npm:^24.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -545,9 +545,16 @@ __metadata:
     "@crawlee/types": "npm:3.10.4"
     "@crawlee/utils": "npm:3.10.4"
     ow: "npm:^0.28.1"
-    playwright: "npm:1.44.1"
     tslib: "npm:^2.4.0"
     type-fest: "npm:^4.0.0"
+  peerDependencies:
+    playwright: "*"
+    puppeteer: "*"
+  peerDependenciesMeta:
+    playwright:
+      optional: true
+    puppeteer:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This PR fixes the errors thrown by yarn 4 when using crawlee in another project.
