### PR TITLE
feat: added request timeout option to sitemapParser

### DIFF
--- a/packages/utils/src/internals/sitemap.ts
+++ b/packages/utils/src/internals/sitemap.ts
@@ -178,7 +178,7 @@ interface ParseSitemapOptions {
     /**
      * Maximum amount of ms to wait for a network respond to respond. Defaults to 60_000 by got-scraping
      */
-    timeout?: number;
+    requestTimeout?: number;
 }
 
 export async function* parseSitemap<T extends ParseSitemapOptions>(
@@ -234,7 +234,7 @@ export async function* parseSitemap<T extends ParseSitemapOptions>(
                         url: sitemapUrl,
                         proxyUrl,
                         method: 'GET',
-                        timeout: { response: options?.timeout },
+                        timeout: { response: options?.requestTimeout },
                     });
                     request.on('response', () => resolve(request));
                     request.on('error', reject);

--- a/packages/utils/test/sitemap.test.ts
+++ b/packages/utils/test/sitemap.test.ts
@@ -362,7 +362,7 @@ describe('Sitemap', () => {
                 },
             ],
             undefined,
-            { timeout: 100 },
+            { requestTimeout: 100 },
         );
 
         for await (const item of siteMapIterator) {


### PR DESCRIPTION
Added a new `requestTimeout ` option when calling `parseSitemap` that overrides the default 60_000 set by`got-scraping`

Reason 1: Some websites might have broken sitemap implementations and no response is returned when retrieving child sitemaps

Reason 2: Request to huge sitemaps might take longer than 60 seconds