### PR TITLE
fix: use `getHTML` in the shadow root expansion

### DIFF
--- a/packages/utils/src/internals/general.ts
+++ b/packages/utils/src/internals/general.ts
@@ -115,7 +115,9 @@ export function expandShadowRoots(document: Document): string {
         for (const el of rootElement.querySelectorAll('*')) {
             if (el.shadowRoot) {
                 replaceShadowDomsWithHtml(el.shadowRoot);
-                el.innerHTML += getShadowDomHtml(el.shadowRoot) ?? '';
+                const content = document.createElement('div');
+                content.innerHTML = getShadowDomHtml(el.shadowRoot) ?? '';
+                el.appendChild(content);
             }
         }
     }

--- a/packages/utils/src/internals/general.ts
+++ b/packages/utils/src/internals/general.ts
@@ -115,9 +115,12 @@ export function expandShadowRoots(document: Document): string {
         for (const el of rootElement.querySelectorAll('*')) {
             if (el.shadowRoot) {
                 replaceShadowDomsWithHtml(el.shadowRoot);
-                const content = document.createElement('div');
-                content.innerHTML = getShadowDomHtml(el.shadowRoot) ?? '';
-                el.appendChild(content);
+                let content = el.getHTML?.({ serializableShadowRoots: true }).trim();
+
+                if (!(content?.length > 0)) {
+                    content = getShadowDomHtml(el.shadowRoot) ?? '';
+                }
+                el.innerHTML += content;
             }
         }
     }

--- a/test/core/playwright_utils.test.ts
+++ b/test/core/playwright_utils.test.ts
@@ -244,6 +244,36 @@ describe('playwrightUtils', () => {
         }
     }, 60_000);
 
+    describe.only('shadow root expansion', () => {
+        let browser: Browser;
+        beforeAll(async () => {
+            browser = await launchPlaywright(launchContext);
+        });
+        afterAll(async () => {
+            await browser.close();
+        });
+
+        test('no expansion with ignoreShadowRoots: true', async () => {
+            const page = await browser.newPage();
+            await page.goto(`${serverAddress}/special/shadow-root`);
+            const result = await playwrightUtils.parseWithCheerio(page, true);
+
+            const text = result('body').text().trim();
+            expect([...text.matchAll(/\[GOOD\]/g)]).toHaveLength(0);
+            expect([...text.matchAll(/\[BAD\]/g)]).toHaveLength(0);
+        });
+
+        test('expansion works', async () => {
+            const page = await browser.newPage();
+            await page.goto(`${serverAddress}/special/shadow-root`);
+            const result = await playwrightUtils.parseWithCheerio(page);
+
+            const text = result('body').text().trim();
+            expect([...text.matchAll(/\[GOOD\]/g)]).toHaveLength(2);
+            expect([...text.matchAll(/\[BAD\]/g)]).toHaveLength(0);
+        });
+    });
+
     describe('infiniteScroll()', () => {
         function isAtBottom() {
             return window.innerHeight + window.pageYOffset >= document.body.offsetHeight;

--- a/test/core/playwright_utils.test.ts
+++ b/test/core/playwright_utils.test.ts
@@ -244,7 +244,7 @@ describe('playwrightUtils', () => {
         }
     }, 60_000);
 
-    describe.only('shadow root expansion', () => {
+    describe('shadow root expansion', () => {
         let browser: Browser;
         beforeAll(async () => {
             browser = await launchPlaywright(launchContext);

--- a/test/core/puppeteer_utils.test.ts
+++ b/test/core/puppeteer_utils.test.ts
@@ -178,6 +178,36 @@ describe('puppeteerUtils', () => {
             }
         });
 
+        describe('parseWithCheerio() shadow root expansion works', () => {
+            let browser: Browser;
+            beforeAll(async () => {
+                browser = await launchPuppeteer(launchContext);
+            });
+            afterAll(async () => {
+                await browser.close();
+            });
+
+            test('no expansion with ignoreShadowRoots: true', async () => {
+                const page = await browser.newPage();
+                await page.goto(`${serverAddress}/special/shadow-root`);
+                const result = await puppeteerUtils.parseWithCheerio(page, true);
+
+                const text = result('body').text().trim();
+                expect([...text.matchAll(/\[GOOD\]/g)]).toHaveLength(0);
+                expect([...text.matchAll(/\[BAD\]/g)]).toHaveLength(0);
+            });
+
+            test('expansion works', async () => {
+                const page = await browser.newPage();
+                await page.goto(`${serverAddress}/special/shadow-root`);
+                const result = await puppeteerUtils.parseWithCheerio(page);
+
+                const text = result('body').text().trim();
+                expect([...text.matchAll(/\[GOOD\]/g)]).toHaveLength(2);
+                expect([...text.matchAll(/\[BAD\]/g)]).toHaveLength(0);
+            });
+        });
+
         describe('blockRequests()', () => {
             let browser: Browser = null;
             beforeAll(async () => {

--- a/test/shared/_helper.ts
+++ b/test/shared/_helper.ts
@@ -194,6 +194,31 @@ console.log('Hello world!');
             <p>Some content from inside of an iframe.</p>
         </body>
     </html>`,
+    shadowRoots: `
+    <html>
+    <body>
+        <div id="open-container">
+            <template shadowrootmode="open">
+                <p>[GOOD] This is inside the OPEN shadow DOM.</p>
+                <div>
+                    <template shadowrootmode="open">
+                        <p>[GOOD] This is inside of inside of the OPEN shadow DOM.</p>
+                    </template>
+                </div>
+            </template>
+        </div> 
+        <div id="closed-container"> 
+            <template shadowrootmode="closed">
+                <p>[BAD] This is inside the CLOSED shadow DOM.</p>
+                <div>
+                    <template shadowrootmode="open">
+                        <p>[BAD] This is inside of inside of the CLOSED shadow DOM.</p>
+                    </template>
+                </div>
+            </template>
+        </div>
+    </body>
+    </html>`,
 };
 
 export async function runExampleComServer(): Promise<[Server, number]> {
@@ -297,6 +322,10 @@ export async function runExampleComServer(): Promise<[Server, number]> {
 
         special.get('/inside-iframe', (_req, res) => {
             res.type('html').send(responseSamples.insideIframe);
+        });
+
+        special.get('/shadow-root', (_req, res) => {
+            res.type('html').send(responseSamples.shadowRoots);
         });
     })();
 


### PR DESCRIPTION
`expandShadowRoots` now does not replace the original content but creates a separate (non-shadow) subtree as a sibling of the original one. 

Note that this doesn't duplicate content $\^{[1\]}$ , as the original shadow roots are inaccessible from JS by design. `document.documentElement.outerHTML` returns only the contents of (new) regular DOM elements. The page also still looks the same, as a shadow DOM tree [masks any "light" DOM sibling](https://stackoverflow.com/questions/47500157/shadow-root-sibling-elements-disappear-on-attachshadow-call).

Closes #2583 

------

$^{[1]}$ With the notable exception of [accessgroup.my.site.com](https://accessgroup.my.site.com/Support/s/article/Access-Capture-Error-Cant-reach-this-page-when-trying-to-access-the-Capture-web-page) pages, where the use of [custom DOM elements](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_custom_elements) somehow creates elements with `shadowRoot` property, the content of which is still accessible from JS(???). This is likely coming from the [ancient web framework](https://github.com/aurajs/aura) they are using.

Either way, double the content is probably better than none (so far we have only noticed this issue on this page).