### PR TITLE
docs: tweak the Crawlee for Python links

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -163,7 +163,7 @@ module.exports = {
         },
         announcementBar: {
             id: `announcement-bar-crawlee-for-python`,
-            content: `🎉️ <b><a href="https://crawlee.dev/blog/launching-crawlee-python">Crawlee for Python is open to early adopters!</b> 🥳️`,
+            content: `🎉️ <b><a href="https://crawlee.dev/python">Crawlee for Python is open to early adopters!</b> 🥳️`,
         },
         navbar: {
             hideOnScroll: true,

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -17,11 +17,6 @@ function Hero() {
     return (
         <header className={clsx('container', styles.heroBanner)}>
             <div className="row padding-horiz--md">
-                <div className="col col--12">
-                    <div className={styles.crawleeForPython}>
-                        🎉&nbsp;<a href="https://crawlee.dev/blog/launching-crawlee-python">Crawlee for Python is open to early adopters!️</a>&nbsp;🥳
-                    </div>
-                </div>
                 <div className="col col--7">
                     <div className={clsx(styles.relative, 'row')}>
                         <div className="col">


### PR DESCRIPTION
Removes the large "hero" banner advertising Crawlee for Python (keeps the top bar). Changes the link in the top bar to the actual `crawlee.dev/python` docs page instead of the blog post.