### PR TITLE
docs: add crawlee python mention in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Crawlee is available as the [`crawlee`](https://www.npmjs.com/package/crawlee) N
 
 > 👉 **View full documentation, guides and examples on the [Crawlee project website](https://crawlee.dev)** 👈
 
+> Crawlee for Python is open for early adopters. 🐍  [👉 Checkout the source code 👈](https://github.com/apify/crawlee-python).
+
 ## Installation
 
 We recommend visiting the [Introduction tutorial](https://crawlee.dev/docs/introduction) in Crawlee documentation for more information.


### PR DESCRIPTION
Added missing mention of Crawlee for Python in readme.