### PR TITLE
docs: remove duplicated `the` in AutoscaledPool

### DIFF
--- a/packages/core/src/autoscaling/autoscaled_pool.ts
+++ b/packages/core/src/autoscaling/autoscaled_pool.ts
@@ -348,7 +348,7 @@ export class AutoscaledPool {
     }
 
     /**
-     * Gets the the number of parallel tasks currently running in the pool.
+     * Gets the number of parallel tasks currently running in the pool.
      */
     get currentConcurrency(): number {
         return this._currentConcurrency;


### PR DESCRIPTION
minor fix