### PR TITLE
feat: `globs` & `regexps` for `SitemapRequestList`

### DIFF
--- a/packages/core/src/storages/sitemap_request_list.ts
+++ b/packages/core/src/storages/sitemap_request_list.ts
@@ -2,20 +2,15 @@ import { Transform } from 'node:stream';
 
 import defaultLog from '@apify/log';
 import { type ParseSitemapOptions, parseSitemap } from '@crawlee/utils';
+import { minimatch } from 'minimatch';
 import ow from 'ow';
 
 import { KeyValueStore } from './key_value_store';
 import type { IRequestList } from './request_list';
 import { purgeDefaultStorages } from './utils';
+import type { GlobInput, RegExpInput, UrlPatternObject } from '../enqueue_links';
+import { constructGlobObjectsFromGlobs, constructRegExpObjectsFromRegExps } from '../enqueue_links';
 import { Request } from '../request';
-import {
-    GlobInput,
-    RegExpInput,
-    UrlPatternObject,
-    constructGlobObjectsFromGlobs,
-    constructRegExpObjectsFromRegExps,
-} from '../enqueue_links';
-import { minimatch } from 'minimatch';
 
 /** @internal */
 const STATE_PERSISTENCE_KEY = 'SITEMAP_REQUEST_LIST_STATE';

--- a/packages/core/src/storages/sitemap_request_list.ts
+++ b/packages/core/src/storages/sitemap_request_list.ts
@@ -52,8 +52,8 @@ interface UrlConstraints {
      *
      * The plain objects must include at least the `regexp` property, which holds the regular expression.
      *
-     * If `regexps` is an empty array or `undefined`, and `globs` are also not defined, then the function
-     * enqueues the links with the same subdomain.
+     * If `regexps` is an empty array or `undefined`, and `globs` are also not defined, then the `SitemapRequestList`
+     * includes all the URLs from the sitemap.
      */
     regexps?: readonly RegExpInput[];
 }

--- a/test/core/sitemap_request_list.test.ts
+++ b/test/core/sitemap_request_list.test.ts
@@ -278,6 +278,45 @@ describe('SitemapRequestList', () => {
         expect(list.fetchNextRequest()).resolves.toBe(null);
     });
 
+    test('globs filtering works', async () => {
+        const list = await SitemapRequestList.open({
+            sitemapUrls: [`${url}/sitemap.xml`],
+            globs: ['http://not-exists.com/catalog**'],
+        });
+
+        for await (const request of list) {
+            await list.markRequestHandled(request);
+        }
+
+        expect(list.handledCount()).toBe(4);
+    });
+
+    test('regexps filtering works', async () => {
+        const list = await SitemapRequestList.open({
+            sitemapUrls: [`${url}/sitemap.xml`],
+            regexps: [/desc=vacation_new.+/],
+        });
+
+        for await (const request of list) {
+            await list.markRequestHandled(request);
+        }
+
+        expect(list.handledCount()).toBe(2);
+    });
+
+    test('exclude filtering works', async () => {
+        const list = await SitemapRequestList.open({
+            sitemapUrls: [`${url}/sitemap.xml`],
+            exclude: [/desc=vacation_new/],
+        });
+
+        for await (const request of list) {
+            await list.markRequestHandled(request);
+        }
+
+        expect(list.handledCount()).toBe(3);
+    });
+
     test('draining the request list between sitemaps', async () => {
         const list = await SitemapRequestList.open({ sitemapUrls: [`${url}/sitemap-index.xml`] });
 


### PR DESCRIPTION
Adds `globs`, `regexps` and `exclude` options to `SitemapRequestList` to make it list only URLs that match those patterns.

While this looked like a single-responsibility violation to me at first, these changes are imo quite justifiable, as the possible use cases (wanting to crawl only a part of a website while utilizing the official sitemap) seem to be very sane. 