### PR TITLE
fix: use namespace imports for cheerio to be compatible with v1

### DIFF
--- a/packages/utils/src/internals/cheerio.ts
+++ b/packages/utils/src/internals/cheerio.ts
@@ -1,6 +1,6 @@
 import type { Dictionary } from '@crawlee/types';
 import type { load, CheerioAPI } from 'cheerio';
-import cheerio from 'cheerio';
+import * as cheerio from 'cheerio';
 
 import { tryAbsoluteURL } from './extract-urls';
 
@@ -32,7 +32,7 @@ const BLOCK_TAGS_REGEX =
  * with the `decodeEntities` option set to `true`. For example:
  *
  * ```javascript
- * import cheerio from 'cheerio';
+ * import * as cheerio from 'cheerio';
  * const html = '<html><body>Some text</body></html>';
  * const text = htmlToText(cheerio.load(html, { decodeEntities: true }));
  * ```

--- a/packages/utils/src/internals/social.ts
+++ b/packages/utils/src/internals/social.ts
@@ -1,4 +1,4 @@
-import cheerio from 'cheerio';
+import * as cheerio from 'cheerio';
 
 import { htmlToText } from './cheerio';
 

--- a/test/utils/cheerio.test.ts
+++ b/test/utils/cheerio.test.ts
@@ -1,6 +1,6 @@
 import type { CheerioRoot } from '@crawlee/utils';
 import { htmlToText } from '@crawlee/utils';
-import cheerio from 'cheerio';
+import * as cheerio from 'cheerio';
 
 import * as htmlToTextData from '../shared/data/html_to_text_test_data';
 


### PR DESCRIPTION
We keep the last RC pinned in the dependencies for now, but is just a forward upgrade which is compatible with both versions.