### PR TITLE
fix: improve `FACEBOOK_REGEX` to match older style page URLs

### DIFF
--- a/packages/utils/src/internals/social.ts
+++ b/packages/utils/src/internals/social.ts
@@ -180,7 +180,7 @@ const TWITTER_REGEX_STRING = `(?<!\\w)(?:http(?:s)?:\\/\\/)?(?:www.)?(?:twitter.
 const FACEBOOK_RESERVED_PATHS =
     'rsrc\\.php|apps|groups|events|l\\.php|friends|images|photo.php|chat|ajax|dyi|common|policies|login|recover|reg|help|security|messages|marketplace|pages|live|bookmarks|games|fundraisers|saved|gaming|salesgroups|jobs|people|ads|ad_campaign|weather|offers|recommendations|crisisresponse|onthisday|developers|settings|connect|business|plugins|intern|sharer';
 
-const FACEBOOK_REGEX_STRING = `(?<!\\w)(?:http(?:s)?:\\/\\/)?(?:www.)?(?:facebook.com|fb.com)\\/(?!(?:${FACEBOOK_RESERVED_PATHS})(?:[\\'\\"\\?\\.\\/]|$))(profile\\.php\\?id\\=[0-9]{3,20}|(?!profile\\.php)[a-z0-9\\.]{5,51})(?![a-z0-9\\.])(?:/)?`;
+const FACEBOOK_REGEX_STRING = `(?<!\\w)(?:http(?:s)?:\\/\\/)?(?:www.)?(?:facebook.com|fb.com)\\/(?!(?:${FACEBOOK_RESERVED_PATHS})(?:[\\'\\"\\?\\.\\/]|$))(profile\\.php\\?id\\=[0-9]{3,20}|(?!profile\\.php)[a-z0-9-\\.]{5,51})(?![a-z0-9\\.])(?:/)?`;
 
 const YOUTUBE_REGEX_STRING =
     '(?<!\\w)(?:https?:\\/\\/)?(?:youtu\\.be\\/|(?:www\\.|m\\.)?youtube\\.com(?:\\/(?:watch|v|embed|user|c(?:hannel)?)(?:\\.php)?)?(?:\\?[^ ]*v=|\\/))([a-zA-Z0-9\\-_]{2,100})';

--- a/test/utils/social.test.ts
+++ b/test/utils/social.test.ts
@@ -779,6 +779,8 @@ describe('utils.social', () => {
 
             expect(FACEBOOK_REGEX.test('https://www.facebook.com/someusername')).toBe(true);
             expect(FACEBOOK_REGEX.test('https://www.facebook.com/someusername/')).toBe(true);
+            expect(FACEBOOK_REGEX.test('https://www.facebook.com/some-username-1234')).toBe(true);
+            expect(FACEBOOK_REGEX.test('https://www.facebook.com/some-username-1234/')).toBe(true);
             expect(FACEBOOK_REGEX.test('http://www.facebook.com/some.username123')).toBe(true);
             expect(FACEBOOK_REGEX.test('www.facebook.com/someusername')).toBe(true);
             expect(FACEBOOK_REGEX.test('facebook.com/someusername')).toBe(true);


### PR DESCRIPTION
Older Facebook URLs could be formatted like this:
`https://www.facebook.com/some-profile-1234`

This package currently incorrectly parses the URL as:
`https://www.facebook.com/some`

The REGEX for this package does not match the `-` character. These URLs have been deprecated, and Facebook will redirect these older style URLs to their newer style. We should still match these older style URLs as they are indeed valid, albeit old.

I've added 2 tests to cover these URL patterns, happy to adjust to any feedback.

Closes #2216