### PR TITLE
fix: `SitemapRequestList.teardown()` doesn't break `persistState` calls

### DIFF
--- a/packages/core/src/storages/sitemap_request_list.ts
+++ b/packages/core/src/storages/sitemap_request_list.ts
@@ -450,6 +450,8 @@ export class SitemapRequestList implements IRequestList {
             urlQueue.push(url);
         }
 
+        // Create a new stream, as we have read all the URLs from the current one.
+        // Pushing the urls back to the original stream might not be possible if it has been ended.
         const newStream = this.createNewStream(this.urlQueueStream.readableHighWaterMark);
 
         for (const url of urlQueue) {

--- a/packages/utils/src/internals/general.ts
+++ b/packages/utils/src/internals/general.ts
@@ -77,7 +77,7 @@ export function weightedAvg(arrValues: number[], arrWeights: number[]): number {
  * @param millis Period of time to sleep, in milliseconds. If not a positive number, the returned promise resolves immediately.
  */
 export async function sleep(millis?: number): Promise<void> {
-    return setTimeout(millis);
+    return setTimeout(millis ?? undefined);
 }
 
 /**

--- a/test/core/sitemap_request_list.test.ts
+++ b/test/core/sitemap_request_list.test.ts
@@ -501,6 +501,18 @@ describe('SitemapRequestList', () => {
         expect(newList.handledCount()).toBe(2);
     });
 
+    test("calling `persistState` doesn't throw", async () => {
+        const list = await SitemapRequestList.open({ sitemapUrls: [`${url}/sitemap.xml`] });
+
+        for await (const request of list) {
+            await list.markRequestHandled(request);
+
+            if (list.handledCount() >= 2) break;
+        }
+
+        await expect(list.persistState()).resolves.toBe(undefined);
+    });
+
     test('state persistence tracks user changes', async () => {
         const options = {
             sitemapUrls: [`${url}/sitemap-stream.xml`],


### PR DESCRIPTION
Pushing to the internal stream in `persistState` at https://github.com/apify/crawlee/blob/f3eb99d9fa9a7aa0ec1dcb9773e666a9ac14fb76/packages/core/src/storages/sitemap_request_list.ts#L446 caused uncaught exceptions if the stream was already closed.

closes #2672 