### PR TITLE
fix(core): accept `UInt8Array` in `KVS.setValue()`

### DIFF
--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -20,7 +20,7 @@ const requestOptionalPredicates = {
     loadedUrl: ow.optional.string.url,
     uniqueKey: ow.optional.string,
     method: ow.optional.string,
-    payload: ow.optional.any(ow.string, ow.buffer, ow.uint8Array),
+    payload: ow.optional.any(ow.string, ow.uint8Array),
     noRetry: ow.optional.boolean,
     retryCount: ow.optional.number,
     sessionRotationCount: ow.optional.number,

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -20,7 +20,7 @@ const requestOptionalPredicates = {
     loadedUrl: ow.optional.string.url,
     uniqueKey: ow.optional.string,
     method: ow.optional.string,
-    payload: ow.optional.any(ow.string, ow.buffer),
+    payload: ow.optional.any(ow.string, ow.buffer, ow.uint8Array),
     noRetry: ow.optional.boolean,
     retryCount: ow.optional.number,
     sessionRotationCount: ow.optional.number,

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -80,7 +80,7 @@ export async function serializeArray<T>(data: T[]): Promise<Buffer> {
  * @internal
  */
 export async function deserializeArray<T extends string | Buffer>(compressedData: Buffer | Uint8Array): Promise<T[]> {
-    ow(compressedData, ow.any(ow.buffer, ow.uint8Array));
+    ow(compressedData, ow.uint8Array);
     const { chunks, collector } = createChunkCollector<T>({ fromValuesStream: true });
     await pipeline(Readable.from([compressedData]), zlib.createGunzip(), StreamArray.withParser(), collector);
 
@@ -97,7 +97,7 @@ export async function deserializeArray<T extends string | Buffer>(compressedData
  * @internal
  */
 export function createDeserialize(compressedData: Buffer | Uint8Array): Readable {
-    ow(compressedData, ow.any(ow.buffer, ow.uint8Array));
+    ow(compressedData, ow.uint8Array);
     const streamArray = StreamArray.withParser();
     const destination = pluckValue(streamArray);
 

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -79,8 +79,8 @@ export async function serializeArray<T>(data: T[]): Promise<Buffer> {
  * when apify-client supports streams.
  * @internal
  */
-export async function deserializeArray<T extends string | Buffer>(compressedData: Buffer): Promise<T[]> {
-    ow(compressedData, ow.buffer);
+export async function deserializeArray<T extends string | Buffer>(compressedData: Buffer | Uint8Array): Promise<T[]> {
+    ow(compressedData, ow.any(ow.buffer, ow.uint8Array));
     const { chunks, collector } = createChunkCollector<T>({ fromValuesStream: true });
     await pipeline(Readable.from([compressedData]), zlib.createGunzip(), StreamArray.withParser(), collector);
 
@@ -96,8 +96,8 @@ export async function deserializeArray<T extends string | Buffer>(compressedData
  * optimized to ingest a Stream if and when apify-client supports streams.
  * @internal
  */
-export function createDeserialize(compressedData: Buffer): Readable {
-    ow(compressedData, ow.buffer);
+export function createDeserialize(compressedData: Buffer | Uint8Array): Readable {
+    ow(compressedData, ow.any(ow.buffer, ow.uint8Array));
     const streamArray = StreamArray.withParser();
     const destination = pluckValue(streamArray);
 

--- a/packages/core/src/storages/key_value_store.ts
+++ b/packages/core/src/storages/key_value_store.ts
@@ -336,7 +336,7 @@ export class KeyValueStore {
         if (
             options.contentType &&
             !(
-                ow.isValid(value, ow.any(ow.string, ow.buffer, ow.uint8Array)) ||
+                ow.isValid(value, ow.any(ow.string, ow.uint8Array)) ||
                 (ow.isValid(value, ow.object) && typeof (value as Dictionary).pipe === 'function')
             )
         ) {

--- a/packages/core/src/storages/key_value_store.ts
+++ b/packages/core/src/storages/key_value_store.ts
@@ -336,7 +336,7 @@ export class KeyValueStore {
         if (
             options.contentType &&
             !(
-                ow.isValid(value, ow.any(ow.string, ow.buffer)) ||
+                ow.isValid(value, ow.any(ow.string, ow.buffer, ow.uint8Array)) ||
                 (ow.isValid(value, ow.object) && typeof (value as Dictionary).pipe === 'function')
             )
         ) {

--- a/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
+++ b/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
@@ -190,7 +190,7 @@ export async function gotoExtended(
             url: ow.string.url,
             method: ow.optional.string,
             headers: ow.optional.object,
-            payload: ow.optional.any(ow.string, ow.buffer, ow.uint8Array),
+            payload: ow.optional.any(ow.string, ow.uint8Array),
         }),
     );
     ow(gotoOptions, ow.object);

--- a/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
+++ b/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
@@ -190,7 +190,7 @@ export async function gotoExtended(
             url: ow.string.url,
             method: ow.optional.string,
             headers: ow.optional.object,
-            payload: ow.optional.any(ow.string, ow.buffer),
+            payload: ow.optional.any(ow.string, ow.buffer, ow.uint8Array),
         }),
     );
     ow(gotoOptions, ow.object);

--- a/packages/puppeteer-crawler/src/internals/utils/puppeteer_utils.ts
+++ b/packages/puppeteer-crawler/src/internals/utils/puppeteer_utils.ts
@@ -465,7 +465,7 @@ export async function gotoExtended(
             url: ow.string.url,
             method: ow.optional.string,
             headers: ow.optional.object,
-            payload: ow.optional.any(ow.string, ow.buffer, ow.uint8Array),
+            payload: ow.optional.any(ow.string, ow.uint8Array),
         }),
     );
     ow(gotoOptions, ow.object);

--- a/packages/puppeteer-crawler/src/internals/utils/puppeteer_utils.ts
+++ b/packages/puppeteer-crawler/src/internals/utils/puppeteer_utils.ts
@@ -465,7 +465,7 @@ export async function gotoExtended(
             url: ow.string.url,
             method: ow.optional.string,
             headers: ow.optional.object,
-            payload: ow.optional.any(ow.string, ow.buffer),
+            payload: ow.optional.any(ow.string, ow.buffer, ow.uint8Array),
         }),
     );
     ow(gotoOptions, ow.object);


### PR DESCRIPTION
This fixes saving screenshots via puppeteer v23, which started returning `UInt8Array` instead of a `Buffer`.

All places where we had a validation for Buffer now also accept `UInt8Array`.