### PR TITLE
fix(puppeteer): rename `ignoreHTTPSErrors` to `acceptInsecureCerts` to support v23

### DIFF
--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -530,6 +530,7 @@ export abstract class BrowserCrawler<
                  */
                 newPageOptions.pageOptions = {
                     ignoreHTTPSErrors: true,
+                    acceptInsecureCerts: true,
                 };
             }
         }
@@ -747,6 +748,7 @@ export abstract class BrowserCrawler<
                  * @see https://github.com/puppeteer/puppeteer/blob/main/docs/api.md
                  */
                 (launchContext.launchOptions as Dictionary).ignoreHTTPSErrors = true;
+                (launchContext.launchOptions as Dictionary).acceptInsecureCerts = true;
             }
         }
 

--- a/test/e2e/puppeteer-ignore-ssl-errors/actor/main.js
+++ b/test/e2e/puppeteer-ignore-ssl-errors/actor/main.js
@@ -11,7 +11,7 @@ const mainOptions = {
 
 await Actor.main(async () => {
     const crawler = new PuppeteerCrawler({
-        launchContext: { launchOptions: { ignoreHTTPSErrors: true } },
+        launchContext: { launchOptions: { acceptInsecureCerts: true } },
         preNavigationHooks: [
             (_ctx, goToOptions) => {
                 goToOptions.waitUntil = ['networkidle2'];

--- a/test/e2e/puppeteer-throw-on-ssl-errors/actor/main.js
+++ b/test/e2e/puppeteer-throw-on-ssl-errors/actor/main.js
@@ -11,7 +11,7 @@ const mainOptions = {
 
 await Actor.main(async () => {
     const crawler = new PuppeteerCrawler({
-        launchContext: { launchOptions: { ignoreHTTPSErrors: false } }, // This is the default
+        launchContext: { launchOptions: { acceptInsecureCerts: false } }, // This is the default
         preNavigationHooks: [
             (_ctx, goToOptions) => {
                 goToOptions.waitUntil = ['networkidle2'];


### PR DESCRIPTION
Both options are now used internally, since those code paths are shared for playwright as well, and we want to support older puppeteer versions too.

Also tested this locally with puppeteer v22, luckily there are no runtime validations for unknown options, so we can just use both.