### PR TITLE
fix(http-crawler): avoid crashing when gotOptions.cache is on

### DIFF
--- a/packages/http-crawler/src/internals/http-crawler.ts
+++ b/packages/http-crawler/src/internals/http-crawler.ts
@@ -977,9 +977,9 @@ function addResponsePropertiesToStream(stream: GotRequest) {
 
     response.on('end', () => {
         // @ts-expect-error
-        Object.assign(stream.rawTrailers, response.rawTrailers);
+        if (stream.rawTrailers) Object.assign(stream.rawTrailers, response.rawTrailers);
         // @ts-expect-error
-        Object.assign(stream.trailers, response.trailers);
+        if (stream.trailers) Object.assign(stream.trailers, response.trailers);
 
         // @ts-expect-error
         stream.complete = response.complete;


### PR DESCRIPTION
When the response is from cache, http-crawler will throw "TypeError: Cannot convert undefined or null to object"

This PR fixes this issue. Related usage is added as test case as well.