### PR TITLE
fix: `forefront` request fetching in RQv2

### DIFF
--- a/packages/core/src/storages/request_provider.ts
+++ b/packages/core/src/storages/request_provider.ts
@@ -542,6 +542,7 @@ export abstract class RequestProvider implements IStorage {
             forefront,
         })) as RequestQueueOperationInfo;
         queueOperationInfo.uniqueKey = request.uniqueKey;
+        this.assumedForefrontCount += forefront ? 1 : 0;
         this._cacheRequest(getRequestId(request.uniqueKey), queueOperationInfo);
 
         return queueOperationInfo;

--- a/packages/core/src/storages/request_queue_v2.ts
+++ b/packages/core/src/storages/request_queue_v2.ts
@@ -223,10 +223,11 @@ export class RequestQueue extends RequestProvider {
                 // To retain the correct queue ordering, we rollback this head read.
                 (forefront && headData.hadMultipleClients)
             ) {
-                this.log.debug(`Skipping request from queue head as it's invalid or recently handled`, {
+                this.log.debug(`Skipping request from queue head as it's potentially invalid or recently handled`, {
                     id,
                     uniqueKey,
                     recentlyHandled: !!this.recentlyHandledRequestsCache.get(id),
+                    inconsistentForefrontRead: forefront && headData.hadMultipleClients,
                 });
 
                 // Remove the lock from the request for now, so that it can be picked up later

--- a/packages/core/src/storages/request_queue_v2.ts
+++ b/packages/core/src/storages/request_queue_v2.ts
@@ -175,8 +175,6 @@ export class RequestQueue extends RequestProvider {
             // Try to delete the request lock if possible
             try {
                 await this.client.deleteRequestLock(request.id!, { forefront: options?.forefront ?? false });
-
-                this.assumedForefrontCount += options?.forefront ? 1 : 0;
             } catch (err) {
                 this.log.debug(`Failed to delete request lock for request ${request.id}`, { err });
             }

--- a/packages/core/src/storages/request_queue_v2.ts
+++ b/packages/core/src/storages/request_queue_v2.ts
@@ -176,7 +176,7 @@ export class RequestQueue extends RequestProvider {
             try {
                 await this.client.deleteRequestLock(request.id!, { forefront: options?.forefront ?? false });
 
-                this.assumedForefrontCount++;
+                this.assumedForefrontCount += options?.forefront ? 1 : 0;
             } catch (err) {
                 this.log.debug(`Failed to delete request lock for request ${request.id}`, { err });
             }

--- a/test/core/storages/request_queue.test.ts
+++ b/test/core/storages/request_queue.test.ts
@@ -5,6 +5,7 @@ import {
     API_PROCESSED_REQUESTS_DELAY_MILLIS,
     STORAGE_CONSISTENCY_DELAY_MILLIS,
     RequestQueueV1 as RequestQueue,
+    RequestQueueV2,
     Request,
     Configuration,
     ProxyConfiguration,
@@ -622,6 +623,36 @@ describe('RequestQueue remote', () => {
         expect(listHeadMock).toHaveBeenLastCalledWith({ limit: QUERY_HEAD_MIN_LENGTH });
     });
 
+    test('`fetchNextRequest` order respects `forefront` enqueues', async () => {
+        const emulator = new MemoryStorageEmulator();
+
+        await emulator.init();
+        const queue = await RequestQueue.open();
+
+        const retrievedUrls: string[] = [];
+
+        await queue.addRequests([
+            { url: 'http://example.com/1' },
+            { url: 'http://example.com/4' },
+            { url: 'http://example.com/5' },
+        ]);
+
+        retrievedUrls.push((await queue.fetchNextRequest()).url);
+
+        await queue.addRequest({ url: 'http://example.com/3' }, { forefront: true });
+        await queue.addRequest({ url: 'http://example.com/2' }, { forefront: true });
+
+        let req = await queue.fetchNextRequest();
+
+        while (req) {
+            retrievedUrls.push(req.url);
+            req = await queue.fetchNextRequest();
+        }
+
+        expect(retrievedUrls.map((x) => new URL(x).pathname)).toEqual(['/1', '/2', '/3', '/4', '/5']);
+        await emulator.destroy();
+    });
+
     test('getInfo() should work', async () => {
         const queue = new RequestQueue({ id: 'some-id', name: 'some-name', client: storageClient });
 
@@ -826,9 +857,9 @@ describe('RequestQueue v2', () => {
     }
 
     async function getEmptyQueue(name: string) {
-        const queue = await RequestQueue.open(name);
+        const queue = await RequestQueueV2.open(name);
         await queue.drop();
-        return RequestQueue.open(name);
+        return RequestQueueV2.open(name);
     }
 
     function getUniqueRequests(count: number) {
@@ -902,5 +933,32 @@ describe('RequestQueue v2', () => {
         const { items: secondFetch } = await queue.client.listAndLockHead({ limit: 1, lockSecs: 60 });
 
         expect(secondFetch[0]).toEqual(firstFetch[0]);
+    });
+
+    test.only('`fetchNextRequest` order respects `forefront` enqueues', async () => {
+        const queue = await getEmptyQueue('fetch-next-request-order');
+
+        const retrievedUrls: string[] = [];
+
+        await queue.addRequests([
+            { url: 'http://example.com/1' },
+            ...Array.from({ length: 25 }, (_, i) => ({ url: `http://example.com/${i + 4}` })),
+        ]);
+
+        retrievedUrls.push((await queue.fetchNextRequest()).url);
+
+        await queue.addRequest({ url: 'http://example.com/3' }, { forefront: true });
+        await queue.addRequest({ url: 'http://example.com/2' }, { forefront: true });
+
+        let req = await queue.fetchNextRequest();
+
+        while (req) {
+            retrievedUrls.push(req.url);
+            req = await queue.fetchNextRequest();
+        }
+
+        expect(retrievedUrls.map((x) => new URL(x).pathname)).toEqual([
+            Array.from({ length: 28 }, (_, i) => `/${i + 1}`),
+        ]);
     });
 });

--- a/test/core/storages/request_queue.test.ts
+++ b/test/core/storages/request_queue.test.ts
@@ -957,8 +957,8 @@ describe('RequestQueue v2', () => {
             req = await queue.fetchNextRequest();
         }
 
-        expect(retrievedUrls.map((x) => new URL(x).pathname)).toEqual([
+        expect(retrievedUrls.map((x) => new URL(x).pathname)).toEqual(
             Array.from({ length: 28 }, (_, i) => `/${i + 1}`),
-        ]);
+        );
     });
 });

--- a/test/core/storages/request_queue.test.ts
+++ b/test/core/storages/request_queue.test.ts
@@ -935,7 +935,7 @@ describe('RequestQueue v2', () => {
         expect(secondFetch[0]).toEqual(firstFetch[0]);
     });
 
-    test.only('`fetchNextRequest` order respects `forefront` enqueues', async () => {
+    test('`fetchNextRequest` order respects `forefront` enqueues', async () => {
         const queue = await getEmptyQueue('fetch-next-request-order');
 
         const retrievedUrls: string[] = [];
@@ -957,6 +957,7 @@ describe('RequestQueue v2', () => {
             req = await queue.fetchNextRequest();
         }
 
+        // 28 requests exceed the RQv2 batch size limit of 25, so we can examine the request ordering
         expect(retrievedUrls.map((x) => new URL(x).pathname)).toEqual(
             Array.from({ length: 28 }, (_, i) => `/${i + 1}`),
         );

--- a/test/core/storages/request_queue.test.ts
+++ b/test/core/storages/request_queue.test.ts
@@ -991,6 +991,8 @@ describe('RequestQueue v2', () => {
 
         await queue.reclaimRequest(req, { forefront: true });
 
+        req = await queue.fetchNextRequest();
+
         while (req) {
             retrievedUrls.push(req.url);
             req = await queue.fetchNextRequest();


### PR DESCRIPTION
Keeps count of the (locally) `forefront` enqueued requests in the RQv2 instance. Uses this counter to signal the need for new remote RQ reads.

Note that with the current API, we cannot solve this for request queues with multiple clients. The original behavior is retained in such a scenario.

Closes #2669 