### PR TITLE
fix: `prolong-` and `deleteRequestLock` `forefront` option

### DIFF
--- a/packages/memory-storage/src/resource-clients/request-queue.ts
+++ b/packages/memory-storage/src/resource-clients/request-queue.ts
@@ -329,6 +329,7 @@ export class RequestQueueClient extends BaseClient implements storage.RequestQue
         internalRequest.orderNo = forefront ? -unlockTimestamp : unlockTimestamp;
 
         await request?.update(internalRequest);
+        if (forefront) this.forefrontRequestIds.push(id);
 
         return {
             lockExpiresAt: new Date(unlockTimestamp),
@@ -361,6 +362,7 @@ export class RequestQueueClient extends BaseClient implements storage.RequestQue
         }
 
         internalRequest.orderNo = forefront ? -start : start;
+        if (forefront) this.forefrontRequestIds.push(id);
 
         await request?.update(internalRequest);
     }


### PR DESCRIPTION
Turns out we neglected the `prolong` and `deleteRequestLock` methods with #2681 , so these do not respect the `forefront`-enforced request ordering. This PR fixes this omission.

Prerequisite for #2689 
Related to #2669 