### PR TITLE
fix: check `.isFinished()` before `RequestList` reads

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -1138,7 +1138,10 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
      * and RequestQueue is present then enqueues it to the queue first.
      */
     protected async _fetchNextRequest() {
-        if (!this.requestList) return this.requestQueue!.fetchNextRequest();
+        if (!this.requestList || (await this.requestList?.isFinished())) {
+            return this.requestQueue!.fetchNextRequest();
+        }
+
         const request = await this.requestList.fetchNextRequest();
         if (!this.requestQueue) return request;
         if (!request) return this.requestQueue.fetchNextRequest();
@@ -1534,7 +1537,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
         }
 
         return process.env.CRAWLEE_VERBOSE_LOG || forceStack
-            ? (error.stack ?? [error.message || error, ...stackLines].join('\n'))
+            ? error.stack ?? [error.message || error, ...stackLines].join('\n')
             : [error.message || error, userLine].join('\n');
     }
 

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -1138,8 +1138,8 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
      * and RequestQueue is present then enqueues it to the queue first.
      */
     protected async _fetchNextRequest() {
-        if (!this.requestList || (await this.requestList?.isFinished())) {
-            return this.requestQueue!.fetchNextRequest();
+        if (!this.requestList || (await this.requestList.isFinished())) {
+            return this.requestQueue?.fetchNextRequest();
         }
 
         const request = await this.requestList.fetchNextRequest();

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -1537,7 +1537,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
         }
 
         return process.env.CRAWLEE_VERBOSE_LOG || forceStack
-            ? error.stack ?? [error.message || error, ...stackLines].join('\n')
+            ? (error.stack ?? [error.message || error, ...stackLines].join('\n'))
             : [error.message || error, userLine].join('\n');
     }
 


### PR DESCRIPTION
Adds a simple `.isFinished()` check before the `RequestList.fetchNextRequest()` call. This eliminates long-blocking calls with non-trivial `RequestList` implementations (e.g. `SitemapRequestList` in some edge cases).