### PR TITLE
fix: decode special characters in proxy `username` and `password`

### DIFF
--- a/packages/core/src/proxy_configuration.ts
+++ b/packages/core/src/proxy_configuration.ts
@@ -284,8 +284,8 @@ export class ProxyConfiguration {
         return {
             sessionId,
             url,
-            username,
-            password,
+            username: decodeURIComponent(username),
+            password: decodeURIComponent(password),
             hostname,
             port: port!,
             proxyTier: tier,

--- a/test/core/proxy_configuration.test.ts
+++ b/test/core/proxy_configuration.test.ts
@@ -24,6 +24,21 @@ describe('ProxyConfiguration', () => {
         expect(await proxyConfiguration.newProxyInfo(sessionId)).toEqual(proxyInfo);
     });
 
+    test('newProxyInfo() works with special characters', async () => {
+        const url = 'http://user%40name:pass%40word@proxy.com:1111';
+        const proxyConfiguration = new ProxyConfiguration({ proxyUrls: [url] });
+
+        const proxyInfo = {
+            sessionId: `${sessionId}`,
+            url,
+            hostname: 'proxy.com',
+            username: 'user@name',
+            password: 'pass@word',
+            port: '1111',
+        };
+        expect(await proxyConfiguration.newProxyInfo(sessionId)).toEqual(proxyInfo);
+    });
+
     test('should throw on invalid newUrlFunction', async () => {
         const newUrlFunction = () => {
             return 'http://proxy.com:1111*invalid_url';


### PR DESCRIPTION
When using `newProxyInfo` function, the `username` and `password` extracted from `proxyUrl` are now properly decoded.

https://apify.slack.com/archives/C0L33UM7Z/p1727966399183259