### PR TITLE
fix: Handle invalid URLs in sitemap by trimming whitespace and skipping malformed URLs #2698

### DIFF
--- a/packages/utils/src/internals/sitemap.ts
+++ b/packages/utils/src/internals/sitemap.ts
@@ -139,18 +139,22 @@ class SitemapXmlParser extends Transform {
     }
 
     private onText(text: string) {
-        if (this.currentTag === 'loc') {
-            if (this.rootTagName === 'sitemapindex') {
-                this.push({ type: 'sitemapUrl', url: text } satisfies SitemapItem);
-            }
+        text =text.trim();
 
-            if (this.rootTagName === 'urlset') {
-                this.url ??= {};
-                this.url.loc = text;
+        if (this.currentTag === 'loc') {
+            try {
+                if (this.rootTagName === 'sitemapindex') {
+                    this.push({ type: 'sitemapUrl', url: text } satisfies SitemapItem);
+                }
+
+                if (this.rootTagName === 'urlset') {
+                    this.url ??= {};
+                    this.url.loc = text;
+                }
+            } catch (e) {
+                
             }
         }
-
-        text = text.trim();
 
         if (this.currentTag === 'lastmod') {
             this.url.lastmod = new Date(text);


### PR DESCRIPTION
Applied trim() to clean up the loc element text before processing URLs.
Used new URL() to ensure that only valid URLs are processed.
Added a try-catch block to skip malformed URLs, preventing the application from breaking if invalid URLs are encountered.
