### PR TITLE
fix: update `fingerprintGeneratorOptions` types

### DIFF
--- a/packages/browser-pool/src/fingerprinting/types.ts
+++ b/packages/browser-pool/src/fingerprinting/types.ts
@@ -1,4 +1,7 @@
-import type { BrowserFingerprintWithHeaders as Fingerprint } from 'fingerprint-generator';
+import type {
+    BrowserFingerprintWithHeaders as Fingerprint,
+    FingerprintGeneratorOptions as FingerprintOptionsOriginal,
+} from 'fingerprint-generator';
 
 export interface FingerprintGenerator {
     getFingerprint: (fingerprintGeneratorOptions?: FingerprintGeneratorOptions) => GetFingerprintReturn;
@@ -8,51 +11,7 @@ export interface GetFingerprintReturn {
     fingerprint: Fingerprint;
 }
 
-export interface FingerprintGeneratorOptions {
-    /**
-     * List of `BrowserSpecification` objects
-     * or one of `chrome`, `edge`, `firefox` and `safari`.
-     */
-    browsers?: BrowserSpecification[] | BrowserName[];
-    /**
-     * Browser generation query based on the real world data.
-     *  For more info see the [query docs](https://github.com/browserslist/browserslist#full-list).
-     *
-     * > Note: If `browserListQuery` is passed, the `browsers` array is ignored.
-     */
-    browserListQuery?: string;
-    /**
-     * List of operating systems to generate the headers for.
-     */
-    operatingSystems?: OperatingSystemsName[];
-    /**
-     * List of device types to generate the fingerprints for.
-     */
-    devices?: DeviceCategory[];
-    /**
-     * List of at most 10 languages to include in the
-     *  [Accept-Language](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language) request header
-     *  in the language format accepted by that header, for example `en`, `en-US` or `de`.
-     */
-    locales?: string[];
-    /**
-     * Http version to be used to generate headers (the headers differ depending on the version).
-     *
-     * Can be either 1 or 2. Default value is 2.
-     */
-    httpVersion?: HttpVersion;
-    /**
-     * Defines the screen dimensions of the generated fingerprint.
-     *
-     * > Note: Using this option can lead to a substantial performance drop (from ~0.0007s/fingerprint to ~0.03s/fingerprint)
-     */
-    screen?: {
-        minWidth?: number;
-        maxWidth?: number;
-        minHeight?: number;
-        maxHeight?: number;
-    };
-}
+export interface FingerprintGeneratorOptions extends Partial<FingerprintOptionsOriginal> {}
 
 const SUPPORTED_HTTP_VERSIONS = ['1', '2'] as const;
 


### PR DESCRIPTION
Manually cross-checked assignability against the types ([1](https://github.com/apify/fingerprint-suite/blob/c61814e6ba8822543deb0ce6c03e0a0249933629/packages/fingerprint-generator/src/fingerprint-generator.ts#L73),[2](https://github.com/apify/fingerprint-suite/blob/c61814e6ba8822543deb0ce6c03e0a0249933629/packages/header-generator/src/header-generator.ts#L87)) from `fingerprint-suite`. 

We should likely remove the enums below in the following breaking version too (in `fingerprint-suite`, we accept only string consts, which provides sufficient DX - regarding suggestions etc.). The current duplicity can cause more disparity down the road (adding new browsers to `fingerprint-suite` etc.).

Closes #2703 