### PR TITLE
fix: ignore errors from iframe content extraction

### DIFF
--- a/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
+++ b/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
@@ -609,7 +609,7 @@ export async function parseWithCheerio(
 
         await Promise.all(
             frames.map(async (frame) => {
-                try{
+                try {
                     const iframe = await frame.contentFrame();
 
                     if (iframe) {
@@ -623,7 +623,7 @@ export async function parseWithCheerio(
                             f.replaceWith(replacementNode);
                         }, contents);
                     }
-                } catch(error) {
+                } catch (error) {
                     log.warning(`Failed to extract iframe content: ${error}`);
                 }
             }),

--- a/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
+++ b/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
@@ -624,7 +624,7 @@ export async function parseWithCheerio(
                         }, contents);
                     }
                 } catch(error) {
-                    console.warn('Failed to extract iframe content:', error);
+                    log.warning(`Failed to extract iframe content: ${error}`);
                 }
             }),
         );

--- a/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
+++ b/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
@@ -609,18 +609,22 @@ export async function parseWithCheerio(
 
         await Promise.all(
             frames.map(async (frame) => {
-                const iframe = await frame.contentFrame();
+                try{
+                    const iframe = await frame.contentFrame();
 
-                if (iframe) {
-                    const contents = await iframe.content();
+                    if (iframe) {
+                        const contents = await iframe.content();
 
-                    await frame.evaluate((f, c) => {
-                        const replacementNode = document.createElement('div');
-                        replacementNode.innerHTML = c;
-                        replacementNode.className = 'crawlee-iframe-replacement';
+                        await frame.evaluate((f, c) => {
+                            const replacementNode = document.createElement('div');
+                            replacementNode.innerHTML = c;
+                            replacementNode.className = 'crawlee-iframe-replacement';
 
-                        f.replaceWith(replacementNode);
-                    }, contents);
+                            f.replaceWith(replacementNode);
+                        }, contents);
+                    }
+                } catch(error) {
+                    console.warn('Failed to extract iframe content:', error);
                 }
             }),
         );

--- a/packages/puppeteer-crawler/src/internals/utils/puppeteer_utils.ts
+++ b/packages/puppeteer-crawler/src/internals/utils/puppeteer_utils.ts
@@ -212,8 +212,8 @@ export async function parseWithCheerio(
 
                             f.replaceWith(replacementNode);
                         }, contents);
-                    } 
-                } catch(error) {
+                    }
+                } catch (error) {
                     log.warning(`Failed to extract iframe content: ${error}`);
                 }
             }),

--- a/packages/puppeteer-crawler/src/internals/utils/puppeteer_utils.ts
+++ b/packages/puppeteer-crawler/src/internals/utils/puppeteer_utils.ts
@@ -200,10 +200,9 @@ export async function parseWithCheerio(
 
         await Promise.all(
             frames.map(async (frame) => {
-                const iframe = await frame.contentFrame();
-
-                if (iframe) {
-                    try{
+                try {
+                    const iframe = await frame.contentFrame();
+                    if (iframe) {
                         const contents = await iframe.content();
 
                         await frame.evaluate((f, c) => {
@@ -213,9 +212,9 @@ export async function parseWithCheerio(
 
                             f.replaceWith(replacementNode);
                         }, contents);
-                    } catch(error) {
-                        console.warn('Failed to extract iframe content:', error);
-                    }
+                    } 
+                } catch(error) {
+                    console.warn('Failed to extract iframe content:', error);
                 }
             }),
         );

--- a/packages/puppeteer-crawler/src/internals/utils/puppeteer_utils.ts
+++ b/packages/puppeteer-crawler/src/internals/utils/puppeteer_utils.ts
@@ -214,7 +214,7 @@ export async function parseWithCheerio(
                         }, contents);
                     } 
                 } catch(error) {
-                    console.warn('Failed to extract iframe content:', error);
+                    log.warning(`Failed to extract iframe content: ${error}`);
                 }
             }),
         );

--- a/packages/puppeteer-crawler/src/internals/utils/puppeteer_utils.ts
+++ b/packages/puppeteer-crawler/src/internals/utils/puppeteer_utils.ts
@@ -203,15 +203,19 @@ export async function parseWithCheerio(
                 const iframe = await frame.contentFrame();
 
                 if (iframe) {
-                    const contents = await iframe.content();
+                    try{
+                        const contents = await iframe.content();
 
-                    await frame.evaluate((f, c) => {
-                        const replacementNode = document.createElement('div');
-                        replacementNode.innerHTML = c;
-                        replacementNode.className = 'crawlee-iframe-replacement';
+                        await frame.evaluate((f, c) => {
+                            const replacementNode = document.createElement('div');
+                            replacementNode.innerHTML = c;
+                            replacementNode.className = 'crawlee-iframe-replacement';
 
-                        f.replaceWith(replacementNode);
-                    }, contents);
+                            f.replaceWith(replacementNode);
+                        }, contents);
+                    } catch(error) {
+                        console.warn('Failed to extract iframe content:', error);
+                    }
                 }
             }),
         );


### PR DESCRIPTION
using try-except block to handle iframe content extraction error
with catch block Handle the error as needed and continue processing other frames

Closes #2708 