### PR TITLE
docs: bump typedoc-api plugin to mitigate stray React errors

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -33,7 +33,7 @@
         "typescript": "^5.7.2"
     },
     "dependencies": {
-        "@apify/docusaurus-plugin-typedoc-api": "^4.2.10",
+        "@apify/docusaurus-plugin-typedoc-api": "^4.3.2",
         "@apify/utilities": "^2.8.0",
         "@docusaurus/core": "3.6.3",
         "@docusaurus/faster": "3.6.3",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -365,7 +365,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@apify/docusaurus-plugin-typedoc-api@npm:^4.2.10":
+"@apify/docusaurus-plugin-typedoc-api@npm:^4.3.2":
   version: 4.3.2
   resolution: "@apify/docusaurus-plugin-typedoc-api@npm:4.3.2"
   dependencies:
@@ -14092,7 +14092,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@apify/docusaurus-plugin-typedoc-api": "npm:^4.2.10"
+    "@apify/docusaurus-plugin-typedoc-api": "npm:^4.3.2"
     "@apify/eslint-config-ts": "npm:^0.4.0"
     "@apify/tsconfig": "npm:^0.1.0"
     "@apify/utilities": "npm:^2.8.0"


### PR DESCRIPTION
Context: https://apify.slack.com/archives/C0L33UM7Z/p1732811764451919