### PR TITLE
feat: add support for parsing comma-separated list environment variables

### DIFF
--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -347,7 +347,9 @@ export class Configuration {
         }
 
         if (Configuration.COMMA_SEPARATED_LIST_VARS.includes(key)) {
-            return String(value).split(',').map((v) => v.trim());
+            return String(value)
+                .split(',')
+                .map((v) => v.trim());
         }
 
         return value;

--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -253,6 +253,8 @@ export class Configuration {
 
     protected static INTEGER_VARS = ['memoryMbytes', 'persistStateIntervalMillis', 'systemInfoIntervalMillis'];
 
+    protected static COMMA_SEPARATED_LIST_VARS: string[] = [];
+
     protected static DEFAULTS: Dictionary = {
         defaultKeyValueStoreId: 'default',
         defaultDatasetId: 'default',
@@ -342,6 +344,10 @@ export class Configuration {
         if (Configuration.BOOLEAN_VARS.includes(key)) {
             // 0, false and empty string are considered falsy values
             return !['0', 'false', ''].includes(String(value).toLowerCase());
+        }
+
+        if (Configuration.COMMA_SEPARATED_LIST_VARS.includes(key)) {
+            return String(value).split(',').map((v) => v.trim());
         }
 
         return value;

--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -347,6 +347,7 @@ export class Configuration {
         }
 
         if (Configuration.COMMA_SEPARATED_LIST_VARS.includes(key)) {
+            if (!value) return [];
             return String(value)
                 .split(',')
                 .map((v) => v.trim());


### PR DESCRIPTION
We're planning to add a new environment variable, `ACTOR_BUILD_TAGS`, to the Actor runtime, which will contain the list of build tags of the currently running Actor build. The environment variable will be a comma-separated list, but I think it would be easier to work with if it was already parsed to an array in the `Configuration` instance.

This adds support for parsing comma-separated list environment variables to arrays. In the SDK, I'll then just override the `COMMA_SEPARATED_LIST_VARS` list to include the environment variable I want to have parsed.