### PR TITLE
fix(core): type definition of Dataset.reduce

### DIFF
--- a/packages/core/src/storages/dataset.ts
+++ b/packages/core/src/storages/dataset.ts
@@ -522,20 +522,23 @@ export class Dataset<Data extends Dictionary = Dictionary> {
      * @param [options] All `reduce()` parameters.
      */
     async reduce(iteratee: DatasetReducer<Data, Data>): Promise<Data | undefined>;
+
     async reduce(
         iteratee: DatasetReducer<Data, Data>,
         memo: undefined,
-        options: DatasetIteratorOptions
+        options: DatasetIteratorOptions,
     ): Promise<Data | undefined>;
+
     async reduce<T>(
         iteratee: DatasetReducer<T, Data>,
         memo: T,
-        options: DatasetIteratorOptions
+        options: DatasetIteratorOptions,
     ): Promise<T>;
+
     async reduce<T = Data>(
         iteratee: DatasetReducer<T, Data>,
         memo?: T,
-        options: DatasetIteratorOptions = {}
+        options: DatasetIteratorOptions = {},
     ): Promise<T | undefined> {
         checkStorageAccess();
 

--- a/packages/core/src/storages/dataset.ts
+++ b/packages/core/src/storages/dataset.ts
@@ -140,7 +140,7 @@ export interface DatasetDataOptions {
     skipEmpty?: boolean;
 }
 
-export interface DatasetExportOptions extends Omit<DatasetDataOptions, 'offset' | 'limit'> {}
+export interface DatasetExportOptions extends Omit<DatasetDataOptions, 'offset' | 'limit'> { }
 
 export interface DatasetIteratorOptions
     extends Omit<DatasetDataOptions, 'offset' | 'limit' | 'clean' | 'skipHidden' | 'skipEmpty'> {
@@ -562,7 +562,7 @@ export class Dataset<Data extends Dictionary = Dictionary> {
      * @param memo Initial state of the reduction.
      * @param [options] An object containing extra options for `reduce()`
      */
-    async reduce<T>(iteratee: DatasetReducer<T, Data>, memo: T, options: DatasetIteratorOptions): Promise<T>;
+    async reduce<T>(iteratee: DatasetReducer<T, Data>, memo: T, options?: DatasetIteratorOptions): Promise<T>;
 
     async reduce<T = Data>(
         iteratee: DatasetReducer<T, Data>,

--- a/packages/core/src/storages/dataset.ts
+++ b/packages/core/src/storages/dataset.ts
@@ -140,7 +140,7 @@ export interface DatasetDataOptions {
     skipEmpty?: boolean;
 }
 
-export interface DatasetExportOptions extends Omit<DatasetDataOptions, 'offset' | 'limit'> { }
+export interface DatasetExportOptions extends Omit<DatasetDataOptions, 'offset' | 'limit'> {}
 
 export interface DatasetIteratorOptions
     extends Omit<DatasetDataOptions, 'offset' | 'limit' | 'clean' | 'skipHidden' | 'skipEmpty'> {

--- a/packages/core/src/storages/dataset.ts
+++ b/packages/core/src/storages/dataset.ts
@@ -536,7 +536,7 @@ export class Dataset<Data extends Dictionary = Dictionary> {
         iteratee: DatasetReducer<T, Data>,
         memo?: T,
         options: DatasetIteratorOptions = {}
-    ): Promise<T> {
+    ): Promise<T | undefined> {
         checkStorageAccess();
 
         let currentMemo: T | undefined = memo;

--- a/packages/core/src/storages/dataset.ts
+++ b/packages/core/src/storages/dataset.ts
@@ -140,7 +140,7 @@ export interface DatasetDataOptions {
     skipEmpty?: boolean;
 }
 
-export interface DatasetExportOptions extends Omit<DatasetDataOptions, 'offset' | 'limit'> {}
+export interface DatasetExportOptions extends Omit<DatasetDataOptions, 'offset' | 'limit'> { }
 
 export interface DatasetIteratorOptions
     extends Omit<DatasetDataOptions, 'offset' | 'limit' | 'clean' | 'skipHidden' | 'skipEmpty'> {
@@ -507,28 +507,61 @@ export class Dataset<Data extends Dictionary = Dictionary> {
 
     /**
      * Reduces a list of values down to a single value.
+     * 
+     * The first element of the dataset is the initial value, with each successive reductions should
+     * be returned by `iteratee()`. The `iteratee()` is passed three arguments: the `memo`, `value`
+     * and `index` of the current element being folded into the reduction.
      *
-     * Memo is the initial state of the reduction, and each successive step of it should be returned by `iteratee()`.
-     * The `iteratee()` is passed three arguments: the `memo`, then the `value` and `index` of the iteration.
-     *
-     * If no `memo` is passed to the initial invocation of reduce (or `memo` is set as `undefined`),
-     * the `iteratee()` is not invoked on the first element of the list.
-     * The first element is instead passed as the memo in the invocation of the `iteratee()` on the next element in the list.
-     *
-     * If `iteratee()` returns a `Promise` then it's awaited before a next call.
+     * The `iteratee` is first invoked on the second element of the list (`index = 1`), with the
+     * first element given as the memo parameter. After that, the rest of the elements in the
+     * dataset is passed to `iteratee`, with the result of the previous invocation as the memo.
+     * 
+     * If `iteratee()` returns a `Promise` it's awaited before a next call. 
+     * 
+     * If the dataset is empty, reduce will return undefined.
      *
      * @param iteratee
-     * @param memo Initial state of the reduction.
-     * @param [options] All `reduce()` parameters.
      */
     async reduce(iteratee: DatasetReducer<Data, Data>): Promise<Data | undefined>;
 
+    /**
+     * Reduces a list of values down to a single value.
+     * 
+     * The first element of the dataset is the initial value, with each successive reductions should
+     * be returned by `iteratee()`. The `iteratee()` is passed three arguments: the `memo`, `value`
+     * and `index` of the current element being folded into the reduction.
+     *
+     * The `iteratee` is first invoked on the second element of the list (`index = 1`), with the
+     * first element given as the memo parameter. After that, the rest of the elements in the
+     * dataset is passed to `iteratee`, with the result of the previous invocation as the memo.
+     * 
+     * If `iteratee()` returns a `Promise` it's awaited before a next call. 
+     * 
+     * If the dataset is empty, reduce will return undefined.
+     *
+     * @param iteratee
+     * @param memo Unset parameter, neccesary to be able to pass options
+     * @param [options] An object containing extra options for `reduce()`
+     */
     async reduce(
         iteratee: DatasetReducer<Data, Data>,
         memo: undefined,
         options: DatasetIteratorOptions,
     ): Promise<Data | undefined>;
 
+    /**
+     * Reduces a list of values down to a single value.
+     *
+     * Memo is the initial state of the reduction, and each successive step of it should be returned
+     * by `iteratee()`. The `iteratee()` is passed three arguments: the `memo`, then the `value` and
+     * `index` of the iteration.
+     *
+     * If `iteratee()` returns a `Promise` then it's awaited before a next call.
+     *
+     * @param iteratee
+     * @param memo Initial state of the reduction.
+     * @param [options] An object containing extra options for `reduce()`
+     */
     async reduce<T>(
         iteratee: DatasetReducer<T, Data>,
         memo: T,

--- a/packages/core/src/storages/dataset.ts
+++ b/packages/core/src/storages/dataset.ts
@@ -140,7 +140,7 @@ export interface DatasetDataOptions {
     skipEmpty?: boolean;
 }
 
-export interface DatasetExportOptions extends Omit<DatasetDataOptions, 'offset' | 'limit'> { }
+export interface DatasetExportOptions extends Omit<DatasetDataOptions, 'offset' | 'limit'> {}
 
 export interface DatasetIteratorOptions
     extends Omit<DatasetDataOptions, 'offset' | 'limit' | 'clean' | 'skipHidden' | 'skipEmpty'> {
@@ -507,7 +507,7 @@ export class Dataset<Data extends Dictionary = Dictionary> {
 
     /**
      * Reduces a list of values down to a single value.
-     * 
+     *
      * The first element of the dataset is the initial value, with each successive reductions should
      * be returned by `iteratee()`. The `iteratee()` is passed three arguments: the `memo`, `value`
      * and `index` of the current element being folded into the reduction.
@@ -515,9 +515,9 @@ export class Dataset<Data extends Dictionary = Dictionary> {
      * The `iteratee` is first invoked on the second element of the list (`index = 1`), with the
      * first element given as the memo parameter. After that, the rest of the elements in the
      * dataset is passed to `iteratee`, with the result of the previous invocation as the memo.
-     * 
-     * If `iteratee()` returns a `Promise` it's awaited before a next call. 
-     * 
+     *
+     * If `iteratee()` returns a `Promise` it's awaited before a next call.
+     *
      * If the dataset is empty, reduce will return undefined.
      *
      * @param iteratee
@@ -526,7 +526,7 @@ export class Dataset<Data extends Dictionary = Dictionary> {
 
     /**
      * Reduces a list of values down to a single value.
-     * 
+     *
      * The first element of the dataset is the initial value, with each successive reductions should
      * be returned by `iteratee()`. The `iteratee()` is passed three arguments: the `memo`, `value`
      * and `index` of the current element being folded into the reduction.
@@ -534,9 +534,9 @@ export class Dataset<Data extends Dictionary = Dictionary> {
      * The `iteratee` is first invoked on the second element of the list (`index = 1`), with the
      * first element given as the memo parameter. After that, the rest of the elements in the
      * dataset is passed to `iteratee`, with the result of the previous invocation as the memo.
-     * 
-     * If `iteratee()` returns a `Promise` it's awaited before a next call. 
-     * 
+     *
+     * If `iteratee()` returns a `Promise` it's awaited before a next call.
+     *
      * If the dataset is empty, reduce will return undefined.
      *
      * @param iteratee
@@ -562,11 +562,7 @@ export class Dataset<Data extends Dictionary = Dictionary> {
      * @param memo Initial state of the reduction.
      * @param [options] An object containing extra options for `reduce()`
      */
-    async reduce<T>(
-        iteratee: DatasetReducer<T, Data>,
-        memo: T,
-        options: DatasetIteratorOptions,
-    ): Promise<T>;
+    async reduce<T>(iteratee: DatasetReducer<T, Data>, memo: T, options: DatasetIteratorOptions): Promise<T>;
 
     async reduce<T = Data>(
         iteratee: DatasetReducer<T, Data>,

--- a/test/core/storages/dataset.test.ts
+++ b/test/core/storages/dataset.test.ts
@@ -298,7 +298,7 @@ describe('dataset', () => {
 
                     return memo.concat(item);
                 },
-                new Array(),
+                [] as unknown[],
                 {
                     limit: 2,
                 },
@@ -324,7 +324,7 @@ describe('dataset', () => {
 
                     return Promise.resolve(memo.concat(item));
                 },
-                new Array(),
+                [] as unknown[],
                 {
                     limit: 2,
                 },

--- a/test/core/storages/dataset.test.ts
+++ b/test/core/storages/dataset.test.ts
@@ -296,10 +296,9 @@ describe('dataset', () => {
                     item.index = index;
                     item.bar = 'xxx';
 
-                    // @ts-expect-error FIXME the inference is broken for `reduce()` method
                     return memo.concat(item);
                 },
-                [],
+                new Array(),
                 {
                     limit: 2,
                 },
@@ -323,10 +322,9 @@ describe('dataset', () => {
                     item.index = index;
                     item.bar = 'xxx';
 
-                    // @ts-expect-error FIXME the inference is broken for `reduce()` method
                     return Promise.resolve(memo.concat(item));
                 },
-                [],
+                new Array(),
                 {
                     limit: 2,
                 },
@@ -369,10 +367,8 @@ describe('dataset', () => {
             const calledForIndexes: number[] = [];
 
             const result = await dataset.reduce(
-                // @ts-expect-error FIXME the inference is broken for `reduce()` method
                 async (memo, item, index) => {
                     calledForIndexes.push(index);
-                    // @ts-expect-error FIXME the inference is broken for `reduce()` method
                     return Promise.resolve(memo.foo > item.foo ? memo : item);
                 },
                 undefined,
@@ -391,8 +387,7 @@ describe('dataset', () => {
                 offset: 2,
             });
 
-            // @ts-expect-error FIXME the inference is broken for `reduce()` method
-            expect(result.foo).toBe(5);
+            expect(result!.foo).toBe(5);
             expect(calledForIndexes).toEqual([1, 2, 3]);
         });
     });


### PR DESCRIPTION
Fixes #2773 

I'm seeing type errors and test failures in `./test/core/sitemap_request_list.test.ts` both before and after my change.

This PR currently doesn't add tests to check that types resolve correctly. In the `reduce() uses first value as memo if no memo is provided` test, the result from reduce was previously inferred to be `any`, and is now inferred to be `Dictionary`. Adding a type annotation doesn't help catch this change as implicit any is allowed.