### PR TITLE
Update click-elements.ts - fix uncaught exception issue

### DIFF
--- a/packages/playwright-crawler/src/internals/enqueue-links/click-elements.ts
+++ b/packages/playwright-crawler/src/internals/enqueue-links/click-elements.ts
@@ -544,7 +544,7 @@ async function restoreHistoryNavigationAndSaveCapturedUrls(page: Page, requests:
         const { stateHistory } = window.history as unknown as ApifyWindow;
         (window as unknown as Dictionary).history = (window as unknown as Dictionary).__originalHistory__;
         return stateHistory;
-    });
+    }) ?? [];
 
     state.forEach((args) => {
         try {


### PR DESCRIPTION
If the history is empty because of a navigation (for example: clicking a link - <a href=...>), then this prevents an empty state to cause an exception on line 549 in the same function.