### PR TITLE
feat(basic-crawler) pass custom sourcePool to crawlers

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -305,6 +305,11 @@ export interface BasicCrawlerOptions<Context extends CrawlingContext = BasicCraw
     useSessionPool?: boolean;
 
     /**
+     * Provide a custom {@apilink SessionPool} in lieu of having one be automatically created.
+     */
+    sessionPool?: SessionPool;
+
+    /**
      * The configuration options for {@apilink SessionPool} to use.
      */
     sessionPoolOptions?: SessionPoolOptions;
@@ -534,6 +539,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
         maxSessionRotations: ow.optional.number,
         maxRequestsPerCrawl: ow.optional.number,
         autoscaledPoolOptions: ow.optional.object,
+        sessionPool: ow.optional.object,
         sessionPoolOptions: ow.optional.object,
         useSessionPool: ow.optional.boolean,
 
@@ -574,6 +580,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
             maxRequestsPerCrawl,
             autoscaledPoolOptions = {},
             keepAlive,
+            sessionPool,
             sessionPoolOptions = {},
             useSessionPool = true,
 
@@ -686,6 +693,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
             config,
             ...statisticsOptions,
         });
+        this.sessionPool = sessionPool;
         this.sessionPoolOptions = {
             ...sessionPoolOptions,
             log,
@@ -1084,7 +1092,8 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
         // (otherwise there would be no way)
         this.autoscaledPool = new AutoscaledPool(this.autoscaledPoolOptions, this.config);
 
-        if (this.useSessionPool) {
+        // Create a new SessionPool if one is requested, unless one is already provided.
+        if (this.useSessionPool && !this.sessionPool) {
             this.sessionPool = await SessionPool.open(this.sessionPoolOptions, this.config);
             // Assuming there are not more than 20 browsers running at once;
             this.sessionPool.setMaxListeners(20);


### PR DESCRIPTION
### tl;dr
Enable developers to provide their own `SessionPool` and `Sessions` to a crawler. Very useful in situations where the crawler's constructor options aren't good enough. 

Example use-cases:
- you need to load specific cookies or UserData into your sessions 
- you need to create sessions as a result of executing some other synchronous logic (like logging in)
Relevant issue:  #569 

### More Details
In the [Session Management](https://crawlee.dev/docs/guides/session-management) Standalone example, we see the creation of custom sessions, but no examples of how to provide that to a crawler. Currently, usage of standalone sessions is relegated to the BasicCrawler where everything has to be manually done. With this PR, that'd no longer the case. Now any crawler can use a developer's custom SessionPool and Sessions.