### PR TITLE
chore(ci): pin Ubuntu 22.04 because of Playwright dependencies

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -7,7 +7,7 @@ on:
 jobs:
     check_pr_title:
         name: 'Check PR title'
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             -   uses: amannn/action-semantic-pull-request@v5.5.3
                 env:

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -26,7 +26,7 @@ env:
 jobs:
     trigger_ci:
         name: Trigger CI
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
 
         if: github.repository == 'apify/crawlee'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
             contents: write
             pages: write
             id-token: write
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
 
         steps:
             -   uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
             fail-fast: true
             matrix:
                 # We don't test on Windows as the tests are flaky
-                os: [ ubuntu-latest ]
+                os: [ ubuntu-22.04 ]
                 node-version: [ 16, 18, 20, 22 ]
 
         runs-on: ${{ matrix.os }}
@@ -86,7 +86,7 @@ jobs:
         name: "Bump Crawlee: ${{ inputs.version }} version (${{ inputs.custom_version || 'n/a' }} custom version)"
         if: (!contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, 'docs:'))
         needs: build_and_test
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
 
         steps:
             -   name: Checkout repository
@@ -173,7 +173,7 @@ jobs:
 
     version-docs:
         needs: release
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         if: (github.event.inputs.version == 'minor' || github.event.inputs.version == 'major')
 
         steps:

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -21,8 +21,8 @@ jobs:
             fail-fast: false
             matrix:
                 # tests on windows are extremely unstable
-                # os: [ ubuntu-latest, windows-2019 ]
-                os: [ ubuntu-latest ]
+                # os: [ ubuntu-22.04, windows-2019 ]
+                os: [ ubuntu-22.04 ]
                 node-version: [ 16, 18, 20, 22 ]
 
         steps:
@@ -83,7 +83,7 @@ jobs:
     docs:
         name: Docs build
         if: (!contains(github.event.head_commit.message, '[skip ci]') && github.ref != 'refs/heads/master')
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             -   name: Checkout Source code
                 uses: actions/checkout@v4
@@ -125,7 +125,7 @@ jobs:
 
     lint:
         name: Lint
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
 
         steps:
             -   name: Checkout repository
@@ -168,7 +168,7 @@ jobs:
         name: Release @next
         if: github.event_name == 'push' && contains(github.event.ref, 'master') && (!contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, 'docs:'))
         needs: build_and_test
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
 
         steps:
             -   name: Checkout repository

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -13,7 +13,7 @@ jobs:
     # NPM install is done in a separate job and cached to speed up the following jobs.
     build_and_test:
         name: Build & Test
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
 
         strategy:
             fail-fast: false

--- a/.github/workflows/update_new_issue.yml
+++ b/.github/workflows/update_new_issue.yml
@@ -8,7 +8,7 @@ on:
 jobs:
     label_issues:
         name: Label issues
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         permissions:
             issues: write
 


### PR DESCRIPTION
While the [Playwright issue](https://github.com/microsoft/playwright/issues/30368) has been closed, the Playwright installation still struggles with the new Ubuntu 24 runner image. Pinning the image version should fix our CI tests and enable releases etc.