### PR TITLE
chore: fix the `LinkeDOM` e2e test

### DIFF
--- a/test/e2e/linkedom-default-ts/actor/main.ts
+++ b/test/e2e/linkedom-default-ts/actor/main.ts
@@ -18,7 +18,7 @@ crawler.router.addDefaultHandler(async ({ document, enqueueLinks, request, log }
         globs: ['https://crawlee.dev/docs/**'],
     });
 
-    const pageTitle = document.title;
+    const pageTitle = document.querySelector('title')?.textContent ?? '';
     assert.notEqual(pageTitle, '');
     log.info(`URL: ${url} TITLE: ${pageTitle}`);
 


### PR DESCRIPTION
The e2e test have been failing since ~2 months ago because of the LinkeDOM test. 

This was happening because of the [brittle implementation](https://github.com/WebReflection/linkedom/blob/71399b5e9128d97e3de901eebad9ce8776793a96/cjs/html/document.js#L79) of the `title` method in LinkeDOM. On the (no JS) Crawlee homepage, there is no `<head>` element, so LinkeDOM doesn't find the `title` and returns empty string. 