### PR TITLE
docs: clarify `run()` resolve condition

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -860,12 +860,14 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
     }
 
     /**
-     * Runs the crawler. Returns a promise that gets resolved once all the requests are processed.
-     * We can use the `requests` parameter to enqueue the initial requests - it is a shortcut for
-     * running {@apilink BasicCrawler.addRequests|`crawler.addRequests()`} before the {@apilink BasicCrawler.run|`crawler.run()`}.
+     * Runs the crawler. Returns a promise that resolves once all the requests are processed
+     * and `autoscaledPool.isFinished` returns `true`.
      *
-     * @param [requests] The requests to add
-     * @param [options] Options for the request queue
+     * We can use the `requests` parameter to enqueue the initial requests — it is a shortcut for
+     * running {@apilink BasicCrawler.addRequests|`crawler.addRequests()`} before {@apilink BasicCrawler.run|`crawler.run()`}.
+     *
+     * @param [requests] The requests to add.
+     * @param [options] Options for the request queue.
      */
     async run(requests?: (string | Request | RequestOptions)[], options?: CrawlerRunOptions): Promise<FinalStatistics> {
         if (this.running) {


### PR DESCRIPTION
### What does this PR do?  
Clarifies the docstring for `BasicCrawler.run()`, specifying that the returned promise resolves **only when** `autoscaledPool.isFinished` returns `true`.  

### Why is this needed?  
Currently, the documentation implies that the promise resolves once all requests are processed, but this is misleading. If `autoscaledPoolOptions.isFinishedFunction` is set to always return `false`, the crawler never completes (e.g., in the case below):  

```ts
const crawler = new BasicCrawler({
    autoscaledPoolOptions: {
        isFinishedFunction: async () => {
            return false;
        },
    },
});

await crawler.run([]);