### PR TITLE
chore: add `postinstall` script to `camoufox` template

### DIFF
--- a/packages/templates/templates/camoufox-ts/Dockerfile
+++ b/packages/templates/templates/camoufox-ts/Dockerfile
@@ -7,6 +7,7 @@ FROM apify/actor-node-playwright-chrome:20 AS builder
 # to speed up the build using Docker layer cache.
 COPY --chown=myuser package*.json ./
 
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 # Install all dependencies. Don't audit to speed up the installation.
 RUN npm install --include=dev --audit=false
 
@@ -39,8 +40,6 @@ RUN npm --quiet set progress=false \
     && node --version \
     && echo "NPM version:" \
     && npm --version
-
-RUN npm run get-binaries
 
 # Next, copy the remaining files and directories with the source code.
 # Since we do this after NPM install, quick build will be really fast

--- a/packages/templates/templates/camoufox-ts/package.json
+++ b/packages/templates/templates/camoufox-ts/package.json
@@ -4,7 +4,7 @@
     "type": "module",
     "description": "This is an example of a Crawlee project.",
     "dependencies": {
-        "camoufox-js": "^0.1.3",
+        "camoufox-js": "^0.2.1",
         "crawlee": "^3.0.0",
         "playwright": "*"
     },
@@ -22,7 +22,8 @@
         "start:dev": "tsx src/main.ts",
         "build": "tsc",
         "test": "echo \"Error: oops, the actor has no tests yet, sad!\" && exit 1",
-        "get-binaries": "camoufox-js fetch"
+        "get-binaries": "camoufox-js fetch",
+        "postinstall": "npm run get-binaries"
     },
     "author": "It's not you it's me",
     "license": "ISC"


### PR DESCRIPTION
Adds `postinstall` script to the `camoufox-ts` template's `package.json` to simplify first-time usage. Makes use of the new support for `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` in `camoufox-js` to avoid multiple browser downloads during `docker build`.