### PR TITLE
chore: pin playwright to 1.50.1 to fix camoufox template

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
         "lerna": "^8.0.0",
         "lint-staged": "^15.0.0",
         "nock": "^13.4.0",
-        "playwright": "1.51.0",
+        "playwright": "1.50.1",
         "portastic": "^1.0.1",
         "proxy": "^1.0.2",
         "puppeteer": "24.4.0",

--- a/packages/templates/templates/camoufox-ts/Dockerfile
+++ b/packages/templates/templates/camoufox-ts/Dockerfile
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://crawlee.dev/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node-playwright-chrome:20 AS builder
+FROM apify/actor-node-playwright-chrome:20-1.50.1 AS builder
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.
@@ -19,7 +19,7 @@ COPY --chown=myuser . ./
 RUN npm run build
 
 # Create final image
-FROM apify/actor-node-playwright-chrome:20
+FROM apify/actor-node-playwright-chrome:20-1.50.1
 
 # Copy only built JS files from builder image
 COPY --from=builder --chown=myuser /home/myuser/dist ./dist

--- a/packages/templates/templates/camoufox-ts/package.json
+++ b/packages/templates/templates/camoufox-ts/package.json
@@ -6,7 +6,7 @@
     "dependencies": {
         "camoufox-js": "^0.2.1",
         "crawlee": "^3.0.0",
-        "playwright": "*"
+        "playwright": "1.50.1"
     },
     "devDependencies": {
         "@apify/tsconfig": "^0.1.0",

--- a/renovate.json
+++ b/renovate.json
@@ -27,6 +27,7 @@
 	"ignoreDeps": [
 		"crawlee",
 		"cheerio",
+		"playwright",
 		"@docusaurus/core",
 		"@docusaurus/mdx-loader",
 		"@docusaurus/module-type-aliases",

--- a/test/e2e/camoufox-cloudflare/actor/Dockerfile
+++ b/test/e2e/camoufox-cloudflare/actor/Dockerfile
@@ -1,4 +1,4 @@
-FROM apify/actor-node-playwright-chrome:20-beta AS builder
+FROM apify/actor-node-playwright-chrome:20-1.50.1-beta AS builder
 
 COPY /packages ./packages
 COPY /package*.json ./
@@ -6,7 +6,7 @@ RUN npm --quiet set progress=false \
     && npm install --only=prod --no-optional --no-audit --ignore-scripts \
     && npm update
 
-FROM apify/actor-node-playwright-chrome:20-beta
+FROM apify/actor-node-playwright-chrome:20-1.50.1-beta
 
 RUN rm -r node_modules
 COPY --from=builder /node_modules ./node_modules

--- a/test/e2e/camoufox-cloudflare/actor/package.json
+++ b/test/e2e/camoufox-cloudflare/actor/package.json
@@ -14,7 +14,7 @@
         "@crawlee/types": "file:./packages/types",
         "@crawlee/utils": "file:./packages/utils",
         "camoufox-js": "^0.2.1",
-        "playwright": "*"
+        "playwright": "1.50.1"
     },
     "overrides": {
         "apify": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -794,7 +794,7 @@ __metadata:
     lerna: "npm:^8.0.0"
     lint-staged: "npm:^15.0.0"
     nock: "npm:^13.4.0"
-    playwright: "npm:1.51.0"
+    playwright: "npm:1.50.1"
     portastic: "npm:^1.0.1"
     proxy: "npm:^1.0.2"
     puppeteer: "npm:24.4.0"
@@ -10932,6 +10932,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"playwright-core@npm:1.50.1":
+  version: 1.50.1
+  resolution: "playwright-core@npm:1.50.1"
+  bin:
+    playwright-core: cli.js
+  checksum: 10c0/c158764257d870897c31807a830ddcc3f5aaf4376719e05aeada3489a01f751650b2dc43e027201a40405a1b075084e89f58cd3730a985a229efe9d8cecfe360
+  languageName: node
+  linkType: hard
+
 "playwright-core@npm:1.51.0":
   version: 1.51.0
   resolution: "playwright-core@npm:1.51.0"
@@ -10941,7 +10950,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright@npm:1.51.0, playwright@npm:^1.50.1":
+"playwright@npm:1.50.1":
+  version: 1.50.1
+  resolution: "playwright@npm:1.50.1"
+  dependencies:
+    fsevents: "npm:2.3.2"
+    playwright-core: "npm:1.50.1"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    playwright: cli.js
+  checksum: 10c0/b292ee6e0d122748a3d024b85ace86a0d9c848fc4121685d90ffc5d43d6bcf13ed7dc7488b1055f69040599c420052306ccba6fabfe2f69a15fc109c55171207
+  languageName: node
+  linkType: hard
+
+"playwright@npm:^1.50.1":
   version: 1.51.0
   resolution: "playwright@npm:1.51.0"
   dependencies:


### PR DESCRIPTION
v1.51 apparently broke the camoufox support. we need to pin it in the root package.json too since that is what E2E tests use outside of platform.

```
ERROR Failed to launch browser. Please check the following:
- Check whether the provided executable path "/home/runner/.cache/camoufox/camoufox-bin" is correct.
- Try installing the required dependencies by running `npx playwright install --with-deps` (https://playwright.dev/docs/browsers).
The original error is available in the `cause` property. Below is the error received when trying to launch a browser:
​
  Failed to launch browser. Please check the following:
- Check whether the provided executable path "/home/runner/.cache/camoufox/camoufox-bin" is correct.
- Try installing the required dependencies by running `npx playwright install --with-deps` (https://playwright.dev/docs/browsers).
The original error is available in the `cause` property. Below is the error received when trying to launch a browser:
​
  - Check whether the provided executable path "/home/runner/.cache/camoufox/camoufox-bin" is correct.
  - Try installing the required dependencies by running `npx playwright install --with-deps` (https://playwright.dev/docs/browsers).
  
  The original error is available in the `cause` property. Below is the error received when trying to launch a browser:
  ​
  browserType.launchPersistentContext: Protocol error (Browser.setContrast): ERROR: method 'Browser.setContrast' is not supported
  Call log:
    - <launching> /home/runner/.cache/camoufox/camoufox-bin -no-remote -headless -profile /tmp/playwright_firefoxdev_profile-3LM8iE -juggler-pipe about:blank
    - <launched> pid=5775
    - [pid=5775][err] *** You are running in headless mode.
    - [pid=5775][out] [GFX1-]: FireTestProcess failed: Failed to spawn child process “/home/runner/.cache/camoufox/glxtest” (No such file or directory)
    - [pid=5775][out]
    - [pid=5775][err] JavaScript warning: resource://services-settings/Utils.sys.mjs, line 57: unreachable code after return statement
    - [pid=5775][err] JavaScript warning: resource://services-settings/Utils.sys.mjs, line 119: unreachable code after return statement
    - [pid=5775][out] Crash Annotation GraphicsCriticalError: |[0][GFX1-]: glxtest: ManageChildProcess failed
    - [pid=5775][out]  (t=0.59007) [GFX1-]: glxtest: ManageChildProcess failed
    - [pid=5775][out]
    - [pid=5775][out] Crash Annotation GraphicsCriticalError: |[0][GFX1-]: glxtest: ManageChildProcess failed
    - [pid=5775][out]  (t=0.59007) |[1][GFX1-]: No GPUs detected via PCI
    - [pid=5775][out]  (t=0.59007) [GFX1-]: No GPUs detected via PCI
    - [pid=5775][out]
    - [pid=5775][err] DEBUG: Juggler pipe initialized
    - [pid=5775][err] DEBUG: Dispatcher created
    - [pid=5775][err] DEBUG: BrowserHandler created
    - [pid=5775][err] DEBUG: BrowserHandler set as root session handler
    - [pid=5775][out]
    - [pid=5775][out] Juggler listening to the pipe
    - [pid=5775][out] console.error: "Ignoring protocol handler for mailto without a uriTemplate!"
    - [pid=5775][out]
    - [pid=5775][out]         ERROR: ERROR: method 'Browser.setContrast' is not supported _dispatch@chrome://juggler/content/protocol/Dispatcher.js:71:15
    - [pid=5775][out] receiveMessage@chrome://juggler/content/components/Juggler.js:121:20
    - [pid=5775][out]
  
      at async PlaywrightPlugin._launch (/home/runner/work/crawlee/crawlee/packages/browser-pool/dist/playwright/playwright-plugin.js:106:40)
      at async BrowserPool._launchBrowser (/home/runner/work/crawlee/crawlee/packages/browser-pool/dist/browser-pool.js:482:29)
      at async /home/runner/work/crawlee/crawlee/packages/browser-pool/dist/browser-pool.js:[28](https://github.com/apify/crawlee/actions/runs/13712422089/job/38361109957#step:12:29)7:37
  Error thrown at:
  
      at PlaywrightPlugin._throwAugmentedLaunchError (/home/runner/work/crawlee/crawlee/packages/browser-pool/dist/abstract-classes/browser-plugin.js:153:15)
      at PlaywrightPlugin._throwOnFailedLaunch (/home/runner/work/crawlee/crawlee/packages/browser-pool/dist/playwright/playwright-plugin.js:167:14)
      at /home/runner/work/crawlee/crawlee/packages/browser-pool/dist/playwright/playwright-plugin.js:109:33
      at async PlaywrightPlugin._launch (/home/runner/work/crawlee/crawlee/packages/browser-pool/dist/playwright/playwright-plugin.js:106:40)
      at async BrowserPool._launchBrowser (/home/runner/work/crawlee/crawlee/packages/browser-pool/dist/browser-pool.js:482:[29](https://github.com/apify/crawlee/actions/runs/13712422089/job/38361109957#step:12:30))
      at async /home/runner/work/crawlee/crawlee/packages/browser-pool/dist/browser-pool.js:287:37
    CAUSE: browserType.launchPersistentContext: Protocol error (Browser.setContrast): ERROR: method 'Browser.setContrast' is not supported
  Call log:
    - <launching> /home/runner/.cache/camoufox/camoufox-bin -no-remote -headless -profile /tmp/playwright_firefoxdev_profile-3LM8iE -juggler-pipe about:blank
    - <launched> pid=5775
    - [pid=5775][err] *** You are running in headless mode.
    - [pid=5775][out] [GFX1-]: FireTestProcess failed: Failed to spawn child process “/home/runner/.cache/camoufox/glxtest” (No such file or directory)
    - [pid=5775][out]
    - [pid=5775][err] JavaScript warning: resource://services-settings/Utils.sys.mjs, line 57: unreachable code after return statement
    - [pid=5775][err] JavaScript warning: resource://services-settings/Utils.sys.mjs, line 119: unreachable code after return statement
    - [pid=5775][out] Crash Annotation GraphicsCriticalError: |[0][GFX1-]: glxtest: ManageChildProcess failed
    - [pid=5775][out]  (t=0.59007) [GFX1-]: glxtest: ManageChildProcess failed
    - [pid=5775][out]
    - [pid=5775][out] Crash Annotation GraphicsCriticalError: |[0][GFX1-]: glxtest: ManageChildProcess failed
    - [pid=5775][out]  (t=0.59007) |[1][GFX1-]: No GPUs detected via PCI
    - [pid=5775][out]  (t=0.59007) [GFX1-]: No GPUs detected via PCI
    - [pid=5775][out]
    - [pid=5775][err] DEBUG: Juggler pipe initialized
    - [pid=5775][err] DEBUG: Dispatcher created
    - [pid=5775][err] DEBUG: BrowserHandler created
    - [pid=5775][err] DEBUG: BrowserHandler set as root session handler
    - [pid=5775][out]
    - [pid=5775][out] Juggler listening to the pipe
    - [pid=5775][out] console.error: "Ignoring protocol handler for mailto without a uriTemplate!"
    - [pid=5775][out]
    - [pid=5775][out]         ERROR: ERROR: method 'Browser.setContrast' is not supported _dispatch@chrome://juggler/content/protocol/Dispatcher.js:71:15
    - [pid=5775][out] receiveMessage@chrome://juggler/content/components/Juggler.js:121:20
    - [pid=5775][out]
  
      Call log:
        - <launching> /home/runner/.cache/camoufox/camoufox-bin -no-remote -headless -profile /tmp/playwright_firefoxdev_profile-3LM8iE -juggler-pipe about:blank
        - <launched> pid=5775
        - [pid=5775][err] *** You are running in headless mode.
        - [pid=5775][out] [GFX1-]: FireTestProcess failed: Failed to spawn child process “/home/runner/.cache/camoufox/glxtest” (No such file or directory)
        - [pid=5775][out]
        - [pid=5775][err] JavaScript warning: resource://services-settings/Utils.sys.mjs, line 57: unreachable code after return statement
        - [pid=5775][err] JavaScript warning: resource://services-settings/Utils.sys.mjs, line 119: unreachable code after return statement
        - [pid=5775][out] Crash Annotation GraphicsCriticalError: |[0][GFX1-]: glxtest: ManageChildProcess failed
        - [pid=5775][out]  (t=0.59007) [GFX1-]: glxtest: ManageChildProcess failed
        - [pid=5775][out]
        - [pid=5775][out] Crash Annotation GraphicsCriticalError: |[0][GFX1-]: glxtest: ManageChildProcess failed
        - [pid=5775][out]  (t=0.59007) |[1][GFX1-]: No GPUs detected via PCI
        - [pid=5775][out]  (t=0.59007) [GFX1-]: No GPUs detected via PCI
        - [pid=5775][out]
        - [pid=5775][err] DEBUG: Juggler pipe initialized
        - [pid=5775][err] DEBUG: Dispatcher created
        - [pid=5775][err] DEBUG: BrowserHandler created
        - [pid=5775][err] DEBUG: BrowserHandler set as root session handler
        - [pid=5775][out]
        - [pid=5775][out] Juggler listening to the pipe
        - [pid=5775][out] console.error: "Ignoring protocol handler for mailto without a uriTemplate!"
        - [pid=5775][out]
        - [pid=5775][out]         ERROR: ERROR: method 'Browser.setContrast' is not supported _dispatch@chrome://juggler/content/protocol/Dispatcher.js:71:15
        - [pid=5775][out] receiveMessage@chrome://juggler/content/components/Juggler.js:121:20
        - [pid=5775][out]
      
          at async PlaywrightPlugin._launch (/home/runner/work/crawlee/crawlee/packages/browser-pool/dist/playwright/playwright-plugin.js:106:40)
          at async BrowserPool._launchBrowser (/home/runner/work/crawlee/crawlee/packages/browser-pool/dist/browser-pool.js:482:29)
          at async /home/runner/work/crawlee/crawlee/packages/browser-pool/dist/browser-pool.js:287:[37](https://github.com/apify/crawlee/actions/runs/13712422089/job/38361109957#step:12:38)
```