### PR TITLE
fix: Try to recover locks after migrations on Apify

### DIFF
--- a/packages/types/src/storages.ts
+++ b/packages/types/src/storages.ts
@@ -219,6 +219,12 @@ export interface ListOptions {
      * @default 100
      */
     limit?: number;
+
+    locked?: boolean;
+
+    pending?: boolean;
+
+    lockedByRunId?: string;
 }
 
 export interface ListAndLockOptions extends ListOptions {

--- a/test/core/storages/request_queue.test.ts
+++ b/test/core/storages/request_queue.test.ts
@@ -1009,4 +1009,11 @@ describe('RequestQueue v2', () => {
 
         expect(retrievedUrls.map((x) => new URL(x).pathname)).toEqual(Array.from({ length: 5 }, (_, i) => `/${i + 1}`));
     });
+
+    test('repeated `open` calls should return the same instance', async () => {
+        const queue1 = await RequestQueueV2.open('repeated-open-call');
+        const queue2 = await RequestQueueV2.open('repeated-open-call');
+
+        expect(queue1).toBe(queue2);
+    });
 });


### PR DESCRIPTION
- closes #2870
- needs https://github.com/apify/apify-core/pull/19973 to get merged and then we need to update the apify-client package as well
