### PR TITLE
fix: treat `406` as other `4xx` status codes in `HttpCrawler`

### DIFF
--- a/packages/http-crawler/src/internals/http-crawler.ts
+++ b/packages/http-crawler/src/internals/http-crawler.ts
@@ -899,13 +899,6 @@ export class HttpCrawler<
         const { statusCode } = response;
         const { type } = parseContentTypeFromResponse(response);
 
-        if (statusCode === 406) {
-            request.noRetry = true;
-            throw new Error(
-                `Resource ${request.url} is not available in the format requested by the Accept header. Skipping resource.`,
-            );
-        }
-
         // eslint-disable-next-line dot-notation -- accessing private property
         const blockedStatusCodes = this.sessionPool ? this.sessionPool['blockedStatusCodes'] : [];
         // if we retry the request, can the Content-Type change?

--- a/test/core/crawlers/cheerio_crawler.test.ts
+++ b/test/core/crawlers/cheerio_crawler.test.ts
@@ -502,35 +502,6 @@ describe('CheerioCrawler', () => {
                 expect(errorMessages).toHaveLength(8);
                 errorMessages.forEach((msg) => expect(msg).toMatch('CUSTOM_ERROR'));
             });
-
-            // Tests legacy behaviour removed in https://github.com/apify/crawlee/pull/2907
-            test.skip('when 406 is received', async () => {
-                // Mock Request to respond with a 406.
-                crawler = new CheerioCrawler({
-                    requestList: await getRequestListForMock({
-                        headers: {
-                            'content-type': 'text/plain',
-                        },
-                        statusCode: 406,
-                    }),
-                    maxRequestRetries: 1,
-                    requestHandler: () => {
-                        handlePageInvocationCount++;
-                    },
-                    failedRequestHandler: ({ request }) => {
-                        errorMessages = [...errorMessages, ...request.errorMessages];
-                    },
-                });
-                await crawler.run();
-
-                expect(handlePageInvocationCount).toBe(0);
-                expect(errorMessages).toHaveLength(4);
-                errorMessages.forEach((msg) => {
-                    expect(msg).toMatch(
-                        'is not available in the format requested by the Accept header. Skipping resource.',
-                    );
-                });
-            });
         });
     });
 

--- a/test/core/crawlers/cheerio_crawler.test.ts
+++ b/test/core/crawlers/cheerio_crawler.test.ts
@@ -503,7 +503,8 @@ describe('CheerioCrawler', () => {
                 errorMessages.forEach((msg) => expect(msg).toMatch('CUSTOM_ERROR'));
             });
 
-            test('when 406 is received', async () => {
+            // Tests legacy behaviour removed in https://github.com/apify/crawlee/pull/2907
+            test.skip('when 406 is received', async () => {
                 // Mock Request to respond with a 406.
                 crawler = new CheerioCrawler({
                     requestList: await getRequestListForMock({


### PR DESCRIPTION
Removes the legacy logic for custom handling of the `406` status code. 

Aligns the `HttpCrawler` behavior with other crawlers, e.g.:

```typescript
const crawler = new PlaywrightCrawler({
    requestHandler: async ({ page, request }) => {
        console.log(request.url);
    },
});

await crawler.run(['https://httpbin.org/status/406']);

/// prints https://httpbin.org/status/406
```

Closes #2892 