### PR TITLE
fix: don't double increment session usage count in `BrowserCrawler`

### DIFF
--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -593,8 +593,6 @@ export abstract class BrowserCrawler<
             throw e;
         }
         tryCancel();
-
-        if (session) session.markGood();
     }
 
     protected _enhanceCrawlingContextWithPageInfo(

--- a/test/core/crawlers/browser_crawler.test.ts
+++ b/test/core/crawlers/browser_crawler.test.ts
@@ -666,6 +666,35 @@ describe('BrowserCrawler', () => {
         expect(called).toBeTruthy();
     });
 
+    test('should increment session usage correctly', async () => {
+        const sessionUsageHistory: number[] = [];
+
+        const browserCrawler = new BrowserCrawlerTest({
+            browserPoolOptions: {
+                browserPlugins: [puppeteerPlugin],
+            },
+            useSessionPool: true,
+            sessionPoolOptions: {
+                maxPoolSize: 1,
+            },
+            requestHandler: async ({ session }) => {
+                // @ts-expect-error Accessing private property
+                sessionUsageHistory.push(session!.usageCount);
+            },
+        });
+
+        await browserCrawler.run([
+            { url: `${serverAddress}/?q=1` },
+            { url: `${serverAddress}/?q=2` },
+            { url: `${serverAddress}/?q=3` },
+            { url: `${serverAddress}/?q=4` },
+            { url: `${serverAddress}/?q=5` },
+            { url: `${serverAddress}/?q=6` },
+        ]);
+
+        expect(sessionUsageHistory).toEqual([0, 1, 2, 3, 4, 5]);
+    });
+
     test('should allow using fingerprints from browser pool', async () => {
         const requestList = await RequestList.open({
             sources: [{ url: `${serverAddress}/?q=1` }],


### PR DESCRIPTION
Changes to the session handling in #1709 caused the same session in `BrowserCrawler` to be marked as good with two different calls. This removes the additional call (keeping only the one in `BasicCrawler`), aligning the `BrowserCrawler` behavior with the other crawler instances.

Closes #2851 