### PR TITLE
feat: add `respectRobotsTxtFile` crawler option

### DIFF
--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -627,7 +627,7 @@ export abstract class BrowserCrawler<
                 options: enqueueOptions,
                 page,
                 requestQueue: await this.getRequestQueue(),
-                robotsFile: await this.getRobotsFileForUrl(crawlingContext.request.url),
+                robotsTxtFile: await this.getRobotsTxtFileForUrl(crawlingContext.request.url),
                 originalRequestUrl: crawlingContext.request.url,
                 finalRequestUrl: crawlingContext.request.loadedUrl,
             });
@@ -793,7 +793,7 @@ interface EnqueueLinksInternalOptions {
     options?: ReadonlyDeep<Omit<EnqueueLinksOptions, 'requestQueue'>> & Pick<EnqueueLinksOptions, 'requestQueue'>;
     page: CommonPage;
     requestQueue: RequestProvider;
-    robotsFile?: RobotsFile;
+    robotsTxtFile?: RobotsFile;
     originalRequestUrl: string;
     finalRequestUrl?: string;
 }
@@ -803,7 +803,7 @@ export async function browserCrawlerEnqueueLinks({
     options,
     page,
     requestQueue,
-    robotsFile,
+    robotsTxtFile,
     originalRequestUrl,
     finalRequestUrl,
 }: EnqueueLinksInternalOptions) {
@@ -822,7 +822,7 @@ export async function browserCrawlerEnqueueLinks({
 
     return enqueueLinks({
         requestQueue,
-        robotsFile,
+        robotsTxtFile,
         urls,
         baseUrl,
         ...(options as EnqueueLinksOptions),

--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -38,7 +38,8 @@ import type {
 } from '@crawlee/browser-pool';
 import { BROWSER_CONTROLLER_EVENTS, BrowserPool } from '@crawlee/browser-pool';
 import type { Cookie as CookieObject } from '@crawlee/types';
-import { CLOUDFLARE_RETRY_CSS_SELECTORS, RETRY_CSS_SELECTORS, RobotsFile, sleep } from '@crawlee/utils';
+import type { RobotsFile} from '@crawlee/utils';
+import { CLOUDFLARE_RETRY_CSS_SELECTORS, RETRY_CSS_SELECTORS, sleep } from '@crawlee/utils';
 import ow from 'ow';
 import type { ReadonlyDeep } from 'type-fest';
 

--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -38,7 +38,7 @@ import type {
 } from '@crawlee/browser-pool';
 import { BROWSER_CONTROLLER_EVENTS, BrowserPool } from '@crawlee/browser-pool';
 import type { Cookie as CookieObject } from '@crawlee/types';
-import type { RobotsFile} from '@crawlee/utils';
+import type { RobotsFile } from '@crawlee/utils';
 import { CLOUDFLARE_RETRY_CSS_SELECTORS, RETRY_CSS_SELECTORS, sleep } from '@crawlee/utils';
 import ow from 'ow';
 import type { ReadonlyDeep } from 'type-fest';

--- a/packages/cheerio-crawler/src/internals/cheerio-crawler.ts
+++ b/packages/cheerio-crawler/src/internals/cheerio-crawler.ts
@@ -15,7 +15,7 @@ import type {
 } from '@crawlee/http';
 import { enqueueLinks, HttpCrawler, resolveBaseUrlForEnqueueLinksFiltering, Router } from '@crawlee/http';
 import type { Dictionary } from '@crawlee/types';
-import { type CheerioRoot, extractUrlsFromCheerio } from '@crawlee/utils';
+import { type CheerioRoot, extractUrlsFromCheerio, type RobotsFile } from '@crawlee/utils';
 import type { CheerioOptions } from 'cheerio';
 import * as cheerio from 'cheerio';
 import { DomHandler, parseDocument } from 'htmlparser2';
@@ -193,6 +193,7 @@ export class CheerioCrawler extends HttpCrawler<CheerioCrawlingContext> {
                     options: enqueueOptions,
                     $,
                     requestQueue: await this.getRequestQueue(),
+                    robotsFile: await this.getRobotsFileForUrl(crawlingContext.request.url),
                     originalRequestUrl: crawlingContext.request.url,
                     finalRequestUrl: crawlingContext.request.loadedUrl,
                 });
@@ -238,6 +239,7 @@ interface EnqueueLinksInternalOptions {
     options?: EnqueueLinksOptions;
     $: cheerio.CheerioAPI | null;
     requestQueue: RequestProvider;
+    robotsFile?: RobotsFile;
     originalRequestUrl: string;
     finalRequestUrl?: string;
 }
@@ -247,6 +249,7 @@ export async function cheerioCrawlerEnqueueLinks({
     options,
     $,
     requestQueue,
+    robotsFile,
     originalRequestUrl,
     finalRequestUrl,
 }: EnqueueLinksInternalOptions) {
@@ -269,6 +272,7 @@ export async function cheerioCrawlerEnqueueLinks({
 
     return enqueueLinks({
         requestQueue,
+        robotsFile,
         urls,
         baseUrl,
         ...options,

--- a/packages/cheerio-crawler/src/internals/cheerio-crawler.ts
+++ b/packages/cheerio-crawler/src/internals/cheerio-crawler.ts
@@ -193,7 +193,7 @@ export class CheerioCrawler extends HttpCrawler<CheerioCrawlingContext> {
                     options: enqueueOptions,
                     $,
                     requestQueue: await this.getRequestQueue(),
-                    robotsFile: await this.getRobotsFileForUrl(crawlingContext.request.url),
+                    robotsTxtFile: await this.getRobotsTxtFileForUrl(crawlingContext.request.url),
                     originalRequestUrl: crawlingContext.request.url,
                     finalRequestUrl: crawlingContext.request.loadedUrl,
                 });
@@ -239,7 +239,7 @@ interface EnqueueLinksInternalOptions {
     options?: EnqueueLinksOptions;
     $: cheerio.CheerioAPI | null;
     requestQueue: RequestProvider;
-    robotsFile?: RobotsFile;
+    robotsTxtFile?: RobotsFile;
     originalRequestUrl: string;
     finalRequestUrl?: string;
 }
@@ -249,7 +249,7 @@ export async function cheerioCrawlerEnqueueLinks({
     options,
     $,
     requestQueue,
-    robotsFile,
+    robotsTxtFile,
     originalRequestUrl,
     finalRequestUrl,
 }: EnqueueLinksInternalOptions) {
@@ -272,7 +272,7 @@ export async function cheerioCrawlerEnqueueLinks({
 
     return enqueueLinks({
         requestQueue,
-        robotsFile,
+        robotsTxtFile,
         urls,
         baseUrl,
         ...options,

--- a/packages/core/src/enqueue_links/enqueue_links.ts
+++ b/packages/core/src/enqueue_links/enqueue_links.ts
@@ -1,10 +1,10 @@
 import type { BatchAddRequestsResult, Dictionary } from '@crawlee/types';
+import { type RobotsFile } from '@crawlee/utils';
 import ow from 'ow';
 import { getDomain } from 'tldts';
 import type { SetRequired } from 'type-fest';
 
 import log from '@apify/log';
-import { type RobotsFile } from '@crawlee/utils';
 
 import type { RequestOptions } from '../request';
 import type { RequestProvider, RequestQueueOperationOptions } from '../storages';

--- a/packages/core/src/enqueue_links/enqueue_links.ts
+++ b/packages/core/src/enqueue_links/enqueue_links.ts
@@ -263,7 +263,7 @@ export async function enqueueLinks(
         ow.object.exactShape({
             urls: ow.array.ofType(ow.string),
             requestQueue: ow.object.hasKeys('fetchNextRequest', 'addRequest'),
-            robotsFile: ow.object.hasKeys('isAllowed'),
+            robotsFile: ow.optional.object.hasKeys('isAllowed'),
             forefront: ow.optional.boolean,
             skipNavigation: ow.optional.boolean,
             limit: ow.optional.number,

--- a/packages/core/src/enqueue_links/enqueue_links.ts
+++ b/packages/core/src/enqueue_links/enqueue_links.ts
@@ -164,7 +164,7 @@ export interface EnqueueLinksOptions extends RequestQueueOperationOptions {
      * RobotsFile instance for the current request that triggered the `enqueueLinks`.
      * If provided, disallowed URLs will be ignored.
      */
-    robotsFile?: RobotsFile;
+    robotsTxtFile?: RobotsFile;
 }
 
 /**
@@ -263,7 +263,7 @@ export async function enqueueLinks(
         ow.object.exactShape({
             urls: ow.array.ofType(ow.string),
             requestQueue: ow.object.hasKeys('fetchNextRequest', 'addRequest'),
-            robotsFile: ow.optional.object.hasKeys('isAllowed'),
+            robotsTxtFile: ow.optional.object.hasKeys('isAllowed'),
             forefront: ow.optional.boolean,
             skipNavigation: ow.optional.boolean,
             limit: ow.optional.number,
@@ -294,7 +294,7 @@ export async function enqueueLinks(
         transformRequestFunction,
         forefront,
         waitForAllRequestsToBeAdded,
-        robotsFile,
+        robotsTxtFile,
     } = options;
 
     const urlExcludePatternObjects: UrlPatternObject[] = [];
@@ -372,9 +372,9 @@ export async function enqueueLinks(
 
     let requestOptions = createRequestOptions(urls, options);
 
-    if (robotsFile) {
+    if (robotsTxtFile) {
         requestOptions = requestOptions.filter((request) => {
-            return robotsFile.isAllowed(request.url);
+            return robotsTxtFile.isAllowed(request.url);
         });
     }
 

--- a/packages/http-crawler/src/internals/http-crawler.ts
+++ b/packages/http-crawler/src/internals/http-crawler.ts
@@ -30,7 +30,7 @@ import {
 } from '@crawlee/basic';
 import type { HttpResponse, StreamingHttpResponse } from '@crawlee/core';
 import type { Awaitable, Dictionary } from '@crawlee/types';
-import { type CheerioRoot, RETRY_CSS_SELECTORS, RobotsFile } from '@crawlee/utils';
+import { type CheerioRoot, RETRY_CSS_SELECTORS } from '@crawlee/utils';
 import * as cheerio from 'cheerio';
 import type { RequestLike, ResponseLike } from 'content-type';
 import contentTypeParser from 'content-type';
@@ -587,22 +587,6 @@ export class HttpCrawler<
         } catch (e: any) {
             request.state = RequestState.ERROR;
             throw e;
-        }
-    }
-
-    protected override async isDisallowedBasedOnRobotsFile(request: Request, session?: Session): Promise<boolean> {
-        if (!this.respectRobotsFile) {
-            return false;
-        }
-
-        try {
-            const proxyInfo = await this.proxyConfiguration?.newProxyInfo(session?.id, { request });
-            const robotsFile = await RobotsFile.find(request.url, proxyInfo?.url);
-
-            return !robotsFile.isAllowed(request.url);
-        } catch (e: any) {
-            this.log.warning(`Failed to fetch robots.txt for request ${request.url}`);
-            return false;
         }
     }
 

--- a/packages/jsdom-crawler/src/internals/jsdom-crawler.ts
+++ b/packages/jsdom-crawler/src/internals/jsdom-crawler.ts
@@ -304,7 +304,7 @@ export class JSDOMCrawler extends HttpCrawler<JSDOMCrawlingContext> {
                     options: enqueueOptions,
                     window,
                     requestQueue: await this.getRequestQueue(),
-                    robotsFile: await this.getRobotsFileForUrl(crawlingContext.request.url),
+                    robotsTxtFile: await this.getRobotsTxtFileForUrl(crawlingContext.request.url),
                     originalRequestUrl: crawlingContext.request.url,
                     finalRequestUrl: crawlingContext.request.loadedUrl,
                 });
@@ -344,7 +344,7 @@ interface EnqueueLinksInternalOptions {
     options?: EnqueueLinksOptions;
     window: DOMWindow | null;
     requestQueue: RequestProvider;
-    robotsFile?: RobotsFile;
+    robotsTxtFile?: RobotsFile;
     originalRequestUrl: string;
     finalRequestUrl?: string;
 }
@@ -354,7 +354,7 @@ export async function domCrawlerEnqueueLinks({
     options,
     window,
     requestQueue,
-    robotsFile,
+    robotsTxtFile,
     originalRequestUrl,
     finalRequestUrl,
 }: EnqueueLinksInternalOptions) {
@@ -377,7 +377,7 @@ export async function domCrawlerEnqueueLinks({
 
     return enqueueLinks({
         requestQueue,
-        robotsFile,
+        robotsTxtFile,
         urls,
         baseUrl,
         ...options,

--- a/packages/jsdom-crawler/src/internals/jsdom-crawler.ts
+++ b/packages/jsdom-crawler/src/internals/jsdom-crawler.ts
@@ -20,7 +20,7 @@ import {
     tryAbsoluteURL,
 } from '@crawlee/http';
 import type { Dictionary } from '@crawlee/types';
-import { type CheerioRoot, sleep } from '@crawlee/utils';
+import { type CheerioRoot, type RobotsFile, sleep } from '@crawlee/utils';
 import * as cheerio from 'cheerio';
 import type { DOMWindow } from 'jsdom';
 import { JSDOM, ResourceLoader, VirtualConsole } from 'jsdom';
@@ -304,6 +304,7 @@ export class JSDOMCrawler extends HttpCrawler<JSDOMCrawlingContext> {
                     options: enqueueOptions,
                     window,
                     requestQueue: await this.getRequestQueue(),
+                    robotsFile: await this.getRobotsFileForUrl(crawlingContext.request.url),
                     originalRequestUrl: crawlingContext.request.url,
                     finalRequestUrl: crawlingContext.request.loadedUrl,
                 });
@@ -343,6 +344,7 @@ interface EnqueueLinksInternalOptions {
     options?: EnqueueLinksOptions;
     window: DOMWindow | null;
     requestQueue: RequestProvider;
+    robotsFile?: RobotsFile;
     originalRequestUrl: string;
     finalRequestUrl?: string;
 }
@@ -352,6 +354,7 @@ export async function domCrawlerEnqueueLinks({
     options,
     window,
     requestQueue,
+    robotsFile,
     originalRequestUrl,
     finalRequestUrl,
 }: EnqueueLinksInternalOptions) {
@@ -374,6 +377,7 @@ export async function domCrawlerEnqueueLinks({
 
     return enqueueLinks({
         requestQueue,
+        robotsFile,
         urls,
         baseUrl,
         ...options,

--- a/packages/linkedom-crawler/src/internals/linkedom-crawler.ts
+++ b/packages/linkedom-crawler/src/internals/linkedom-crawler.ts
@@ -19,7 +19,7 @@ import {
     tryAbsoluteURL,
 } from '@crawlee/http';
 import type { Dictionary } from '@crawlee/types';
-import { type CheerioRoot, sleep } from '@crawlee/utils';
+import { type CheerioRoot, type RobotsFile, sleep } from '@crawlee/utils';
 import * as cheerio from 'cheerio';
 // @ts-expect-error This throws a compilation error due to TypeScript not inferring the module has CJS versions too
 import { DOMParser } from 'linkedom/cached';
@@ -187,6 +187,7 @@ export class LinkeDOMCrawler extends HttpCrawler<LinkeDOMCrawlingContext> {
                     options: enqueueOptions,
                     window: document.defaultView,
                     requestQueue: await this.getRequestQueue(),
+                    robotsFile: await this.getRobotsFileForUrl(crawlingContext.request.url),
                     originalRequestUrl: crawlingContext.request.url,
                     finalRequestUrl: crawlingContext.request.loadedUrl,
                 });
@@ -226,6 +227,7 @@ interface EnqueueLinksInternalOptions {
     options?: LinkeDOMCrawlerEnqueueLinksOptions;
     window: Window | null;
     requestQueue: RequestProvider;
+    robotsFile?: RobotsFile;
     originalRequestUrl: string;
     finalRequestUrl?: string;
 }
@@ -235,6 +237,7 @@ export async function linkedomCrawlerEnqueueLinks({
     options,
     window,
     requestQueue,
+    robotsFile,
     originalRequestUrl,
     finalRequestUrl,
 }: EnqueueLinksInternalOptions) {
@@ -257,6 +260,7 @@ export async function linkedomCrawlerEnqueueLinks({
 
     return enqueueLinks({
         requestQueue,
+        robotsFile,
         urls,
         baseUrl,
         ...options,

--- a/packages/linkedom-crawler/src/internals/linkedom-crawler.ts
+++ b/packages/linkedom-crawler/src/internals/linkedom-crawler.ts
@@ -187,7 +187,7 @@ export class LinkeDOMCrawler extends HttpCrawler<LinkeDOMCrawlingContext> {
                     options: enqueueOptions,
                     window: document.defaultView,
                     requestQueue: await this.getRequestQueue(),
-                    robotsFile: await this.getRobotsFileForUrl(crawlingContext.request.url),
+                    robotsTxtFile: await this.getRobotsTxtFileForUrl(crawlingContext.request.url),
                     originalRequestUrl: crawlingContext.request.url,
                     finalRequestUrl: crawlingContext.request.loadedUrl,
                 });
@@ -227,7 +227,7 @@ interface EnqueueLinksInternalOptions {
     options?: LinkeDOMCrawlerEnqueueLinksOptions;
     window: Window | null;
     requestQueue: RequestProvider;
-    robotsFile?: RobotsFile;
+    robotsTxtFile?: RobotsFile;
     originalRequestUrl: string;
     finalRequestUrl?: string;
 }
@@ -237,7 +237,7 @@ export async function linkedomCrawlerEnqueueLinks({
     options,
     window,
     requestQueue,
-    robotsFile,
+    robotsTxtFile,
     originalRequestUrl,
     finalRequestUrl,
 }: EnqueueLinksInternalOptions) {
@@ -260,7 +260,7 @@ export async function linkedomCrawlerEnqueueLinks({
 
     return enqueueLinks({
         requestQueue,
-        robotsFile,
+        robotsTxtFile,
         urls,
         baseUrl,
         ...options,

--- a/packages/utils/src/internals/robots.ts
+++ b/packages/utils/src/internals/robots.ts
@@ -38,11 +38,11 @@ export class RobotsFile {
      * @param [proxyUrl] a proxy to be used for fetching the robots.txt file
      */
     static async find(url: string, proxyUrl?: string): Promise<RobotsFile> {
-        const robotsFileUrl = new URL(url);
-        robotsFileUrl.pathname = '/robots.txt';
-        robotsFileUrl.search = '';
+        const robotsTxtFileUrl = new URL(url);
+        robotsTxtFileUrl.pathname = '/robots.txt';
+        robotsTxtFileUrl.search = '';
 
-        return RobotsFile.load(robotsFileUrl.toString(), proxyUrl);
+        return RobotsFile.load(robotsTxtFileUrl.toString(), proxyUrl);
     }
 
     /**

--- a/test/e2e/cheerio-robots-file/actor/.actor/actor.json
+++ b/test/e2e/cheerio-robots-file/actor/.actor/actor.json
@@ -1,0 +1,7 @@
+{
+	"actorSpecification": 1,
+	"name": "test-cheerio-robots-file",
+	"version": "0.0",
+	"buildTag": "latest",
+	"env": null
+}

--- a/test/e2e/cheerio-robots-file/actor/.gitignore
+++ b/test/e2e/cheerio-robots-file/actor/.gitignore
@@ -1,0 +1,7 @@
+.idea
+.DS_Store
+node_modules
+package-lock.json
+apify_storage
+crawlee_storage
+storage

--- a/test/e2e/cheerio-robots-file/actor/Dockerfile
+++ b/test/e2e/cheerio-robots-file/actor/Dockerfile
@@ -1,0 +1,16 @@
+FROM apify/actor-node:20-beta
+
+COPY packages ./packages
+COPY package*.json ./
+
+RUN npm --quiet set progress=false \
+	&& npm install --only=prod --no-optional --no-audit \
+	&& npm update --no-audit \
+	&& echo "Installed NPM packages:" \
+	&& (npm list --only=prod --no-optional --all || true) \
+	&& echo "Node.js version:" \
+	&& node --version \
+	&& echo "NPM version:" \
+	&& npm --version
+
+COPY . ./

--- a/test/e2e/cheerio-robots-file/actor/main.js
+++ b/test/e2e/cheerio-robots-file/actor/main.js
@@ -1,0 +1,33 @@
+import { CheerioCrawler } from '@crawlee/cheerio';
+import { Actor } from 'apify';
+
+await Actor.init({
+    storage:
+        process.env.STORAGE_IMPLEMENTATION === 'LOCAL'
+            ? new (await import('@apify/storage-local')).ApifyStorageLocal()
+            : undefined,
+});
+
+const crawler = new CheerioCrawler({
+    maxRequestsPerCrawl: 10,
+    respectRobotsFile: true,
+});
+
+crawler.router.addDefaultHandler(async ({ log, request, enqueueLinks, pushData }) => {
+    log.info(`Processing ${request.loadedUrl}`);
+    await enqueueLinks({
+        // '/cart' is disallowed by robots.txt
+        globs: ['**/cart'],
+    });
+    await pushData({ url: request.url, loadedUrl: request.loadedUrl });
+});
+
+await crawler.run([
+    'https://warehouse-theme-metal.myshopify.com',
+    'https://warehouse-theme-metal.myshopify.com/checkout',
+]);
+
+const data = await crawler.getData();
+console.table(data.items);
+
+await Actor.exit({ exit: Actor.isAtHome() });

--- a/test/e2e/cheerio-robots-file/actor/main.js
+++ b/test/e2e/cheerio-robots-file/actor/main.js
@@ -17,14 +17,14 @@ crawler.router.addDefaultHandler(async ({ log, request, enqueueLinks, pushData }
     log.info(`Processing ${request.loadedUrl}`);
     await enqueueLinks({
         // '/cart' is disallowed by robots.txt
-        globs: ['**/cart'],
+        globs: ['**/cart', '**/collections/*'],
     });
     await pushData({ url: request.url, loadedUrl: request.loadedUrl });
 });
 
 await crawler.run([
     'https://warehouse-theme-metal.myshopify.com',
-    'https://warehouse-theme-metal.myshopify.com/checkout',
+    'https://warehouse-theme-metal.myshopify.com/checkout', // '/checkout' is disallowed by robots.txt
 ]);
 
 const data = await crawler.getData();

--- a/test/e2e/cheerio-robots-file/actor/main.js
+++ b/test/e2e/cheerio-robots-file/actor/main.js
@@ -10,7 +10,7 @@ await Actor.init({
 
 const crawler = new CheerioCrawler({
     maxRequestsPerCrawl: 10,
-    respectRobotsFile: true,
+    respectRobotsTxtFile: true,
 });
 
 crawler.router.addDefaultHandler(async ({ log, request, enqueueLinks, pushData }) => {

--- a/test/e2e/cheerio-robots-file/actor/package.json
+++ b/test/e2e/cheerio-robots-file/actor/package.json
@@ -1,0 +1,28 @@
+{
+    "name": "test-cheerio-robots-file",
+    "version": "0.0.1",
+    "description": "Cheerio Test - Robots file",
+    "dependencies": {
+        "apify": "next",
+        "@apify/storage-local": "^2.1.3",
+        "@crawlee/basic": "file:./packages/basic-crawler",
+        "@crawlee/browser": "file:./packages/browser-crawler",
+        "@crawlee/browser-pool": "file:./packages/browser-pool",
+        "@crawlee/core": "file:./packages/core",
+        "@crawlee/memory-storage": "file:./packages/memory-storage",
+        "@crawlee/cheerio": "file:./packages/cheerio-crawler",
+        "@crawlee/types": "file:./packages/types",
+        "@crawlee/utils": "file:./packages/utils"
+    },
+    "overrides": {
+        "apify": {
+            "@crawlee/core": "file:./packages/core",
+            "@crawlee/utils": "file:./packages/utils"
+        }
+    },
+    "scripts": {
+        "start": "node main.js"
+    },
+    "type": "module",
+    "license": "ISC"
+}

--- a/test/e2e/cheerio-robots-file/test.mjs
+++ b/test/e2e/cheerio-robots-file/test.mjs
@@ -1,0 +1,16 @@
+import { initialize, getActorTestDir, runActor, expect } from '../tools.mjs';
+
+const testActorDirname = getActorTestDir(import.meta.url);
+await initialize(testActorDirname);
+
+const { stats, datasetItems } = await runActor(testActorDirname);
+
+await expect(stats.requestsFinished >= 1, 'All requests finished');
+
+const cartRequest = datasetItems.find((item) => item.url === 'https://warehouse-theme-metal.myshopify.com/cart');
+const checkoutRequest = datasetItems.find(
+    (item) => item.url === 'https://warehouse-theme-metal.myshopify.com/checkout',
+);
+
+await expect(!cartRequest, '/cart URL is not processed');
+await expect(!checkoutRequest, '/checkout URL is not processed');

--- a/test/e2e/playwright-robots-file/actor/.actor/actor.json
+++ b/test/e2e/playwright-robots-file/actor/.actor/actor.json
@@ -1,0 +1,7 @@
+{
+	"actorSpecification": 1,
+	"name": "test-playwright-robots-file",
+	"version": "0.0",
+	"buildTag": "latest",
+	"env": null
+}

--- a/test/e2e/playwright-robots-file/actor/.gitignore
+++ b/test/e2e/playwright-robots-file/actor/.gitignore
@@ -1,0 +1,7 @@
+.idea
+.DS_Store
+node_modules
+package-lock.json
+apify_storage
+crawlee_storage
+storage

--- a/test/e2e/playwright-robots-file/actor/Dockerfile
+++ b/test/e2e/playwright-robots-file/actor/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:20 AS builder
+
+COPY /packages ./packages
+COPY /package*.json ./
+RUN npm --quiet set progress=false \
+    && npm install --only=prod --no-optional --no-audit \
+    && npm update
+
+FROM apify/actor-node-playwright-chrome:20-beta
+
+RUN rm -r node_modules
+COPY --from=builder /node_modules ./node_modules
+COPY --from=builder /packages ./packages
+COPY --from=builder /package*.json ./
+COPY /.actor ./.actor
+COPY /main.js ./
+
+RUN echo "Installed NPM packages:" \
+    && (npm list --only=prod --no-optional --all || true) \
+    && echo "Node.js version:" \
+    && node --version \
+    && echo "NPM version:" \
+    && npm --version
+
+ENV PLAYWRIGHT_EXECUTABLE_PATH=/usr/bin/google-chrome

--- a/test/e2e/playwright-robots-file/actor/main.js
+++ b/test/e2e/playwright-robots-file/actor/main.js
@@ -17,14 +17,14 @@ crawler.router.addDefaultHandler(async ({ log, request, enqueueLinks, pushData }
     log.info(`Processing ${request.loadedUrl}`);
     await enqueueLinks({
         // '/cart' is disallowed by robots.txt
-        globs: ['**/cart'],
+        globs: ['**/cart', '**/collections/*'],
     });
     await pushData({ url: request.url, loadedUrl: request.loadedUrl });
 });
 
 await crawler.run([
     'https://warehouse-theme-metal.myshopify.com',
-    'https://warehouse-theme-metal.myshopify.com/checkout',
+    'https://warehouse-theme-metal.myshopify.com/checkout', // '/checkout' is disallowed by robots.txt
 ]);
 
 const data = await crawler.getData();

--- a/test/e2e/playwright-robots-file/actor/main.js
+++ b/test/e2e/playwright-robots-file/actor/main.js
@@ -10,7 +10,7 @@ await Actor.init({
 
 const crawler = new PlaywrightCrawler({
     maxRequestsPerCrawl: 10,
-    respectRobotsFile: true,
+    respectRobotsTxtFile: true,
 });
 
 crawler.router.addDefaultHandler(async ({ log, request, enqueueLinks, pushData }) => {

--- a/test/e2e/playwright-robots-file/actor/main.js
+++ b/test/e2e/playwright-robots-file/actor/main.js
@@ -1,0 +1,33 @@
+import { PlaywrightCrawler } from '@crawlee/playwright';
+import { Actor } from 'apify';
+
+await Actor.init({
+    storage:
+        process.env.STORAGE_IMPLEMENTATION === 'LOCAL'
+            ? new (await import('@apify/storage-local')).ApifyStorageLocal()
+            : undefined,
+});
+
+const crawler = new PlaywrightCrawler({
+    maxRequestsPerCrawl: 10,
+    respectRobotsFile: true,
+});
+
+crawler.router.addDefaultHandler(async ({ log, request, enqueueLinks, pushData }) => {
+    log.info(`Processing ${request.loadedUrl}`);
+    await enqueueLinks({
+        // '/cart' is disallowed by robots.txt
+        globs: ['**/cart'],
+    });
+    await pushData({ url: request.url, loadedUrl: request.loadedUrl });
+});
+
+await crawler.run([
+    'https://warehouse-theme-metal.myshopify.com',
+    'https://warehouse-theme-metal.myshopify.com/checkout',
+]);
+
+const data = await crawler.getData();
+console.table(data.items);
+
+await Actor.exit({ exit: Actor.isAtHome() });

--- a/test/e2e/playwright-robots-file/actor/package.json
+++ b/test/e2e/playwright-robots-file/actor/package.json
@@ -1,0 +1,29 @@
+{
+    "name": "test-playwright-robots-file",
+    "version": "0.0.1",
+    "description": "Playwright Test - Robots file",
+    "dependencies": {
+        "apify": "next",
+        "@apify/storage-local": "^2.1.3",
+        "@crawlee/basic": "file:./packages/basic-crawler",
+        "@crawlee/browser": "file:./packages/browser-crawler",
+        "@crawlee/browser-pool": "file:./packages/browser-pool",
+        "@crawlee/core": "file:./packages/core",
+        "@crawlee/memory-storage": "file:./packages/memory-storage",
+        "@crawlee/playwright": "file:./packages/playwright-crawler",
+        "@crawlee/types": "file:./packages/types",
+        "@crawlee/utils": "file:./packages/utils",
+        "playwright": "*"
+    },
+    "overrides": {
+        "apify": {
+            "@crawlee/core": "file:./packages/core",
+            "@crawlee/utils": "file:./packages/utils"
+        }
+    },
+    "scripts": {
+        "start": "node main.js"
+    },
+    "type": "module",
+    "license": "ISC"
+}

--- a/test/e2e/playwright-robots-file/test.mjs
+++ b/test/e2e/playwright-robots-file/test.mjs
@@ -1,0 +1,16 @@
+import { initialize, getActorTestDir, runActor, expect } from '../tools.mjs';
+
+const testActorDirname = getActorTestDir(import.meta.url);
+await initialize(testActorDirname);
+
+const { stats, datasetItems } = await runActor(testActorDirname, 16384);
+
+await expect(stats.requestsFinished >= 1, 'All requests finished');
+
+const cartRequest = datasetItems.find((item) => item.url === 'https://warehouse-theme-metal.myshopify.com/cart');
+const checkoutRequest = datasetItems.find(
+    (item) => item.url === 'https://warehouse-theme-metal.myshopify.com/checkout',
+);
+
+await expect(!cartRequest, '/cart URL is not processed');
+await expect(!checkoutRequest, '/checkout URL is not processed');


### PR DESCRIPTION
This PR implements automatic skipping of requests based on the robots.txt file. It works based on a new boolean flag in the crawler options called `respectRobotsTxtFile`.

Checks are implemented in `BasicCrawler._runTaskFunction()`, `enqueueLinks` (the context helper), and `BasicCrawler.addRequests()`, so we ensure disallowed requests are neither processed, nor added to the queue (this only works with the `enqueueLinks` context helper). The robots.txt files are cached based on the URL origin, so we should fetch it only once for each domain (up to 1000 domains, uses LRU cache). We don't use a proxy to fetch the robots.txt file, which should be fine, since the file should be accessible by robots in general.

We might want to enable this by default in the next major.