### PR TITLE
fix: disable default fingerprints in the Camoufox template

### DIFF
--- a/docs/guides/avoid_blocking_camoufox.ts
+++ b/docs/guides/avoid_blocking_camoufox.ts
@@ -8,6 +8,10 @@ const crawler = new PlaywrightCrawler({
             await handleCloudflareChallenge();
         },
     ],
+    browserPoolOptions: {
+        // Disable the default fingerprint spoofing to avoid conflicts with Camoufox.
+        useFingerprints: false,
+    },
     launchContext: {
         launcher: firefox,
         launchOptions: await launchOptions({

--- a/packages/templates/templates/camoufox-ts/src/main.ts
+++ b/packages/templates/templates/camoufox-ts/src/main.ts
@@ -12,6 +12,10 @@ const crawler = new PlaywrightCrawler({
     requestHandler: router,
     // Comment this option to scrape the full website.
     maxRequestsPerCrawl: 20,
+    browserPoolOptions: {
+        // Disable the default fingerprint spoofing to avoid conflicts with Camoufox.
+        useFingerprints: false,
+    },
     launchContext: {
         launcher: firefox,
         launchOptions: await launchOptions({


### PR DESCRIPTION
Using default Crawlee-issued fingerprints (through the `fingerprint-injector`) with the Camoufox browser can lead to inconsistent browser fingerprints (see e.g. https://github.com/apify/camoufox-js/issues/11).

This PR explicitly disables the default fingerprints in Camoufox examples / templates.