### PR TITLE
docs: improve `maxRequestRetries` documentation

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -235,7 +235,12 @@ export interface BasicCrawlerOptions<Context extends CrawlingContext = BasicCraw
     handleFailedRequestFunction?: ErrorHandler<Context>;
 
     /**
-     * Indicates how many times the request is retried if {@apilink BasicCrawlerOptions.requestHandler|`requestHandler`} fails.
+     * Specifies the maximum number of retries allowed for a request if its processing fails.
+     * This includes retries due to navigation errors or errors thrown from user-supplied functions
+     * (`requestHandler`, `preNavigationHooks`, `postNavigationHooks`).
+     *
+     * This limit does not apply to retries triggered by session rotation
+     * (see {@apilink BasicCrawlerOptions.maxSessionRotations|`maxSessionRotations`}).
      * @default 3
      */
     maxRequestRetries?: number;


### PR DESCRIPTION
Improves the option documentation based on [the discussion in Crawlee Python](https://github.com/apify/crawlee-python/issues/1171). Once we reach agreement on the new wording, we should update this in [Crawlee Python too](https://github.com/apify/crawlee-python/blob/9a63edf64be7cb032fe5345701e727c9f0af9f3e/src/crawlee/crawlers/_basic/_basic_crawler.py#L112).