### PR TITLE
fix(core): respect `systemInfoV2` in snapshotter

### DIFF
--- a/packages/core/src/autoscaling/snapshotter.ts
+++ b/packages/core/src/autoscaling/snapshotter.ts
@@ -1,5 +1,5 @@
 import type { StorageClient } from '@crawlee/types';
-import { getMemoryInfo } from '@crawlee/utils';
+import { getMemoryInfo, getMemoryInfoV2, isContainerized } from '@crawlee/utils';
 import ow from 'ow';
 
 import type { Log } from '@apify/log';
@@ -195,7 +195,17 @@ export class Snapshotter {
         if (memoryMbytes > 0) {
             this.maxMemoryBytes = memoryMbytes * 1024 * 1024;
         } else {
-            const { totalBytes } = await getMemoryInfo();
+            let totalBytes: number;
+
+            if (this.config.get('systemInfoV2')) {
+                const containerized = this.config.get('containerized', await isContainerized());
+                const memInfo = await getMemoryInfoV2(containerized);
+                totalBytes = memInfo.totalBytes;
+            } else {
+                const memInfo = await getMemoryInfo();
+                totalBytes = memInfo.totalBytes;
+            }
+
             this.maxMemoryBytes = Math.ceil(totalBytes * this.config.get('availableMemoryRatio')!);
             this.log.debug(
                 `Setting max memory of this run to ${Math.round(this.maxMemoryBytes / 1024 / 1024)} MB. ` +

--- a/packages/core/src/events/local_event_manager.ts
+++ b/packages/core/src/events/local_event_manager.ts
@@ -54,11 +54,7 @@ export class LocalEventManager extends EventManager {
      * @internal
      */
     async isContainerizedWrapper() {
-        const config = this.config.get('containerized');
-        if (config !== undefined) {
-            return config;
-        }
-        return isContainerized();
+        return this.config.get('containerized', await isContainerized());
     }
 
     private getCurrentCpuTicks() {


### PR DESCRIPTION
When no `memoryMbytes` option is provided, we infer the available memory in the snapshotter. This place was not respecting the `systemInfoV2` option, which this PR resolves.

Closes #2958