### PR TITLE
fix(core): use short timeouts for periodic `KVS.setRecord` calls

### DIFF
--- a/packages/core/src/crawlers/statistics.ts
+++ b/packages/core/src/crawlers/statistics.ts
@@ -329,7 +329,13 @@ export class Statistics {
 
         this.log.debug('Persisting state', { persistStateKey: this.persistStateKey });
 
-        await this.keyValueStore.setValue(this.persistStateKey, this.toJSON());
+        // use half the interval of `persistState` to avoid race conditions
+        const persistStateIntervalMillis = this.config.get('persistStateIntervalMillis')!;
+        const timeoutSecs = persistStateIntervalMillis / 2_000;
+        await this.keyValueStore.setValue(this.persistStateKey, this.toJSON(), {
+            timeoutSecs,
+            doNotRetryTimeouts: true,
+        });
     }
 
     /**

--- a/packages/core/src/session_pool/session_pool.ts
+++ b/packages/core/src/session_pool/session_pool.ts
@@ -367,7 +367,14 @@ export class SessionPool extends EventEmitter {
             persistStateKeyValueStoreId: this.persistStateKeyValueStoreId,
             persistStateKey: this.persistStateKey,
         });
-        await this.keyValueStore.setValue(this.persistStateKey, this.getState());
+
+        // use half the interval of `persistState` to avoid race conditions
+        const persistStateIntervalMillis = this.config.get('persistStateIntervalMillis')!;
+        const timeoutSecs = persistStateIntervalMillis / 2_000;
+        await this.keyValueStore.setValue(this.persistStateKey, this.getState(), {
+            timeoutSecs,
+            doNotRetryTimeouts: true,
+        });
     }
 
     /**

--- a/packages/types/src/storages.ts
+++ b/packages/types/src/storages.ts
@@ -124,6 +124,11 @@ export interface KeyValueStoreRecord {
     contentType?: string;
 }
 
+export interface KeyValueStoreRecordOptions {
+    timeoutSecs?: number;
+    doNotRetryTimeouts?: boolean;
+}
+
 export interface KeyValueStoreClientUpdateOptions {
     name?: string;
 }
@@ -162,7 +167,7 @@ export interface KeyValueStoreClient {
     listKeys(options?: KeyValueStoreClientListOptions): Promise<KeyValueStoreClientListData>;
     recordExists(key: string): Promise<boolean>;
     getRecord(key: string, options?: KeyValueStoreClientGetRecordOptions): Promise<KeyValueStoreRecord | undefined>;
-    setRecord(record: KeyValueStoreRecord): Promise<void>;
+    setRecord(record: KeyValueStoreRecord, options?: KeyValueStoreRecordOptions): Promise<void>;
     deleteRecord(key: string): Promise<void>;
 }
 

--- a/test/core/crawlers/statistics.test.ts
+++ b/test/core/crawlers/statistics.test.ts
@@ -187,7 +187,14 @@ describe('Statistics', () => {
             const { retryHistogram, finished, failed, ...rest } = stats.calculate();
 
             // @ts-expect-error Accessing private prop
-            expect(setValueSpy).toBeCalledWith(stats.persistStateKey, { ...state, ...rest });
+            expect(setValueSpy).toBeCalledWith(
+                stats.persistStateKey,
+                { ...state, ...rest },
+                {
+                    doNotRetryTimeouts: true,
+                    timeoutSecs: 30,
+                },
+            );
         }, 2000);
     });
 

--- a/test/core/storages/key_value_store.test.ts
+++ b/test/core/storages/key_value_store.test.ts
@@ -40,11 +40,17 @@ describe('KeyValueStore', () => {
         await store.setValue('key-1', record);
 
         expect(mockSetRecord).toBeCalledTimes(1);
-        expect(mockSetRecord).toBeCalledWith({
-            key: 'key-1',
-            value: recordStr,
-            contentType: 'application/json; charset=utf-8',
-        });
+        expect(mockSetRecord).toBeCalledWith(
+            {
+                key: 'key-1',
+                value: recordStr,
+                contentType: 'application/json; charset=utf-8',
+            },
+            {
+                doNotRetryTimeouts: undefined,
+                timeoutSecs: undefined,
+            },
+        );
 
         // Get Record
         const mockGetRecord = vitest
@@ -281,11 +287,17 @@ describe('KeyValueStore', () => {
             await store.setValue('key-1', 'xxxx', { contentType: 'text/plain; charset=utf-8' });
 
             expect(mockSetRecord).toBeCalledTimes(1);
-            expect(mockSetRecord).toBeCalledWith({
-                key: 'key-1',
-                value: 'xxxx',
-                contentType: 'text/plain; charset=utf-8',
-            });
+            expect(mockSetRecord).toBeCalledWith(
+                {
+                    key: 'key-1',
+                    value: 'xxxx',
+                    contentType: 'text/plain; charset=utf-8',
+                },
+                {
+                    doNotRetryTimeouts: undefined,
+                    timeoutSecs: undefined,
+                },
+            );
         });
 
         test('correctly passes object values as JSON', async () => {
@@ -305,11 +317,50 @@ describe('KeyValueStore', () => {
             await store.setValue('key-1', record);
 
             expect(mockSetRecord).toBeCalledTimes(1);
-            expect(mockSetRecord).toBeCalledWith({
-                key: 'key-1',
-                value: recordStr,
-                contentType: 'application/json; charset=utf-8',
+            expect(mockSetRecord).toBeCalledWith(
+                {
+                    key: 'key-1',
+                    value: recordStr,
+                    contentType: 'application/json; charset=utf-8',
+                },
+                {
+                    doNotRetryTimeouts: undefined,
+                    timeoutSecs: undefined,
+                },
+            );
+        });
+
+        test('correctly passes timeout options', async () => {
+            const store = new KeyValueStore({
+                id: 'my-store-id-1',
+                client,
             });
+
+            const record = { foo: 'bar' };
+            const recordStr = JSON.stringify(record, null, 2);
+
+            const mockSetRecord = vitest
+                // @ts-expect-error Accessing private property
+                .spyOn(store.client, 'setRecord')
+                .mockResolvedValueOnce(undefined);
+
+            await store.setValue('key-1', record, {
+                timeoutSecs: 1,
+                doNotRetryTimeouts: true,
+            });
+
+            expect(mockSetRecord).toBeCalledTimes(1);
+            expect(mockSetRecord).toBeCalledWith(
+                {
+                    key: 'key-1',
+                    value: recordStr,
+                    contentType: 'application/json; charset=utf-8',
+                },
+                {
+                    doNotRetryTimeouts: true,
+                    timeoutSecs: 1,
+                },
+            );
         });
 
         test('correctly passes raw string values', async () => {
@@ -326,11 +377,17 @@ describe('KeyValueStore', () => {
             await store.setValue('key-1', 'xxxx', { contentType: 'text/plain; charset=utf-8' });
 
             expect(mockSetRecord).toBeCalledTimes(1);
-            expect(mockSetRecord).toBeCalledWith({
-                key: 'key-1',
-                value: 'xxxx',
-                contentType: 'text/plain; charset=utf-8',
-            });
+            expect(mockSetRecord).toBeCalledWith(
+                {
+                    key: 'key-1',
+                    value: 'xxxx',
+                    contentType: 'text/plain; charset=utf-8',
+                },
+                {
+                    doNotRetryTimeouts: undefined,
+                    timeoutSecs: undefined,
+                },
+            );
         });
 
         test('correctly passes raw Buffer values', async () => {
@@ -348,11 +405,17 @@ describe('KeyValueStore', () => {
             await store.setValue('key-1', value, { contentType: 'image/jpeg; charset=something' });
 
             expect(mockSetRecord).toBeCalledTimes(1);
-            expect(mockSetRecord).toBeCalledWith({
-                key: 'key-1',
-                value,
-                contentType: 'image/jpeg; charset=something',
-            });
+            expect(mockSetRecord).toBeCalledWith(
+                {
+                    key: 'key-1',
+                    value,
+                    contentType: 'image/jpeg; charset=something',
+                },
+                {
+                    doNotRetryTimeouts: undefined,
+                    timeoutSecs: undefined,
+                },
+            );
         });
 
         test('correctly passes a stream', async () => {
@@ -373,11 +436,17 @@ describe('KeyValueStore', () => {
             value.destroy();
 
             expect(mockSetRecord).toHaveBeenCalledTimes(1);
-            expect(mockSetRecord).toHaveBeenCalledWith({
-                key: 'key-1',
-                value,
-                contentType: 'plain/text',
-            });
+            expect(mockSetRecord).toHaveBeenCalledWith(
+                {
+                    key: 'key-1',
+                    value,
+                    contentType: 'plain/text',
+                },
+                {
+                    doNotRetryTimeouts: undefined,
+                    timeoutSecs: undefined,
+                },
+            );
         });
     });
 


### PR DESCRIPTION
Sometimes the `setRecord` calls might get stuck and since we issue a new one every 60s (via `persistState` event), and the default API call timeout is 6 minutes, we might end up overloading the API.

This PR disables retries on those calls in case of a timeout, and overrides the default 6-minute timeout to half of the persist state interval (so to 30s by default).

Related: https://apify.slack.com/archives/C0L33UM7Z/p1747043120071539