### PR TITLE
fix: enable full cookie support for `ImpitHttpClient`

### DIFF
--- a/packages/http-crawler/src/internals/http-crawler.ts
+++ b/packages/http-crawler/src/internals/http-crawler.ts
@@ -791,6 +791,7 @@ export class HttpCrawler<
             method: request.method as Method,
             proxyUrl,
             timeout: { request: this.navigationTimeoutMillis },
+            cookieJar: this.persistCookiesPerSession ? session?.cookieJar : undefined,
             sessionToken: session,
             ...gotOptions,
             headers: { ...request.headers, ...gotOptions?.headers },

--- a/packages/impit-client/package.json
+++ b/packages/impit-client/package.json
@@ -60,7 +60,7 @@
     },
     "dependencies": {
         "@apify/datastructures": "^2.0.3",
-        "impit": "^0.4.3",
+        "impit": "^0.5.0",
         "tough-cookie": "^5.1.2"
     },
     "packageManager": "yarn@4.8.1"

--- a/packages/impit-client/package.json
+++ b/packages/impit-client/package.json
@@ -60,7 +60,8 @@
     },
     "dependencies": {
         "@apify/datastructures": "^2.0.3",
-        "impit": "^0.4.3"
+        "impit": "^0.4.3",
+        "tough-cookie": "^5.1.2"
     },
     "packageManager": "yarn@4.8.1"
 }

--- a/packages/impit-client/src/index.ts
+++ b/packages/impit-client/src/index.ts
@@ -4,8 +4,8 @@ import { isGeneratorObject } from 'node:util/types';
 
 import type { BaseHttpClient, HttpRequest, HttpResponse, ResponseTypes, StreamingHttpResponse } from '@crawlee/core';
 import type { HttpMethod, ImpitOptions, ImpitResponse, RequestInit } from 'impit';
-import type { CookieJar as ToughCookieJar } from 'tough-cookie';
 import { Impit } from 'impit';
+import type { CookieJar as ToughCookieJar } from 'tough-cookie';
 
 import { LruCache } from '@apify/datastructures';
 

--- a/packages/impit-client/src/index.ts
+++ b/packages/impit-client/src/index.ts
@@ -118,7 +118,7 @@ export class ImpitHttpClient implements BaseHttpClient {
 
         const impit = this.getClient({
             ...this.impitOptions,
-            ...(request?.cookieJar ? { cookieJar: request.cookieJar as any } : {}),
+            ...(request?.cookieJar ? { cookieJar: request.cookieJar as ToughCookieJar } : {}),
             proxyUrl: request.proxyUrl,
             followRedirects: false,
         });

--- a/packages/impit-client/src/index.ts
+++ b/packages/impit-client/src/index.ts
@@ -4,6 +4,7 @@ import { isGeneratorObject } from 'node:util/types';
 
 import type { BaseHttpClient, HttpRequest, HttpResponse, ResponseTypes, StreamingHttpResponse } from '@crawlee/core';
 import type { HttpMethod, ImpitOptions, ImpitResponse, RequestInit } from 'impit';
+import type { CookieJar as ToughCookieJar } from 'tough-cookie';
 import { Impit } from 'impit';
 
 import { LruCache } from '@apify/datastructures';
@@ -32,17 +33,20 @@ export class ImpitHttpClient implements BaseHttpClient {
      * a new client for each request breaks TCP connection
      * (and other resources) reuse.
      */
-    private clientCache: LruCache<Impit> = new LruCache({ maxLength: 10 });
+    private clientCache: LruCache<{ client: Impit; cookieJar: ToughCookieJar }> = new LruCache({ maxLength: 10 });
 
     private getClient(options: ImpitOptions) {
-        const cacheKey = JSON.stringify(options);
+        const { cookieJar, ...rest } = options;
 
-        if (this.clientCache.get(cacheKey)) {
-            return this.clientCache.get(cacheKey)!;
+        const cacheKey = JSON.stringify(rest);
+        const existingClient = this.clientCache.get(cacheKey);
+
+        if (existingClient && (!cookieJar || existingClient.cookieJar === cookieJar)) {
+            return existingClient.client;
         }
 
         const client = new Impit(options);
-        this.clientCache.add(cacheKey, client);
+        this.clientCache.add(cacheKey, { client, cookieJar: cookieJar as ToughCookieJar });
 
         return client;
     }
@@ -114,6 +118,7 @@ export class ImpitHttpClient implements BaseHttpClient {
 
         const impit = this.getClient({
             ...this.impitOptions,
+            ...(request?.cookieJar ? { cookieJar: request.cookieJar as any } : {}),
             proxyUrl: request.proxyUrl,
             followRedirects: false,
         });

--- a/test/core/crawlers/http_crawler.test.ts
+++ b/test/core/crawlers/http_crawler.test.ts
@@ -95,7 +95,11 @@ afterAll(async () => {
     await localStorageEmulator.destroy();
 });
 
-describe.each([new GotScrapingHttpClient(), new ImpitHttpClient()])('HttpCrawler with %s', (httpClient) => {
+describe.each(
+    process.version.startsWith('v16')
+        ? [new GotScrapingHttpClient()]
+        : [new GotScrapingHttpClient(), new ImpitHttpClient()],
+)('HttpCrawler with %s', (httpClient) => {
     test('works', async () => {
         const results: string[] = [];
 

--- a/test/core/crawlers/http_crawler.test.ts
+++ b/test/core/crawlers/http_crawler.test.ts
@@ -2,8 +2,9 @@ import http from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { Readable } from 'node:stream';
 
-import { HttpCrawler } from '@crawlee/http';
+import { GotScrapingHttpClient, HttpCrawler } from '@crawlee/http';
 import { MemoryStorageEmulator } from 'test/shared/MemoryStorageEmulator';
+import { ImpitHttpClient } from '@crawlee/impit-client';
 
 const router = new Map<string, http.RequestListener>();
 router.set('/', (req, res) => {
@@ -94,364 +95,381 @@ afterAll(async () => {
     await localStorageEmulator.destroy();
 });
 
-test('works', async () => {
-    const results: string[] = [];
+describe.each([new GotScrapingHttpClient(), new ImpitHttpClient()])('HttpCrawler with %s', (httpClient) => {
+    test('works', async () => {
+        const results: string[] = [];
 
-    const crawler = new HttpCrawler({
-        maxRequestRetries: 0,
-        requestHandler: ({ body }) => {
-            results.push(body as string);
-        },
+        const crawler = new HttpCrawler({
+            httpClient,
+            maxRequestRetries: 0,
+            requestHandler: ({ body }) => {
+                results.push(body as string);
+            },
+        });
+
+        await crawler.run([url]);
+
+        expect(results[0].includes('Example Domain')).toBeTruthy();
     });
 
-    await crawler.run([url]);
+    test('parseWithCheerio works', async () => {
+        const results: string[] = [];
 
-    expect(results[0].includes('Example Domain')).toBeTruthy();
-});
+        const crawler = new HttpCrawler({
+            httpClient,
+            maxRequestRetries: 0,
+            requestHandler: async ({ parseWithCheerio }) => {
+                const $ = await parseWithCheerio('title');
+                results.push($('title').text());
+            },
+        });
 
-test('parseWithCheerio works', async () => {
-    const results: string[] = [];
+        await crawler.run([`${url}/hello.html`]);
 
-    const crawler = new HttpCrawler({
-        maxRequestRetries: 0,
-        requestHandler: async ({ parseWithCheerio }) => {
-            const $ = await parseWithCheerio('title');
-            results.push($('title').text());
-        },
+        expect(results).toStrictEqual(['Example Domain']);
     });
 
-    await crawler.run([`${url}/hello.html`]);
+    test('should parse content type from header', async () => {
+        const results: { type: string; encoding: BufferEncoding }[] = [];
 
-    expect(results).toStrictEqual(['Example Domain']);
-});
+        const crawler = new HttpCrawler({
+            httpClient,
+            maxRequestRetries: 0,
+            requestHandler: ({ contentType }) => {
+                results.push(contentType);
+            },
+        });
 
-test('should parse content type from header', async () => {
-    const results: { type: string; encoding: BufferEncoding }[] = [];
+        await crawler.run([url]);
 
-    const crawler = new HttpCrawler({
-        maxRequestRetries: 0,
-        requestHandler: ({ contentType }) => {
-            results.push(contentType);
-        },
+        expect(results).toStrictEqual([
+            {
+                type: 'text/html',
+                encoding: 'utf-8',
+            },
+        ]);
     });
 
-    await crawler.run([url]);
+    test('should parse content type from file extension', async () => {
+        const results: { type: string; encoding: BufferEncoding }[] = [];
 
-    expect(results).toStrictEqual([
-        {
-            type: 'text/html',
-            encoding: 'utf-8',
-        },
-    ]);
-});
+        const crawler = new HttpCrawler({
+            httpClient,
+            maxRequestRetries: 0,
+            requestHandler: ({ contentType }) => {
+                results.push(contentType);
+            },
+        });
 
-test('should parse content type from file extension', async () => {
-    const results: { type: string; encoding: BufferEncoding }[] = [];
+        await crawler.run([`${url}/hello.html`]);
 
-    const crawler = new HttpCrawler({
-        maxRequestRetries: 0,
-        requestHandler: ({ contentType }) => {
-            results.push(contentType);
-        },
+        expect(results).toStrictEqual([
+            {
+                type: 'text/html',
+                encoding: 'utf-8',
+            },
+        ]);
     });
 
-    await crawler.run([`${url}/hello.html`]);
+    test('no content type defaults to octet-stream', async () => {
+        const results: { type: string; encoding: BufferEncoding }[] = [];
 
-    expect(results).toStrictEqual([
-        {
-            type: 'text/html',
-            encoding: 'utf-8',
-        },
-    ]);
-});
+        const crawler = new HttpCrawler({
+            httpClient,
+            maxRequestRetries: 0,
+            additionalMimeTypes: ['*/*'],
+            requestHandler: ({ contentType }) => {
+                results.push(contentType);
+            },
+        });
 
-test('no content type defaults to octet-stream', async () => {
-    const results: { type: string; encoding: BufferEncoding }[] = [];
+        await crawler.run([`${url}/noext`]);
 
-    const crawler = new HttpCrawler({
-        maxRequestRetries: 0,
-        additionalMimeTypes: ['*/*'],
-        requestHandler: ({ contentType }) => {
-            results.push(contentType);
-        },
+        expect(results).toStrictEqual([
+            {
+                type: 'application/octet-stream',
+                encoding: 'utf-8',
+            },
+        ]);
     });
 
-    await crawler.run([`${url}/noext`]);
+    test('invalid content type defaults to octet-stream', async () => {
+        const results: { type: string; encoding: BufferEncoding }[] = [];
 
-    expect(results).toStrictEqual([
-        {
-            type: 'application/octet-stream',
-            encoding: 'utf-8',
-        },
-    ]);
-});
+        const crawler = new HttpCrawler({
+            httpClient,
+            maxRequestRetries: 0,
+            additionalMimeTypes: ['*/*'],
+            requestHandler: ({ contentType }) => {
+                results.push(contentType);
+            },
+        });
 
-test('invalid content type defaults to octet-stream', async () => {
-    const results: { type: string; encoding: BufferEncoding }[] = [];
+        await crawler.run([`${url}/invalidContentType`]);
 
-    const crawler = new HttpCrawler({
-        maxRequestRetries: 0,
-        additionalMimeTypes: ['*/*'],
-        requestHandler: ({ contentType }) => {
-            results.push(contentType);
-        },
+        expect(results).toStrictEqual([
+            {
+                type: 'application/octet-stream',
+                encoding: 'utf-8',
+            },
+        ]);
     });
 
-    await crawler.run([`${url}/invalidContentType`]);
+    test('handles cookies from redirects', async () => {
+        const results: string[] = [];
 
-    expect(results).toStrictEqual([
-        {
-            type: 'application/octet-stream',
-            encoding: 'utf-8',
-        },
-    ]);
-});
+        const crawler = new HttpCrawler({
+            httpClient,
+            sessionPoolOptions: {
+                maxPoolSize: 1,
+            },
+            handlePageFunction: async ({ body }) => {
+                results.push(JSON.parse(body.toString()));
+            },
+        });
 
-test('handles cookies from redirects', async () => {
-    const results: string[] = [];
+        await crawler.run([`${url}/redirectAndCookies`]);
 
-    const crawler = new HttpCrawler({
-        sessionPoolOptions: {
-            maxPoolSize: 1,
-        },
-        handlePageFunction: async ({ body }) => {
-            results.push(JSON.parse(body.toString()));
-        },
+        expect(results).toStrictEqual(['foo=bar']);
     });
 
-    await crawler.run([`${url}/redirectAndCookies`]);
+    test('handles cookies from redirects - no empty cookie header', async () => {
+        const results: string[] = [];
 
-    expect(results).toStrictEqual(['foo=bar']);
-});
+        const crawler = new HttpCrawler({
+            httpClient,
+            sessionPoolOptions: {
+                maxPoolSize: 1,
+            },
+            handlePageFunction: async ({ body }) => {
+                const str = body.toString();
 
-test('handles cookies from redirects - no empty cookie header', async () => {
-    const results: string[] = [];
-
-    const crawler = new HttpCrawler({
-        sessionPoolOptions: {
-            maxPoolSize: 1,
-        },
-        handlePageFunction: async ({ body }) => {
-            const str = body.toString();
-
-            if (str !== '') {
-                results.push(JSON.parse(str));
-            }
-        },
-    });
-
-    await crawler.run([`${url}/redirectWithoutCookies`]);
-
-    expect(results).toStrictEqual([]);
-});
-
-test('no empty cookie header', async () => {
-    const results: string[] = [];
-
-    const crawler = new HttpCrawler({
-        sessionPoolOptions: {
-            maxPoolSize: 1,
-        },
-        handlePageFunction: async ({ body }) => {
-            const str = body.toString();
-
-            if (str !== '') {
-                results.push(JSON.parse(str));
-            }
-        },
-    });
-
-    await crawler.run([`${url}/cookies`]);
-
-    expect(results).toStrictEqual([]);
-});
-
-test('POST with undefined (empty) payload', async () => {
-    const results: string[] = [];
-
-    const crawler = new HttpCrawler({
-        handlePageFunction: async ({ body }) => {
-            results.push(body.toString());
-        },
-    });
-
-    await crawler.run([
-        {
-            url: `${url}/echo`,
-            payload: undefined,
-            method: 'POST',
-        },
-    ]);
-
-    expect(results).toStrictEqual(['']);
-});
-
-test('should ignore http error status codes set by user', async () => {
-    const failed: any[] = [];
-
-    const crawler = new HttpCrawler({
-        minConcurrency: 2,
-        maxConcurrency: 2,
-        ignoreHttpErrorStatusCodes: [500],
-        requestHandler: () => {},
-        failedRequestHandler: ({ request }) => {
-            failed.push(request);
-        },
-    });
-
-    await crawler.run([`${url}/500Error`]);
-
-    expect(crawler.autoscaledPool!.minConcurrency).toBe(2);
-    expect(failed).toHaveLength(0);
-});
-
-test('should throw an error on http error status codes set by user', async () => {
-    const failed: any[] = [];
-
-    const crawler = new HttpCrawler({
-        minConcurrency: 2,
-        maxConcurrency: 2,
-        additionalHttpErrorStatusCodes: [200],
-        requestHandler: () => {},
-        failedRequestHandler: ({ request }) => {
-            failed.push(request);
-        },
-    });
-
-    await crawler.run([`${url}/hello.html`]);
-
-    expect(crawler.autoscaledPool!.minConcurrency).toBe(2);
-    expect(failed).toHaveLength(1);
-});
-
-test('should work with delete requests', async () => {
-    const failed: any[] = [];
-
-    const cheerioCrawler = new HttpCrawler({
-        maxConcurrency: 1,
-        maxRequestRetries: 0,
-        navigationTimeoutSecs: 5,
-        requestHandlerTimeoutSecs: 5,
-        requestHandler: async () => {},
-        failedRequestHandler: async ({ request }) => {
-            failed.push(request);
-        },
-    });
-
-    await cheerioCrawler.run([
-        {
-            url: `${url}`,
-            method: 'DELETE',
-        },
-    ]);
-
-    expect(failed).toHaveLength(0);
-});
-
-test('should retry on 403 even with disallowed content-type', async () => {
-    const succeeded: any[] = [];
-
-    const crawler = new HttpCrawler({
-        maxConcurrency: 1,
-        maxRequestRetries: 1,
-        preNavigationHooks: [
-            async ({ request }) => {
-                // mock 403 response with octet stream on first request attempt, but not on
-                // subsequent retries, so the request should eventually succeed
-                if (request.retryCount === 0) {
-                    request.url = `${url}/403-with-octet-stream`;
-                } else {
-                    request.url = url;
+                if (str !== '') {
+                    results.push(JSON.parse(str));
                 }
             },
-        ],
-        requestHandler: async ({ request }) => {
-            succeeded.push(request);
-        },
+        });
+
+        await crawler.run([`${url}/redirectWithoutCookies`]);
+
+        expect(results).toStrictEqual([]);
     });
 
-    await crawler.run([url]);
+    test('no empty cookie header', async () => {
+        const results: string[] = [];
 
-    expect(succeeded).toHaveLength(1);
-    expect(succeeded[0].retryCount).toBe(1);
-});
-
-test('should work with cacheable-request', async () => {
-    const isFromCache: Record<string, boolean> = {};
-    const cache = new Map();
-    const crawler = new HttpCrawler({
-        maxConcurrency: 1,
-        preNavigationHooks: [
-            async (_, gotOptions) => {
-                gotOptions.cache = cache;
-                gotOptions.headers = {
-                    ...gotOptions.headers,
-                    // to force cache
-                    'cache-control': 'max-stale',
-                };
+        const crawler = new HttpCrawler({
+            httpClient,
+            sessionPoolOptions: {
+                maxPoolSize: 1,
             },
-        ],
-        requestHandler: async ({ request, response }) => {
-            isFromCache[request.uniqueKey] = response.isFromCache;
-        },
-    });
-    await crawler.run([
-        { url, uniqueKey: 'first' },
-        { url, uniqueKey: 'second' },
-    ]);
-    expect(isFromCache).toEqual({ first: false, second: true });
-});
+            handlePageFunction: async ({ body }) => {
+                const str = body.toString();
 
-test('works with a custom HttpClient', async () => {
-    const results: string[] = [];
-
-    const crawler = new HttpCrawler({
-        maxRequestRetries: 0,
-        requestHandler: async ({ body, sendRequest }) => {
-            results.push(body as string);
-
-            results.push((await sendRequest()).body);
-        },
-        httpClient: {
-            async sendRequest(request) {
-                if (request.responseType !== 'text') {
-                    throw new Error('Not implemented');
+                if (str !== '') {
+                    results.push(JSON.parse(str));
                 }
-
-                return {
-                    body: 'Hello from sendRequest()' as any,
-                    request,
-                    url,
-                    redirectUrls: [],
-                    statusCode: 200,
-                    headers: {},
-                    trailers: {},
-                    complete: true,
-                };
             },
-            async stream(request) {
-                const stream = new Readable();
-                stream.push('<html><head><title>Schmexample Domain</title></head></html>');
-                stream.push(null);
+        });
 
-                return {
-                    stream,
-                    downloadProgress: { percent: 100, transferred: 0 },
-                    uploadProgress: { percent: 100, transferred: 0 },
-                    request,
-                    url,
-                    redirectUrls: [],
-                    statusCode: 200,
-                    headers: { 'content-type': 'text/html; charset=utf-8' },
-                    trailers: {},
-                    complete: true,
-                };
-            },
-        },
+        await crawler.run([`${url}/cookies`]);
+
+        expect(results).toStrictEqual([]);
     });
 
-    await crawler.run([url]);
+    test('POST with undefined (empty) payload', async () => {
+        const results: string[] = [];
 
-    expect(results[0].includes('Schmexample Domain')).toBeTruthy();
-    expect(results[1].includes('Hello')).toBeTruthy();
+        const crawler = new HttpCrawler({
+            httpClient,
+            handlePageFunction: async ({ body }) => {
+                results.push(body.toString());
+            },
+        });
+
+        await crawler.run([
+            {
+                url: `${url}/echo`,
+                payload: undefined,
+                method: 'POST',
+            },
+        ]);
+
+        expect(results).toStrictEqual(['']);
+    });
+
+    test('should ignore http error status codes set by user', async () => {
+        const failed: any[] = [];
+
+        const crawler = new HttpCrawler({
+            httpClient,
+            minConcurrency: 2,
+            maxConcurrency: 2,
+            ignoreHttpErrorStatusCodes: [500],
+            requestHandler: () => {},
+            failedRequestHandler: ({ request }) => {
+                failed.push(request);
+            },
+        });
+
+        await crawler.run([`${url}/500Error`]);
+
+        expect(crawler.autoscaledPool!.minConcurrency).toBe(2);
+        expect(failed).toHaveLength(0);
+    });
+
+    test('should throw an error on http error status codes set by user', async () => {
+        const failed: any[] = [];
+
+        const crawler = new HttpCrawler({
+            httpClient,
+            minConcurrency: 2,
+            maxConcurrency: 2,
+            additionalHttpErrorStatusCodes: [200],
+            requestHandler: () => {},
+            failedRequestHandler: ({ request }) => {
+                failed.push(request);
+            },
+        });
+
+        await crawler.run([`${url}/hello.html`]);
+
+        expect(crawler.autoscaledPool!.minConcurrency).toBe(2);
+        expect(failed).toHaveLength(1);
+    });
+
+    test('should work with delete requests', async () => {
+        const failed: any[] = [];
+
+        const cheerioCrawler = new HttpCrawler({
+            httpClient,
+            maxConcurrency: 1,
+            maxRequestRetries: 0,
+            navigationTimeoutSecs: 5,
+            requestHandlerTimeoutSecs: 5,
+            requestHandler: async () => {},
+            failedRequestHandler: async ({ request }) => {
+                failed.push(request);
+            },
+        });
+
+        await cheerioCrawler.run([
+            {
+                url: `${url}`,
+                method: 'DELETE',
+            },
+        ]);
+
+        expect(failed).toHaveLength(0);
+    });
+
+    test('should retry on 403 even with disallowed content-type', async () => {
+        const succeeded: any[] = [];
+
+        const crawler = new HttpCrawler({
+            httpClient,
+            maxConcurrency: 1,
+            maxRequestRetries: 1,
+            preNavigationHooks: [
+                async ({ request }) => {
+                    // mock 403 response with octet stream on first request attempt, but not on
+                    // subsequent retries, so the request should eventually succeed
+                    if (request.retryCount === 0) {
+                        request.url = `${url}/403-with-octet-stream`;
+                    } else {
+                        request.url = url;
+                    }
+                },
+            ],
+            requestHandler: async ({ request }) => {
+                succeeded.push(request);
+            },
+        });
+
+        await crawler.run([url]);
+
+        expect(succeeded).toHaveLength(1);
+        expect(succeeded[0].retryCount).toBe(1);
+    });
+
+    test('should work with cacheable-request', async () => {
+        const isFromCache: Record<string, boolean> = {};
+        const cache = new Map();
+        const crawler = new HttpCrawler({
+            httpClient,
+            maxConcurrency: 1,
+            preNavigationHooks: [
+                async (_, gotOptions) => {
+                    gotOptions.cache = cache;
+                    gotOptions.headers = {
+                        ...gotOptions.headers,
+                        // to force cache
+                        'cache-control': 'max-stale',
+                    };
+                },
+            ],
+            requestHandler: async ({ request, response }) => {
+                isFromCache[request.uniqueKey] = response.isFromCache;
+            },
+        });
+        await crawler.run([
+            { url, uniqueKey: 'first' },
+            { url, uniqueKey: 'second' },
+        ]);
+        expect(isFromCache).toEqual({ first: false, second: true });
+    });
+
+    test('works with a custom HttpClient', async () => {
+        const results: string[] = [];
+
+        const crawler = new HttpCrawler({
+            maxRequestRetries: 0,
+            requestHandler: async ({ body, sendRequest }) => {
+                results.push(body as string);
+
+                results.push((await sendRequest()).body);
+            },
+            httpClient: {
+                async sendRequest(request) {
+                    if (request.responseType !== 'text') {
+                        throw new Error('Not implemented');
+                    }
+
+                    return {
+                        body: 'Hello from sendRequest()' as any,
+                        request,
+                        url,
+                        redirectUrls: [],
+                        statusCode: 200,
+                        headers: {},
+                        trailers: {},
+                        complete: true,
+                    };
+                },
+                async stream(request) {
+                    const stream = new Readable();
+                    stream.push('<html><head><title>Schmexample Domain</title></head></html>');
+                    stream.push(null);
+
+                    return {
+                        stream,
+                        downloadProgress: { percent: 100, transferred: 0 },
+                        uploadProgress: { percent: 100, transferred: 0 },
+                        request,
+                        url,
+                        redirectUrls: [],
+                        statusCode: 200,
+                        headers: { 'content-type': 'text/html; charset=utf-8' },
+                        trailers: {},
+                        complete: true,
+                    };
+                },
+            },
+        });
+
+        await crawler.run([url]);
+
+        expect(results[0].includes('Schmexample Domain')).toBeTruthy();
+        expect(results[1].includes('Hello')).toBeTruthy();
+    });
 });

--- a/test/core/crawlers/http_crawler.test.ts
+++ b/test/core/crawlers/http_crawler.test.ts
@@ -3,8 +3,8 @@ import type { AddressInfo } from 'node:net';
 import { Readable } from 'node:stream';
 
 import { GotScrapingHttpClient, HttpCrawler } from '@crawlee/http';
-import { MemoryStorageEmulator } from 'test/shared/MemoryStorageEmulator';
 import { ImpitHttpClient } from '@crawlee/impit-client';
+import { MemoryStorageEmulator } from 'test/shared/MemoryStorageEmulator';
 
 const router = new Map<string, http.RequestListener>();
 router.set('/', (req, res) => {

--- a/test/core/crawlers/http_crawler.test.ts
+++ b/test/core/crawlers/http_crawler.test.ts
@@ -392,7 +392,7 @@ describe.each([new GotScrapingHttpClient(), new ImpitHttpClient()])('HttpCrawler
         expect(succeeded[0].retryCount).toBe(1);
     });
 
-    test('should work with cacheable-request', async () => {
+    test.skipIf(httpClient instanceof ImpitHttpClient)('should work with cacheable-request', async () => {
         const isFromCache: Record<string, boolean> = {};
         const cache = new Map();
         const crawler = new HttpCrawler({

--- a/yarn.lock
+++ b/yarn.lock
@@ -623,6 +623,7 @@ __metadata:
     "@apify/datastructures": "npm:^2.0.3"
     "@crawlee/core": "npm:^3.13.5"
     impit: "npm:^0.4.3"
+    tough-cookie: "npm:^5.1.2"
   peerDependencies:
     "@crawlee/core": ^3.12.1
   languageName: unknown
@@ -12752,7 +12753,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tough-cookie@npm:^5.0.0, tough-cookie@npm:^5.1.1":
+"tough-cookie@npm:^5.0.0, tough-cookie@npm:^5.1.1, tough-cookie@npm:^5.1.2":
   version: 5.1.2
   resolution: "tough-cookie@npm:5.1.2"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -622,7 +622,7 @@ __metadata:
   dependencies:
     "@apify/datastructures": "npm:^2.0.3"
     "@crawlee/core": "npm:^3.13.5"
-    impit: "npm:^0.4.3"
+    impit: "npm:^0.5.0"
     tough-cookie: "npm:^5.1.2"
   peerDependencies:
     "@crawlee/core": ^3.12.1
@@ -7409,9 +7409,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"impit-darwin-arm64@npm:0.5.0":
+  version: 0.5.0
+  resolution: "impit-darwin-arm64@npm:0.5.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "impit-darwin-x64@npm:0.4.7":
   version: 0.4.7
   resolution: "impit-darwin-x64@npm:0.4.7"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"impit-darwin-x64@npm:0.5.0":
+  version: 0.5.0
+  resolution: "impit-darwin-x64@npm:0.5.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -7423,9 +7437,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"impit-linux-arm64-gnu@npm:0.5.0":
+  version: 0.5.0
+  resolution: "impit-linux-arm64-gnu@npm:0.5.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "impit-linux-arm64-musl@npm:0.4.7":
   version: 0.4.7
   resolution: "impit-linux-arm64-musl@npm:0.4.7"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"impit-linux-arm64-musl@npm:0.5.0":
+  version: 0.5.0
+  resolution: "impit-linux-arm64-musl@npm:0.5.0"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
@@ -7437,9 +7465,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"impit-linux-x64-gnu@npm:0.5.0":
+  version: 0.5.0
+  resolution: "impit-linux-x64-gnu@npm:0.5.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "impit-linux-x64-musl@npm:0.4.7":
   version: 0.4.7
   resolution: "impit-linux-x64-musl@npm:0.4.7"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"impit-linux-x64-musl@npm:0.5.0":
+  version: 0.5.0
+  resolution: "impit-linux-x64-musl@npm:0.5.0"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
@@ -7451,6 +7493,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"impit-win32-arm64-msvc@npm:0.5.0":
+  version: 0.5.0
+  resolution: "impit-win32-arm64-msvc@npm:0.5.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "impit-win32-x64-msvc@npm:0.4.7":
   version: 0.4.7
   resolution: "impit-win32-x64-msvc@npm:0.4.7"
@@ -7458,7 +7507,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"impit@npm:^0.4.3, impit@npm:^0.4.6":
+"impit-win32-x64-msvc@npm:0.5.0":
+  version: 0.5.0
+  resolution: "impit-win32-x64-msvc@npm:0.5.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"impit@npm:^0.4.6":
   version: 0.4.7
   resolution: "impit@npm:0.4.7"
   dependencies:
@@ -7488,6 +7544,39 @@ __metadata:
     impit-win32-x64-msvc:
       optional: true
   checksum: 10c0/d0037f55f6b6d577fb0f2d4474a8b892e48216e9bc5a32bbe9925bc985c32d3074919e6c041266b66b94248dd50ea62b8b2aa96f9b5ab9689b9164ae0fcabff8
+  languageName: node
+  linkType: hard
+
+"impit@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "impit@npm:0.5.0"
+  dependencies:
+    impit-darwin-arm64: "npm:0.5.0"
+    impit-darwin-x64: "npm:0.5.0"
+    impit-linux-arm64-gnu: "npm:0.5.0"
+    impit-linux-arm64-musl: "npm:0.5.0"
+    impit-linux-x64-gnu: "npm:0.5.0"
+    impit-linux-x64-musl: "npm:0.5.0"
+    impit-win32-arm64-msvc: "npm:0.5.0"
+    impit-win32-x64-msvc: "npm:0.5.0"
+  dependenciesMeta:
+    impit-darwin-arm64:
+      optional: true
+    impit-darwin-x64:
+      optional: true
+    impit-linux-arm64-gnu:
+      optional: true
+    impit-linux-arm64-musl:
+      optional: true
+    impit-linux-x64-gnu:
+      optional: true
+    impit-linux-x64-musl:
+      optional: true
+    impit-win32-arm64-msvc:
+      optional: true
+    impit-win32-x64-msvc:
+      optional: true
+  checksum: 10c0/d4ded2bab33ffb5593769ac608f297990abb1ccfc3a73b64dd328b35e561eb2b89d8eacf695185914935f36300374ba9a1bda7faf5bbca4a26308711c1eb146f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Runs the `HttpCrawler` tests with both `HttpClient` implementations (`GotScrapingHttpClient`, `ImpitHttpClient`). 

Improves cookie store integration for `ImpitHttpClient`.