### PR TITLE
feat: implement `IRequestList.chain()`

### DIFF
--- a/packages/core/src/storages/sitemap_request_list.ts
+++ b/packages/core/src/storages/sitemap_request_list.ts
@@ -566,6 +566,10 @@ export class SitemapRequestList implements IRequestList {
         return this.requestData.get(nextUrl)!;
     }
 
+    chain() {
+        return this;
+    }
+
     /**
      * @inheritDoc
      */

--- a/test/core/request_list.test.ts
+++ b/test/core/request_list.test.ts
@@ -163,6 +163,29 @@ describe('RequestList', () => {
         }
     });
 
+    test('chaining works', async () => {
+        const sources = [
+            'https://example.com/1',
+            'https://example.com/2',
+            'https://example.com/3',
+            'https://example.com/4',
+            'https://example.com/5',
+            'https://example.com/6',
+            'https://example.com/7',
+            'https://example.com/8',
+        ];
+        const requestList = (await RequestList.open(null, sources.slice(0, 4)))
+            .chain(await RequestList.open(null, sources.slice(4, 6)))
+            .chain([
+                await RequestList.open(null, sources.slice(6, 7)),
+                await RequestList.open(null, sources.slice(7, 8)),
+            ]);
+
+        for await (const request of requestList) {
+            expect(request?.url).toBe(sources.shift());
+        }
+    });
+
     test('should correctly load list from hosted files in correct order', async () => {
         const spy = vitest.spyOn(RequestList.prototype as any, '_downloadListOfUrls');
         const list1 = ['https://example.com', 'https://google.com', 'https://wired.com'];


### PR DESCRIPTION
Adds `.chain()` method for `IRequestList`. 

`requestList.chain(requestList2)` combines the lists so that repeated calls to `requestList.fetchNextRequest` will return all requests from `requestList` and then also all requests of `requestList2`.

Chaining can be done on an existing request list instance (also one registered in a crawler instance).

todo:

- `.chain()` calls should be idempotent (hashing the parameter?)
- Implement `.chain()` for `SitemapRequestList` (required for WCC use case)
- better docs, explain that for fully dynamic use cases, `RequestQueue` is a better choice
- test different persistence scenarios