### PR TITLE
fix: use merged cookies correctly in `GotScrapingHttpClient`

### DIFF
--- a/packages/core/src/http_clients/got-scraping-http-client.ts
+++ b/packages/core/src/http_clients/got-scraping-http-client.ts
@@ -23,6 +23,9 @@ export class GotScrapingHttpClient implements BaseHttpClient {
     ): Promise<HttpResponse<TResponseType>> {
         const gotResult = await gotScraping({
             ...request,
+            // `HttpCrawler` reads the cookies beforehand and sets them in `request.gotOptions`.
+            // Using the `cookieJar` option directly would override that.
+            cookieJar: undefined,
             retry: {
                 limit: 0,
                 ...(request.retry as Record<string, unknown> | undefined),
@@ -42,7 +45,7 @@ export class GotScrapingHttpClient implements BaseHttpClient {
     async stream(request: HttpRequest, handleRedirect?: RedirectHandler): Promise<StreamingHttpResponse> {
         // eslint-disable-next-line no-async-promise-executor
         return new Promise(async (resolve, reject) => {
-            const stream = await Promise.resolve(gotScraping({ ...request, isStream: true }));
+            const stream = await Promise.resolve(gotScraping({ ...request, isStream: true, cookieJar: undefined }));
 
             stream.on('redirect', (updatedOptions: Options, redirectResponse: PlainResponse) => {
                 handleRedirect?.(redirectResponse, updatedOptions);


### PR DESCRIPTION
Fixes a regression from #2991 . Passing the `CookieJar` instance directly to `GotScrapingHttpClient` caused got to only use the `CookieJar` cookies, discarding `headers` and `gotOptions` cookies.

This broke the `cheerio-initial-cookies` [e2e test](https://github.com/apify/crawlee/actions/runs/15481489734/job/43599601808#step:12:95).

As mentioned in [comments](https://github.com/apify/crawlee/pull/2991#discussion_r2128689930) under #2991, the cookie management interface is quite unintuitive and should be redesigned for the v4 release.