### PR TITLE
feat: Accept (Async)Iterables in `addRequests` methods

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -1131,7 +1131,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
             }
         }
 
-        const result = requestQueue.addRequestsBatched(filteredRequests(), options);
+        const result = await requestQueue.addRequestsBatched(filteredRequests(), options);
 
         if (skippedBecauseOfRobots.size > 0) {
             this.log.warning(`Some requests were skipped because they were disallowed based on the robots.txt file`, {

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -1110,7 +1110,6 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
         const skippedBecauseOfLimit = new Set<string>();
 
         const isAllowedBasedOnRobotsTxtFile = this.isAllowedBasedOnRobotsTxtFile.bind(this);
-        const handleSkippedRequest = this.handleSkippedRequest.bind(this);
 
         async function* filteredRequests() {
             let yieldedRequestCount = 0;
@@ -1128,7 +1127,6 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
                     yieldedRequestCount += 1;
                 } else {
                     skippedBecauseOfRobots.add(url);
-                    await handleSkippedRequest({ url, reason: 'robotsTxt' });
                 }
             }
         }

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -22,7 +22,6 @@ import type {
     Session,
     SessionPoolOptions,
     SkippedRequestCallback,
-    Source,
     StatisticsOptions,
     StatisticState,
 } from '@crawlee/core';

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -50,7 +50,7 @@ import {
     validators,
 } from '@crawlee/core';
 import type { Awaitable, BatchAddRequestsResult, Dictionary, SetStatusMessageOptions } from '@crawlee/types';
-import { asyncifyIterable, RobotsTxtFile, ROTATE_PROXY_ERRORS } from '@crawlee/utils';
+import { RobotsTxtFile, ROTATE_PROXY_ERRORS } from '@crawlee/utils';
 import { stringify } from 'csv-stringify/sync';
 import { ensureDir, writeFile, writeJSON } from 'fs-extra';
 import ow, { ArgumentError } from 'ow';
@@ -1115,7 +1115,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
         async function* filteredRequests() {
             let yieldedRequestCount = 0;
 
-            for await (const request of asyncifyIterable(requests)) {
+            for await (const request of requests) {
                 const url = typeof request === 'string' ? request : request.url!;
 
                 if (requestLimit !== undefined && yieldedRequestCount >= requestLimit) {

--- a/packages/core/src/storages/request_provider.ts
+++ b/packages/core/src/storages/request_provider.ts
@@ -36,7 +36,7 @@ import type { IStorage, StorageManagerOptions } from './storage_manager';
 import { StorageManager } from './storage_manager';
 import { getRequestId, purgeDefaultStorages, QUERY_HEAD_MIN_LENGTH } from './utils';
 
-export type RequestsLike = AsyncIterable<Source | string> | Iterable<Source | string> | Array<Source | string>;
+export type RequestsLike = AsyncIterable<Source | string> | Iterable<Source | string> | (Source | string)[];
 
 export abstract class RequestProvider implements IStorage {
     id: string;

--- a/packages/core/src/storages/request_provider.ts
+++ b/packages/core/src/storages/request_provider.ts
@@ -10,7 +10,6 @@ import type {
     StorageClient,
 } from '@crawlee/types';
 import {
-    asyncifyIterable,
     chunkedAsyncIterable,
     downloadListOfUrls,
     isAsyncIterable,
@@ -252,7 +251,7 @@ export abstract class RequestProvider implements IStorage {
 
         const requests: Request<Dictionary>[] = [];
 
-        for await (const requestLike of asyncifyIterable(requestsLike)) {
+        for await (const requestLike of requestsLike) {
             if (typeof requestLike === 'string') {
                 requests.push(new Request({ url: requestLike }));
             } else if ('requestsFromUrl' in requestLike) {
@@ -350,7 +349,7 @@ export abstract class RequestProvider implements IStorage {
         const addRequest = this.addRequest.bind(this);
 
         async function* generateRequests() {
-            for await (const opts of asyncifyIterable(requests)) {
+            for await (const opts of requests) {
                 // Validate the input
                 if (typeof opts === 'object' && opts !== null) {
                     if (opts.url !== undefined && typeof opts.url !== 'string') {

--- a/packages/core/src/storages/request_provider.ts
+++ b/packages/core/src/storages/request_provider.ts
@@ -351,9 +351,7 @@ export abstract class RequestProvider implements IStorage {
 
         async function* generateRequests() {
             for await (const opts of asyncifyIterable(requests)) {
-                // The `requests` array can be huge, and `ow` is very slow for anything more complex.
-                // This handwritten check takes a few milliseconds, while the ow check can take tens of seconds.
-
+                // Validate the input
                 if (typeof opts === 'object' && opts !== null) {
                     if (opts.url !== undefined && typeof opts.url !== 'string') {
                         throw new Error(
@@ -378,8 +376,10 @@ export abstract class RequestProvider implements IStorage {
                 }
 
                 if (opts && typeof opts === 'object' && 'requestsFromUrl' in opts) {
+                    // Handle URL lists right away
                     await addRequest(opts, { forefront: options.forefront });
                 } else {
+                    // Yield valid requests
                     yield typeof opts === 'string' ? { url: opts } : (opts as RequestOptions);
                 }
             }

--- a/packages/core/src/storages/request_provider.ts
+++ b/packages/core/src/storages/request_provider.ts
@@ -421,7 +421,7 @@ export abstract class RequestProvider implements IStorage {
         await chunksIterator.next();
 
         // If we have no more requests to add, return immediately
-        if (chunksIterator.peek() === undefined) {
+        if ((await chunksIterator.peek()) === undefined) {
             return {
                 addedRequests,
                 waitForAllRequestsToBeAdded: Promise.resolve([]),

--- a/packages/core/src/storages/request_provider.ts
+++ b/packages/core/src/storages/request_provider.ts
@@ -355,7 +355,7 @@ export abstract class RequestProvider implements IStorage {
                 // This handwritten check takes a few milliseconds, while the ow check can take tens of seconds.
 
                 if (typeof opts === 'object' && opts !== null) {
-                    if (typeof opts.url !== 'string' || typeof opts.id !== 'undefined') {
+                    if (opts.url !== undefined && typeof opts.url !== 'string') {
                         throw new Error(
                             `Request options are not valid, the 'url' property is not a string. Input: ${inspect(opts)}`,
                         );
@@ -367,17 +367,20 @@ export abstract class RequestProvider implements IStorage {
                         );
                     }
 
-                    if (typeof (opts as any).requestsFromUrl !== 'string') {
+                    if (
+                        (opts as any).requestsFromUrl !== undefined &&
+                        typeof (opts as any).requestsFromUrl !== 'string'
+                    ) {
                         throw new Error(
                             `Request options are not valid, the 'requestsFromUrl' property is not a string. Input: ${inspect(opts)}`,
                         );
                     }
+                }
 
-                    if (opts && typeof opts === 'object' && 'requestsFromUrl' in opts) {
-                        await addRequest(opts, { forefront: options.forefront });
-                    } else {
-                        yield typeof opts === 'string' ? { url: opts } : (opts as RequestOptions);
-                    }
+                if (opts && typeof opts === 'object' && 'requestsFromUrl' in opts) {
+                    await addRequest(opts, { forefront: options.forefront });
+                } else {
+                    yield typeof opts === 'string' ? { url: opts } : (opts as RequestOptions);
                 }
             }
         }

--- a/packages/core/src/storages/request_queue_v2.ts
+++ b/packages/core/src/storages/request_queue_v2.ts
@@ -8,6 +8,7 @@ import type {
     RequestProviderOptions,
     RequestQueueOperationInfo,
     RequestQueueOperationOptions,
+    RequestsLike,
 } from './request_provider';
 import { RequestProvider } from './request_provider';
 import { getRequestId } from './utils';
@@ -124,7 +125,7 @@ export class RequestQueue extends RequestProvider {
      * @inheritDoc
      */
     override async addRequests(
-        requestsLike: Source[],
+        requestsLike: RequestsLike,
         options: RequestQueueOperationOptions = {},
     ): Promise<BatchAddRequestsResult> {
         const result = await super.addRequests(requestsLike, options);

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -9,6 +9,7 @@ export * as social from './internals/social';
 export * from './internals/typedefs';
 export * from './internals/open_graph_parser';
 export * from './internals/gotScraping';
+export * from './internals/iterables';
 export * from './internals/robots';
 export * from './internals/sitemap';
 export * from './internals/url';

--- a/packages/utils/src/internals/iterables.ts
+++ b/packages/utils/src/internals/iterables.ts
@@ -2,6 +2,7 @@ import { inspect } from 'node:util';
 
 /**
  * Type guard that checks if a value is iterable (has Symbol.iterator).
+ * @internal
  *
  * **Example usage:**
  * ```ts
@@ -26,6 +27,7 @@ export function isIterable<T>(value: unknown): value is Iterable<T> {
 
 /**
  * Type guard that checks if a value is async iterable (has Symbol.asyncIterator).
+ * @internal
  *
  * **Example usage:**
  * ```ts
@@ -46,6 +48,7 @@ export function isAsyncIterable<T>(value: unknown): value is AsyncIterable<T> {
 
 /**
  * Converts any iterable or async iterable to an async iterable.
+ * @internal
  *
  * @yields Each item from the input iterable
  *
@@ -65,6 +68,7 @@ export async function* asyncifyIterable<T>(iterable: Iterable<T> | AsyncIterable
  * Lazily splits the input async iterable into chunks of specified size.
  * The last chunk may contain fewer items if the total number of items
  * is not evenly divisible by the chunk size.
+ * @internal
  *
  * @yields Arrays of items, each containing up to chunkSize items
  *
@@ -106,6 +110,7 @@ export async function* chunkedAsyncIterable<T>(
 /**
  * An async iterator that also supports peeking at the next value without consuming it.
  * Extends both AsyncIterator and AsyncIterable interfaces.
+ * @internal
  */
 export interface PeekableAsyncIterator<T> extends AsyncIterator<T>, AsyncIterable<T> {
     /**
@@ -119,6 +124,7 @@ export interface PeekableAsyncIterator<T> extends AsyncIterator<T>, AsyncIterabl
 
 /**
  * An async iterable that yields peekable async iterators.
+ * @internal
  */
 export interface PeekableAsyncIterable<T> extends AsyncIterable<T> {
     [Symbol.asyncIterator](): PeekableAsyncIterator<T>;
@@ -127,6 +133,7 @@ export interface PeekableAsyncIterable<T> extends AsyncIterable<T> {
 /**
  * Wraps an async iterable to provide peek functionality, allowing you to look at
  * the next value without consuming it from the iterator.
+ * @internal
  *
  * @param iterable - The async iterable to make peekable
  *

--- a/packages/utils/src/internals/iterables.ts
+++ b/packages/utils/src/internals/iterables.ts
@@ -58,14 +58,7 @@ export function isAsyncIterable<T>(value: unknown): value is AsyncIterable<T> {
  * ```
  */
 export async function* asyncifyIterable<T>(iterable: Iterable<T> | AsyncIterable<T>): AsyncIterable<T> {
-    if (isAsyncIterable(iterable)) {
-        yield* iterable;
-        return;
-    }
-
-    for (const item of iterable) {
-        yield item;
-    }
+    yield* iterable;
 }
 
 /**
@@ -86,7 +79,10 @@ export async function* asyncifyIterable<T>(iterable: Iterable<T> | AsyncIterable
  * }
  * ```
  */
-export async function* chunkedAsyncIterable<T>(iterable: AsyncIterable<T>, chunkSize: number): AsyncIterable<T[]> {
+export async function* chunkedAsyncIterable<T>(
+    iterable: AsyncIterable<T> | Iterable<T>,
+    chunkSize: number,
+): AsyncIterable<T[]> {
     if (typeof chunkSize !== 'number' || chunkSize < 1) {
         throw new Error(`Chunk size must be a positive number (${inspect(chunkSize)}) received`);
     }
@@ -149,8 +145,8 @@ export interface PeekableAsyncIterable<T> extends AsyncIterable<T> {
  * console.log(await iterator.peek()); // 2 (next value)
  * ```
  */
-export function peekableAsyncIterable<T>(iterable: AsyncIterable<T>): PeekableAsyncIterable<T> {
-    const iterator = iterable[Symbol.asyncIterator]();
+export function peekableAsyncIterable<T>(iterable: AsyncIterable<T> | Iterable<T>): PeekableAsyncIterable<T> {
+    const iterator = asyncifyIterable(iterable)[Symbol.asyncIterator]();
     let peekedValue: { done: boolean; value: T } | undefined;
     let isExhausted = false;
 

--- a/packages/utils/src/internals/iterables.ts
+++ b/packages/utils/src/internals/iterables.ts
@@ -1,0 +1,215 @@
+import { inspect } from 'node:util';
+
+/**
+ * Type guard that checks if a value is iterable (has Symbol.iterator).
+ *
+ * **Example usage:**
+ * ```ts
+ * if (isIterable(someValue)) {
+ *   for (const item of someValue) {
+ *     console.log(item);
+ *   }
+ * }
+ * ```
+ */
+export function isIterable<T>(value: unknown): value is Iterable<T> {
+    if (value == null || typeof value === 'string' || ArrayBuffer.isView(value)) {
+        return false;
+    }
+
+    if (Array.isArray(value)) {
+        return true;
+    }
+
+    return typeof Object(value)[Symbol.iterator] === 'function';
+}
+
+/**
+ * Type guard that checks if a value is async iterable (has Symbol.asyncIterator).
+ *
+ * **Example usage:**
+ * ```ts
+ * if (isAsyncIterable(someValue)) {
+ *   for await (const item of someValue) {
+ *     console.log(item);
+ *   }
+ * }
+ * ```
+ */
+export function isAsyncIterable<T>(value: unknown): value is AsyncIterable<T> {
+    if (value == null || typeof value === 'string' || ArrayBuffer.isView(value)) {
+        return false;
+    }
+
+    return typeof Object(value)[Symbol.asyncIterator] === 'function';
+}
+
+/**
+ * Converts any iterable or async iterable to an async iterable.
+ *
+ * @yields Each item from the input iterable
+ *
+ * **Example usage:**
+ * ```ts
+ * const syncArray = [1, 2, 3];
+ * for await (const item of asyncifyIterable(syncArray)) {
+ *   console.log(item); // 1, 2, 3
+ * }
+ * ```
+ */
+export async function* asyncifyIterable<T>(iterable: Iterable<T> | AsyncIterable<T>): AsyncIterable<T> {
+    if (isAsyncIterable(iterable)) {
+        yield* iterable;
+        return;
+    }
+
+    for (const item of iterable) {
+        yield item;
+    }
+}
+
+/**
+ * Lazily splits the input async iterable into chunks of specified size.
+ * The last chunk may contain fewer items if the total number of items
+ * is not evenly divisible by the chunk size.
+ *
+ * @yields Arrays of items, each containing up to chunkSize items
+ *
+ * **Example usage:**
+ * ```ts
+ * const numbers = async function* () {
+ *   for (let i = 1; i <= 10; i++) yield i;
+ * };
+ *
+ * for await (const chunk of chunkedAsyncIterable(numbers(), 3)) {
+ *   console.log(chunk); // [1, 2, 3], [4, 5, 6], [7, 8, 9], [10]
+ * }
+ * ```
+ */
+export async function* chunkedAsyncIterable<T>(iterable: AsyncIterable<T>, chunkSize: number): AsyncIterable<T[]> {
+    if (typeof chunkSize !== 'number' || chunkSize < 1) {
+        throw new Error(`Chunk size must be a positive number (${inspect(chunkSize)}) received`);
+    }
+
+    let chunk: T[] = [];
+
+    for await (const item of iterable) {
+        chunk.push(item);
+
+        if (chunk.length >= chunkSize) {
+            yield chunk;
+            chunk = [];
+        }
+    }
+
+    if (chunk.length) {
+        yield chunk;
+    }
+}
+
+/**
+ * An async iterator that also supports peeking at the next value without consuming it.
+ * Extends both AsyncIterator and AsyncIterable interfaces.
+ */
+export interface PeekableAsyncIterator<T> extends AsyncIterator<T>, AsyncIterable<T> {
+    /**
+     * Peeks at the next value without consuming it from the iterator.
+     * Subsequent calls to peek() will return the same value until next() is called.
+     *
+     * @returns Promise that resolves to the next value, or undefined if the iterator is exhausted
+     */
+    peek(): Promise<T | undefined>;
+}
+
+/**
+ * An async iterable that yields peekable async iterators.
+ */
+export interface PeekableAsyncIterable<T> extends AsyncIterable<T> {
+    [Symbol.asyncIterator](): PeekableAsyncIterator<T>;
+}
+
+/**
+ * Wraps an async iterable to provide peek functionality, allowing you to look at
+ * the next value without consuming it from the iterator.
+ *
+ * @param iterable - The async iterable to make peekable
+ *
+ * **Example usage:**
+ * ```ts
+ * const numbers = async function* () {
+ *   yield 1; yield 2; yield 3;
+ * };
+ *
+ * const peekable = peekableAsyncIterable(numbers());
+ * const iterator = peekable[Symbol.asyncIterator]();
+ *
+ * console.log(await iterator.peek()); // 1 (doesn't consume)
+ * console.log(await iterator.peek()); // 1 (still doesn't consume)
+ * console.log(await iterator.next()); // { value: 1, done: false } (now consumed)
+ * console.log(await iterator.peek()); // 2 (next value)
+ * ```
+ */
+export function peekableAsyncIterable<T>(iterable: AsyncIterable<T>): PeekableAsyncIterable<T> {
+    const iterator = iterable[Symbol.asyncIterator]();
+    let peekedValue: { done: boolean; value: T } | undefined;
+    let isExhausted = false;
+
+    const peekableIterator: PeekableAsyncIterator<T> = {
+        async next(): Promise<IteratorResult<T>> {
+            // If we have peeked a value, return it and clear the peek
+            if (peekedValue !== undefined) {
+                const result = peekedValue;
+                peekedValue = undefined;
+
+                if (result.done) {
+                    isExhausted = true;
+                    return { done: true, value: undefined };
+                }
+
+                return { done: false, value: result.value };
+            }
+
+            if (isExhausted) {
+                return { done: true, value: undefined };
+            }
+
+            const result = await iterator.next();
+
+            if (result.done) {
+                isExhausted = true;
+            }
+
+            return result;
+        },
+
+        async peek(): Promise<T | undefined> {
+            if (peekedValue !== undefined) {
+                return peekedValue.done ? undefined : peekedValue.value;
+            }
+
+            if (isExhausted) {
+                return undefined;
+            }
+
+            const result = await iterator.next();
+            peekedValue = { done: result.done ?? false, value: result.value };
+
+            if (result.done) {
+                isExhausted = true;
+                return undefined;
+            }
+
+            return result.value;
+        },
+
+        [Symbol.asyncIterator]() {
+            return this;
+        },
+    };
+
+    return {
+        [Symbol.asyncIterator]() {
+            return peekableIterator;
+        },
+    };
+}

--- a/test/core/enqueue_links/click_elements.test.ts
+++ b/test/core/enqueue_links/click_elements.test.ts
@@ -2,7 +2,6 @@ import type { Server } from 'node:http';
 
 import type { RequestQueueOperationOptions, Source } from 'crawlee';
 import {
-    asyncifyIterable,
     Configuration,
     launchPlaywright,
     launchPuppeteer,
@@ -118,7 +117,7 @@ testCases.forEach(({ caseName, launchBrowser, clickElements, utils }) => {
             const addedRequests: { request: Source; options?: RequestQueueOperationOptions }[] = [];
             const requestQueue = new RequestQueue({ id: 'xxx', client: Configuration.getStorageClient() });
             requestQueue.addRequests = async (requests, options) => {
-                for await (const request of asyncifyIterable(requests)) {
+                for await (const request of requests) {
                     addedRequests.push({ request: typeof request === 'string' ? { url: request } : request, options });
                 }
                 return { processedRequests: [], unprocessedRequests: [] };

--- a/test/core/enqueue_links/enqueue_links.test.ts
+++ b/test/core/enqueue_links/enqueue_links.test.ts
@@ -8,7 +8,7 @@ import {
     launchPuppeteer,
     RequestQueue,
 } from '@crawlee/puppeteer';
-import { asyncifyIterable, type CheerioRoot } from '@crawlee/utils';
+import { type CheerioRoot } from '@crawlee/utils';
 import { load } from 'cheerio';
 import type { Browser as PlaywrightBrowser, Page as PlaywrightPage } from 'playwright';
 import type { Browser as PuppeteerBrowser, Page as PuppeteerPage } from 'puppeteer';
@@ -51,7 +51,7 @@ function createRequestQueueMock() {
     // @ts-expect-error Override method for testing
     requestQueue.addRequests = async function (requests) {
         const processedRequests: Source[] = [];
-        for await (const request of asyncifyIterable(requests)) {
+        for await (const request of requests) {
             processedRequests.push(typeof request === 'string' ? { url: request } : request);
         }
         enqueued.push(...processedRequests);
@@ -976,7 +976,7 @@ describe('enqueueLinks()', () => {
             requestQueue.addRequests = async (requests, options) => {
                 // copy the requests to the enqueued list, along with options that were passed to addRequests,
                 // so that it doesn't matter how many calls were made
-                for await (const request of asyncifyIterable(requests)) {
+                for await (const request of requests) {
                     enqueued.push({ request: typeof request === 'string' ? { url: request } : request, options });
                 }
                 return { processedRequests: [], unprocessedRequests: [] };
@@ -1005,7 +1005,7 @@ describe('enqueueLinks()', () => {
             requestQueue.addRequestsBatched = async (requests, options) => {
                 // copy the requests to the enqueued list, along with options that were passed to addRequests,
                 // so that it doesn't matter how many calls were made
-                for await (const request of asyncifyIterable(requests)) {
+                for await (const request of requests) {
                     enqueued.push({ request: typeof request === 'string' ? { url: request } : request, options });
                 }
                 return { addedRequests: [], waitForAllRequestsToBeAdded: Promise.resolve([]) };

--- a/test/utils/iterables.test.ts
+++ b/test/utils/iterables.test.ts
@@ -55,10 +55,8 @@ describe('asyncifyIterable', () => {
 
 describe('chunkedAsyncIterable', () => {
     it('should chunk an async iterable into specified sizes', async () => {
-        const asyncIterable = asyncifyIterable([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-
         const result = [];
-        for await (const chunk of chunkedAsyncIterable(asyncIterable, 3)) {
+        for await (const chunk of chunkedAsyncIterable([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3)) {
             result.push(chunk);
         }
 
@@ -66,10 +64,8 @@ describe('chunkedAsyncIterable', () => {
     });
 
     it('should handle chunk size of 1', async () => {
-        const asyncIterable = asyncifyIterable([1, 2, 3]);
-
         const result = [];
-        for await (const chunk of chunkedAsyncIterable(asyncIterable, 1)) {
+        for await (const chunk of chunkedAsyncIterable([1, 2, 3], 1)) {
             result.push(chunk);
         }
 
@@ -77,8 +73,7 @@ describe('chunkedAsyncIterable', () => {
     });
 
     it('should handle chunk size larger than input', async () => {
-        const asyncIterable = asyncifyIterable([1, 2, 3]);
-        const chunked = chunkedAsyncIterable(asyncIterable, 10);
+        const chunked = chunkedAsyncIterable([1, 2, 3], 10);
 
         const result = [];
         for await (const chunk of chunked) {
@@ -89,10 +84,8 @@ describe('chunkedAsyncIterable', () => {
     });
 
     it('should handle empty async iterable', async () => {
-        const asyncIterable = asyncifyIterable([]);
-
         const result = [];
-        for await (const chunk of chunkedAsyncIterable(asyncIterable, 3)) {
+        for await (const chunk of chunkedAsyncIterable([], 3)) {
             result.push(chunk);
         }
 
@@ -100,19 +93,16 @@ describe('chunkedAsyncIterable', () => {
     });
 
     it('should throw error for invalid chunk size', async () => {
-        const input = [1, 2, 3];
-        const asyncIterable = asyncifyIterable(input);
-
         await expect(
             (async () => {
-                for await (const _ of chunkedAsyncIterable(asyncIterable, 0)) {
+                for await (const _ of chunkedAsyncIterable([1, 2, 3], 0)) {
                     // Empty block
                 }
             })(),
         ).rejects.toThrow();
         await expect(
             (async () => {
-                for await (const _ of chunkedAsyncIterable(asyncIterable, -1)) {
+                for await (const _ of chunkedAsyncIterable([1, 2, 3], -1)) {
                     // Empty block
                 }
             })(),
@@ -122,7 +112,7 @@ describe('chunkedAsyncIterable', () => {
 
 describe('peekableAsyncIterable', () => {
     it('should allow peeking at the next value without advancing', async () => {
-        const iterable = peekableAsyncIterable(asyncifyIterable([1, 2, 3]));
+        const iterable = peekableAsyncIterable([1, 2, 3]);
         const iterator = iterable[Symbol.asyncIterator]();
 
         const peeked = await iterator.peek();
@@ -142,7 +132,7 @@ describe('peekableAsyncIterable', () => {
     });
 
     it('should return undefined when peeking at empty iterable', async () => {
-        const iterable = peekableAsyncIterable(asyncifyIterable([]));
+        const iterable = peekableAsyncIterable([]);
         const iterator = iterable[Symbol.asyncIterator]();
 
         const peeked = await iterator.peek();
@@ -150,7 +140,7 @@ describe('peekableAsyncIterable', () => {
     });
 
     it('should handle peek after exhausting the iterable', async () => {
-        const iterable = peekableAsyncIterable(asyncifyIterable([1]));
+        const iterable = peekableAsyncIterable([1]);
 
         // Consume the iterable
         const results = [];
@@ -166,7 +156,7 @@ describe('peekableAsyncIterable', () => {
     });
 
     it('should work with manual iteration', async () => {
-        const iterable = peekableAsyncIterable(asyncifyIterable([10, 20, 30]));
+        const iterable = peekableAsyncIterable([10, 20, 30]);
         const iterator = iterable[Symbol.asyncIterator]();
 
         // Peek first
@@ -193,7 +183,7 @@ describe('peekableAsyncIterable', () => {
     });
 
     it('should handle peek on single element iterable', async () => {
-        const iterable = peekableAsyncIterable(asyncifyIterable([42]));
+        const iterable = peekableAsyncIterable([42]);
         const iterator = iterable[Symbol.asyncIterator]();
 
         expect(await iterator.peek()).toBe(42);

--- a/test/utils/iterables.test.ts
+++ b/test/utils/iterables.test.ts
@@ -1,0 +1,212 @@
+import { asyncifyIterable, chunkedAsyncIterable, peekableAsyncIterable } from '@crawlee/utils';
+import { describe, expect, it } from 'vitest';
+
+describe('asyncifyIterable', () => {
+    it('should convert a regular array to async iterable', async () => {
+        const asyncIterable = asyncifyIterable([1, 2, 3, 4, 5]);
+
+        const result = [];
+        for await (const item of asyncIterable) {
+            result.push(item);
+        }
+
+        expect(result).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it('should handle empty arrays', async () => {
+        const asyncIterable = asyncifyIterable([]);
+
+        const result: unknown[] = [];
+        for await (const item of asyncIterable) {
+            result.push(item);
+        }
+
+        expect(result).toEqual([]);
+    });
+
+    it('should work with Set', async () => {
+        const asyncIterable = asyncifyIterable(new Set([1, 2, 3, 2, 1]));
+
+        const result = [];
+        for await (const item of asyncIterable) {
+            result.push(item);
+        }
+
+        expect(result).toEqual([1, 2, 3]);
+    });
+
+    it('should work with generator function', async () => {
+        function* generator() {
+            yield 1;
+            yield 2;
+            yield 3;
+        }
+
+        const asyncIterable = asyncifyIterable(generator());
+
+        const result = [];
+        for await (const item of asyncIterable) {
+            result.push(item);
+        }
+
+        expect(result).toEqual([1, 2, 3]);
+    });
+});
+
+describe('chunkedAsyncIterable', () => {
+    it('should chunk an async iterable into specified sizes', async () => {
+        const asyncIterable = asyncifyIterable([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+        const result = [];
+        for await (const chunk of chunkedAsyncIterable(asyncIterable, 3)) {
+            result.push(chunk);
+        }
+
+        expect(result).toEqual([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10]]);
+    });
+
+    it('should handle chunk size of 1', async () => {
+        const asyncIterable = asyncifyIterable([1, 2, 3]);
+
+        const result = [];
+        for await (const chunk of chunkedAsyncIterable(asyncIterable, 1)) {
+            result.push(chunk);
+        }
+
+        expect(result).toEqual([[1], [2], [3]]);
+    });
+
+    it('should handle chunk size larger than input', async () => {
+        const asyncIterable = asyncifyIterable([1, 2, 3]);
+        const chunked = chunkedAsyncIterable(asyncIterable, 10);
+
+        const result = [];
+        for await (const chunk of chunked) {
+            result.push(chunk);
+        }
+
+        expect(result).toEqual([[1, 2, 3]]);
+    });
+
+    it('should handle empty async iterable', async () => {
+        const asyncIterable = asyncifyIterable([]);
+
+        const result = [];
+        for await (const chunk of chunkedAsyncIterable(asyncIterable, 3)) {
+            result.push(chunk);
+        }
+
+        expect(result).toEqual([]);
+    });
+
+    it('should throw error for invalid chunk size', async () => {
+        const input = [1, 2, 3];
+        const asyncIterable = asyncifyIterable(input);
+
+        await expect(
+            (async () => {
+                for await (const _ of chunkedAsyncIterable(asyncIterable, 0)) {
+                    // Empty block
+                }
+            })(),
+        ).rejects.toThrow();
+        await expect(
+            (async () => {
+                for await (const _ of chunkedAsyncIterable(asyncIterable, -1)) {
+                    // Empty block
+                }
+            })(),
+        ).rejects.toThrow();
+    });
+});
+
+describe('peekableAsyncIterable', () => {
+    it('should allow peeking at the next value without advancing', async () => {
+        const iterable = peekableAsyncIterable(asyncifyIterable([1, 2, 3]));
+        const iterator = iterable[Symbol.asyncIterator]();
+
+        const peeked = await iterator.peek();
+        expect(peeked).toBe(1);
+
+        // Peeking again should return the same value
+        const peekedAgain = await iterator.peek();
+        expect(peekedAgain).toBe(1);
+
+        // Now iterate and verify we get the peeked value first
+        const results = [];
+        for await (const value of iterable) {
+            results.push(value);
+        }
+
+        expect(results).toEqual([1, 2, 3]);
+    });
+
+    it('should return undefined when peeking at empty iterable', async () => {
+        const iterable = peekableAsyncIterable(asyncifyIterable([]));
+        const iterator = iterable[Symbol.asyncIterator]();
+
+        const peeked = await iterator.peek();
+        expect(peeked).toBeUndefined();
+    });
+
+    it('should handle peek after exhausting the iterable', async () => {
+        const iterable = peekableAsyncIterable(asyncifyIterable([1]));
+
+        // Consume the iterable
+        const results = [];
+        for await (const value of iterable) {
+            results.push(value);
+        }
+        expect(results).toEqual([1]);
+
+        // Get a fresh iterator and peek should return undefined
+        const iterator = iterable[Symbol.asyncIterator]();
+        const peeked = await iterator.peek();
+        expect(peeked).toBeUndefined();
+    });
+
+    it('should work with manual iteration', async () => {
+        const iterable = peekableAsyncIterable(asyncifyIterable([10, 20, 30]));
+        const iterator = iterable[Symbol.asyncIterator]();
+
+        // Peek first
+        expect(await iterator.peek()).toBe(10);
+
+        const first = await iterator.next();
+        expect(first.value).toBe(10);
+        expect(first.done).toBe(false);
+        expect(await iterator.peek()).toBe(20);
+
+        const second = await iterator.next();
+        expect(second.value).toBe(20);
+        expect(second.done).toBe(false);
+        expect(await iterator.peek()).toBe(30);
+
+        const third = await iterator.next();
+        expect(third.value).toBe(30);
+        expect(third.done).toBe(false);
+        expect(await iterator.peek()).toBe(undefined);
+
+        const done = await iterator.next();
+        expect(done.done).toBe(true);
+        expect(await iterator.peek()).toBe(undefined);
+    });
+
+    it('should handle peek on single element iterable', async () => {
+        const iterable = peekableAsyncIterable(asyncifyIterable([42]));
+        const iterator = iterable[Symbol.asyncIterator]();
+
+        expect(await iterator.peek()).toBe(42);
+
+        const results = [];
+        for await (const value of iterable) {
+            results.push(value);
+        }
+
+        expect(results).toEqual([42]);
+
+        // Get a fresh iterator and peek after exhaustion
+        const newIterator = iterable[Symbol.asyncIterator]();
+        expect(await newIterator.peek()).toBeUndefined();
+    });
+});


### PR DESCRIPTION
- closes #2980
- the Apify client does not accept iterables yet, so the individual "batches" are still stored in memory 
- even considering that, the change should enable reducing memory footprint by passing in an async generator that loads a long list of requests
