### PR TITLE
refactor: remove manual deleteRequestLock from BasicCrawler [#2840]

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -1550,13 +1550,9 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
             this.crawlingContexts.delete(crawlingContext.id);
 
             // Safety net - release the lock if nobody managed to do it before
-            if (isRequestLocked && source instanceof RequestProvider) {
-                try {
-                    await source.client.deleteRequestLock(request.id!);
-                } catch {
-                    // We don't have the lock, or the request was never locked. Either way it's fine
-                }
-            }
+            // Removed manual deleteRequestLock as this should be handled by markRequestHandled()
+// See: https://github.com/apify/crawlee/issues/2840
+
         }
     }
 


### PR DESCRIPTION
**Summary**
This pull request addresses a technical debt issue in BasicCrawler, where request locks were being manually released using deleteRequestLock(). According to the discussion in [#2840](https://github.com/apify/crawlee/issues/2840), this behavior was not aligned with the intended architectural design, as request lifecycle responsibilities should be handled exclusively by markRequestHandled().

**Changes Introduced**
- Removed the manual call to source.client.deleteRequestLock(request.id!) from the finally block in BasicCrawler.
- Simplified the control flow and avoided potential redundancy or race conditions in request unlocking.
- Added an inline comment referencing the decision to defer unlocking to markRequestHandled().

**Related Information**
- Fixes: [#2840](https://github.com/apify/crawlee/issues/2840)
- This change improves architectural consistency by ensuring BasicCrawler does not directly manage request locks, adhering to single-responsibility principles.
