### PR TITLE
chore(e2e): make `playwright-multi-run` more stable

### DIFF
--- a/test/e2e/playwright-multi-run/test.mjs
+++ b/test/e2e/playwright-multi-run/test.mjs
@@ -10,5 +10,5 @@ await initialize(testActorDirname);
 const { datasetItems } = await runActor(testActorDirname, 16384);
 
 // we cant assert number of requests as the stats KVS is being wiped on each `run` call, unlike the dataset
-await expect(datasetItems.length > 30, `Number of dataset items (actual: ${datasetItems.length}, expected: > 30)`);
+await expect(datasetItems.length >= 30, `Number of dataset items (actual: ${datasetItems.length}, expected: >= 30)`);
 await expect(validateDataset(datasetItems, ['url', 'pageTitle']), 'Dataset items validation');


### PR DESCRIPTION
If the `maxRequestsPerCrawl` is not overshot, the total number of results can be equal to `30`.