### PR TITLE
fix: call `onSkippedRequest` for `AdaptivePlaywrightCrawler.enqueueLinks`

### DIFF
--- a/packages/playwright-crawler/src/internals/adaptive-playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/adaptive-playwright-crawler.ts
@@ -678,6 +678,8 @@ export class AdaptivePlaywrightCrawler extends PlaywrightCrawler {
         });
 
         return await enqueueLinks({
+            limit: this.calculateEnqueuedRequestLimit(options.limit),
+            onSkippedRequest: this.handleSkippedRequest,
             ...options,
             baseUrl,
             requestQueue: {


### PR DESCRIPTION
`AdaptivePlaywrightCrawler` seems to have been omitted from #3026 and #2990. This PR fixes those omissions.

Closes #3039 