### PR TITLE
feat: add `maxCrawlDepth` crawler option

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -1520,12 +1520,12 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
                 const newRequestDepth = (request?.crawlDepth ?? -1) + 1;
 
                 async function* injectDepth() {
-                    for await (const request of requests) {
-                        if (typeof request === 'string') {
-                            yield { url: request, crawlDepth: newRequestDepth };
+                    for await (const rq of requests) {
+                        if (typeof rq === 'string') {
+                            yield { url: rq, crawlDepth: newRequestDepth };
                         } else {
-                            request.crawlDepth ??= newRequestDepth;
-                            yield request;
+                            rq.crawlDepth ??= newRequestDepth;
+                            yield rq;
                         }
                     }
                 }

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -268,6 +268,8 @@ export interface BasicCrawlerOptions<Context extends CrawlingContext = BasicCraw
 
     /**
      * Maximum depth of the crawl. If not set, the crawl will continue until all requests are processed.
+     * Setting this to `0` will only process the initial requests, skipping all links enqueued by `crawlingContext.enqueueLinks` and `crawlingContext.addRequests`.
+     * Passing `1` will process the initial requests and all links enqueued by `crawlingContext.enqueueLinks` and `crawlingContext.addRequests` in the handler for initial requests.
      */
     maxCrawlDepth?: number;
 
@@ -1503,15 +1505,15 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
                     robotsTxtFile: await this.getRobotsTxtFileForUrl(request!.url),
                     onSkippedRequest: this.handleSkippedRequest,
                     limit: this.calculateEnqueuedRequestLimit(options.limit),
-                    transformRequestFunction: (rq) => {
-                        rq.crawlDepth = (request?.crawlDepth ?? 0) + 1;
+                    transformRequestFunction: (newRequest) => {
+                        newRequest.crawlDepth = (request?.crawlDepth ?? 0) + 1;
 
-                        if (this.maxCrawlDepth !== undefined && rq.crawlDepth > this.maxCrawlDepth) {
-                            rq.skippedReason = 'depth';
+                        if (this.maxCrawlDepth !== undefined && newRequest.crawlDepth > this.maxCrawlDepth) {
+                            newRequest.skippedReason = 'depth';
                             return false;
                         }
 
-                        return options.transformRequestFunction?.(rq) ?? rq;
+                        return options.transformRequestFunction?.(newRequest) ?? newRequest;
                     },
                     ...options,
                 });

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -267,6 +267,11 @@ export interface BasicCrawlerOptions<Context extends CrawlingContext = BasicCraw
     maxRequestsPerCrawl?: number;
 
     /**
+     * Maximum depth of the crawl. If not set, the crawl will continue until all requests are processed.
+     */
+    maxCrawlDepth?: number;
+
+    /**
      * Custom options passed to the underlying {@apilink AutoscaledPool} constructor.
      * > *NOTE:* The {@apilink AutoscaledPoolOptions.runTaskFunction|`runTaskFunction`}
      * option is provided by the crawler and cannot be overridden.
@@ -516,6 +521,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
     protected requestHandlerTimeoutMillis!: number;
     protected internalTimeoutMillis: number;
     protected maxRequestRetries: number;
+    protected maxCrawlDepth?: number;
     protected sameDomainDelayMillis: number;
     protected domainAccessedTime: Map<string, number>;
     protected maxSessionRotations: number;
@@ -559,6 +565,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
         sameDomainDelaySecs: ow.optional.number,
         maxSessionRotations: ow.optional.number,
         maxRequestsPerCrawl: ow.optional.number,
+        maxCrawlDepth: ow.optional.number,
         autoscaledPoolOptions: ow.optional.object,
         sessionPoolOptions: ow.optional.object,
         useSessionPool: ow.optional.boolean,
@@ -600,6 +607,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
             sameDomainDelaySecs = 0,
             maxSessionRotations = 10,
             maxRequestsPerCrawl,
+            maxCrawlDepth,
             autoscaledPoolOptions = {},
             keepAlive,
             sessionPoolOptions = {},
@@ -711,6 +719,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
         }
 
         this.maxRequestRetries = maxRequestRetries;
+        this.maxCrawlDepth = maxCrawlDepth;
         this.sameDomainDelayMillis = sameDomainDelaySecs * 1000;
         this.maxSessionRotations = maxSessionRotations;
         this.stats = new Statistics({
@@ -1112,8 +1121,10 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
 
         const skippedBecauseOfRobots = new Set<string>();
         const skippedBecauseOfLimit = new Set<string>();
+        const skippedBecauseOfMaxCrawlDepth = new Set<string>();
 
         const isAllowedBasedOnRobotsTxtFile = this.isAllowedBasedOnRobotsTxtFile.bind(this);
+        const maxCrawlDepth = this.maxCrawlDepth;
 
         async function* filteredRequests() {
             let yieldedRequestCount = 0;
@@ -1123,6 +1134,11 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
 
                 if (requestLimit !== undefined && yieldedRequestCount >= requestLimit) {
                     skippedBecauseOfLimit.add(url);
+                    continue;
+                }
+
+                if (maxCrawlDepth !== undefined && (request as any).crawlDepth > maxCrawlDepth) {
+                    skippedBecauseOfMaxCrawlDepth.add(url);
                     continue;
                 }
 
@@ -1143,7 +1159,11 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
             });
         }
 
-        if (skippedBecauseOfRobots.size > 0 || skippedBecauseOfLimit.size > 0) {
+        if (
+            skippedBecauseOfRobots.size > 0 ||
+            skippedBecauseOfLimit.size > 0 ||
+            skippedBecauseOfMaxCrawlDepth.size > 0
+        ) {
             await Promise.all(
                 [...skippedBecauseOfRobots]
                     .map((url) => {
@@ -1152,6 +1172,9 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
                     .concat(
                         [...skippedBecauseOfLimit].map((url) => {
                             return this.handleSkippedRequest({ url, reason: 'limit' });
+                        }),
+                        [...skippedBecauseOfMaxCrawlDepth].map((url) => {
+                            return this.handleSkippedRequest({ url, reason: 'depth' });
                         }),
                     ),
             );
@@ -1480,10 +1503,35 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
                     robotsTxtFile: await this.getRobotsTxtFileForUrl(request!.url),
                     onSkippedRequest: this.handleSkippedRequest,
                     limit: this.calculateEnqueuedRequestLimit(options.limit),
+                    transformRequestFunction: (rq) => {
+                        rq.crawlDepth = (request?.crawlDepth ?? 0) + 1;
+
+                        if (this.maxCrawlDepth !== undefined && rq.crawlDepth > this.maxCrawlDepth) {
+                            rq.skippedReason = 'depth';
+                            return false;
+                        }
+
+                        return options.transformRequestFunction?.(rq) ?? rq;
+                    },
                     ...options,
                 });
             },
-            addRequests: this.addRequests.bind(this),
+            addRequests: async (requests: RequestsLike, options: CrawlerAddRequestsOptions = {}) => {
+                const newRequestDepth = (request?.crawlDepth ?? -1) + 1;
+
+                async function* injectDepth() {
+                    for await (const request of requests) {
+                        if (typeof request === 'string') {
+                            yield { url: request, crawlDepth: newRequestDepth };
+                        } else {
+                            request.crawlDepth ??= newRequestDepth;
+                            yield request;
+                        }
+                    }
+                }
+
+                return this.addRequests(injectDepth(), options);
+            },
             pushData: this.pushData.bind(this),
             useState: this.useState.bind(this),
             sendRequest: createSendRequest(this.httpClient, request!, session, () => crawlingContext.proxyInfo?.url),

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -1517,7 +1517,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
                 });
             },
             addRequests: async (requests: RequestsLike, options: CrawlerAddRequestsOptions = {}) => {
-                const newRequestDepth = (request?.crawlDepth ?? -1) + 1;
+                const newRequestDepth = (request?.crawlDepth ?? 0) + 1;
 
                 async function* injectDepth() {
                     for await (const rq of requests) {

--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -814,7 +814,7 @@ interface BoundEnqueueLinksInternalOptions {
 }
 
 /** @internal */
-function isBoundEnqueueLinks(
+function isEnqueueLinksBound(
     options: EnqueueLinksInternalOptions | BoundEnqueueLinksInternalOptions,
 ): options is BoundEnqueueLinksInternalOptions {
     return !!(options as BoundEnqueueLinksInternalOptions).enqueueLinks;
@@ -839,7 +839,7 @@ export async function browserCrawlerEnqueueLinks(
         enqueueLinksOptions?.baseUrl ?? finalRequestUrl ?? originalRequestUrl,
     );
 
-    if (isBoundEnqueueLinks(options)) {
+    if (isEnqueueLinksBound(options)) {
         return options.enqueueLinks({
             urls,
             baseUrl,

--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -624,7 +624,7 @@ export abstract class BrowserCrawler<
             crawlingContext.proxyInfo = browserControllerInstance.launchContext.proxyInfo as ProxyInfo;
         }
 
-        const originalEnqueueLinks = crawlingContext.enqueueLinks;
+        const contextEnqueueLinks = crawlingContext.enqueueLinks;
         crawlingContext.enqueueLinks = async (enqueueOptions) => {
             return browserCrawlerEnqueueLinks({
                 options: { ...enqueueOptions, limit: this.calculateEnqueuedRequestLimit(enqueueOptions?.limit) },
@@ -634,7 +634,7 @@ export abstract class BrowserCrawler<
                 onSkippedRequest: this.handleSkippedRequest,
                 originalRequestUrl: crawlingContext.request.url,
                 finalRequestUrl: crawlingContext.request.loadedUrl,
-                enqueueLinks: originalEnqueueLinks,
+                enqueueLinks: contextEnqueueLinks,
             });
         };
     }
@@ -814,7 +814,7 @@ interface BoundEnqueueLinksInternalOptions {
 }
 
 /** @internal */
-function isEnqueueLinksBound(
+function containsEnqueueLinks(
     options: EnqueueLinksInternalOptions | BoundEnqueueLinksInternalOptions,
 ): options is BoundEnqueueLinksInternalOptions {
     return !!(options as BoundEnqueueLinksInternalOptions).enqueueLinks;
@@ -839,7 +839,7 @@ export async function browserCrawlerEnqueueLinks(
         enqueueLinksOptions?.baseUrl ?? finalRequestUrl ?? originalRequestUrl,
     );
 
-    if (isEnqueueLinksBound(options)) {
+    if (containsEnqueueLinks(options)) {
         return options.enqueueLinks({
             urls,
             baseUrl,

--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -1,6 +1,7 @@
 import type {
     Awaitable,
     BasicCrawlerOptions,
+    BasicCrawlingContext,
     CrawlingContext,
     Dictionary,
     EnqueueLinksOptions,
@@ -623,6 +624,7 @@ export abstract class BrowserCrawler<
             crawlingContext.proxyInfo = browserControllerInstance.launchContext.proxyInfo as ProxyInfo;
         }
 
+        const originalEnqueueLinks = crawlingContext.enqueueLinks;
         crawlingContext.enqueueLinks = async (enqueueOptions) => {
             return browserCrawlerEnqueueLinks({
                 options: { ...enqueueOptions, limit: this.calculateEnqueuedRequestLimit(enqueueOptions?.limit) },
@@ -632,6 +634,7 @@ export abstract class BrowserCrawler<
                 onSkippedRequest: this.handleSkippedRequest,
                 originalRequestUrl: crawlingContext.request.url,
                 finalRequestUrl: crawlingContext.request.loadedUrl,
+                enqueueLinks: originalEnqueueLinks,
             });
         };
     }
@@ -802,35 +805,54 @@ interface EnqueueLinksInternalOptions {
 }
 
 /** @internal */
-export async function browserCrawlerEnqueueLinks({
-    options,
-    page,
-    requestQueue,
-    robotsTxtFile,
-    onSkippedRequest,
-    originalRequestUrl,
-    finalRequestUrl,
-}: EnqueueLinksInternalOptions) {
+interface BoundEnqueueLinksInternalOptions {
+    enqueueLinks: BasicCrawlingContext['enqueueLinks'];
+    options?: ReadonlyDeep<Omit<EnqueueLinksOptions, 'requestQueue'>> & Pick<EnqueueLinksOptions, 'requestQueue'>;
+    originalRequestUrl: string;
+    finalRequestUrl?: string;
+    page: CommonPage;
+}
+
+/** @internal */
+function isBoundEnqueueLinks(
+    options: EnqueueLinksInternalOptions | BoundEnqueueLinksInternalOptions,
+): options is BoundEnqueueLinksInternalOptions {
+    return !!(options as BoundEnqueueLinksInternalOptions).enqueueLinks;
+}
+
+/** @internal */
+export async function browserCrawlerEnqueueLinks(
+    options: EnqueueLinksInternalOptions | BoundEnqueueLinksInternalOptions,
+) {
+    const { options: enqueueLinksOptions, finalRequestUrl, originalRequestUrl, page } = options;
+
     const baseUrl = resolveBaseUrlForEnqueueLinksFiltering({
-        enqueueStrategy: options?.strategy,
+        enqueueStrategy: enqueueLinksOptions?.strategy,
         finalRequestUrl,
         originalRequestUrl,
-        userProvidedBaseUrl: options?.baseUrl,
+        userProvidedBaseUrl: enqueueLinksOptions?.baseUrl,
     });
 
     const urls = await extractUrlsFromPage(
         page as any,
-        options?.selector ?? 'a',
-        options?.baseUrl ?? finalRequestUrl ?? originalRequestUrl,
+        enqueueLinksOptions?.selector ?? 'a',
+        enqueueLinksOptions?.baseUrl ?? finalRequestUrl ?? originalRequestUrl,
     );
 
+    if (isBoundEnqueueLinks(options)) {
+        return options.enqueueLinks({
+            urls,
+            baseUrl,
+            ...enqueueLinksOptions,
+        });
+    }
     return enqueueLinks({
-        requestQueue,
-        robotsTxtFile,
-        onSkippedRequest,
+        requestQueue: options.requestQueue,
+        robotsTxtFile: options.robotsTxtFile,
+        onSkippedRequest: options.onSkippedRequest,
         urls,
         baseUrl,
-        ...(options as EnqueueLinksOptions),
+        ...(enqueueLinksOptions as EnqueueLinksOptions),
     });
 }
 

--- a/packages/cheerio-crawler/src/internals/cheerio-crawler.ts
+++ b/packages/cheerio-crawler/src/internals/cheerio-crawler.ts
@@ -260,7 +260,7 @@ interface BoundEnqueueLinksInternalOptions {
 }
 
 /** @internal */
-function isBoundEnqueueLinks(
+function isEnqueueLinksBound(
     options: EnqueueLinksInternalOptions | BoundEnqueueLinksInternalOptions,
 ): options is BoundEnqueueLinksInternalOptions {
     return !!(options as BoundEnqueueLinksInternalOptions).enqueueLinks;
@@ -288,7 +288,7 @@ export async function cheerioCrawlerEnqueueLinks(
         enqueueLinksOptions?.baseUrl ?? finalRequestUrl ?? originalRequestUrl,
     );
 
-    if (isBoundEnqueueLinks(options)) {
+    if (isEnqueueLinksBound(options)) {
         return options.enqueueLinks({
             urls,
             baseUrl,

--- a/packages/cheerio-crawler/src/internals/cheerio-crawler.ts
+++ b/packages/cheerio-crawler/src/internals/cheerio-crawler.ts
@@ -260,7 +260,7 @@ interface BoundEnqueueLinksInternalOptions {
 }
 
 /** @internal */
-function isEnqueueLinksBound(
+function containsEnqueueLinks(
     options: EnqueueLinksInternalOptions | BoundEnqueueLinksInternalOptions,
 ): options is BoundEnqueueLinksInternalOptions {
     return !!(options as BoundEnqueueLinksInternalOptions).enqueueLinks;
@@ -288,7 +288,7 @@ export async function cheerioCrawlerEnqueueLinks(
         enqueueLinksOptions?.baseUrl ?? finalRequestUrl ?? originalRequestUrl,
     );
 
-    if (isEnqueueLinksBound(options)) {
+    if (containsEnqueueLinks(options)) {
         return options.enqueueLinks({
             urls,
             baseUrl,

--- a/packages/core/src/enqueue_links/enqueue_links.ts
+++ b/packages/core/src/enqueue_links/enqueue_links.ts
@@ -401,11 +401,14 @@ export async function enqueueLinks(
         }
     }
 
-    async function reportSkippedRequests(skippedRequests: { url: string }[], reason: SkippedRequestReason) {
+    async function reportSkippedRequests(
+        skippedRequests: { url: string; skippedReason?: SkippedRequestReason }[],
+        reason: SkippedRequestReason,
+    ) {
         if (onSkippedRequest && skippedRequests.length > 0) {
             await Promise.all(
                 skippedRequests.map((request) => {
-                    return onSkippedRequest({ url: request.url, reason });
+                    return onSkippedRequest({ url: request.url, reason: request.skippedReason ?? reason });
                 }),
             );
         }

--- a/packages/core/src/enqueue_links/shared.ts
+++ b/packages/core/src/enqueue_links/shared.ts
@@ -47,7 +47,7 @@ export type RegExpObject = { regexp: RegExp } & Pick<
 
 export type RegExpInput = RegExp | RegExpObject;
 
-export type SkippedRequestReason = 'robotsTxt' | 'limit' | 'filters' | 'redirect';
+export type SkippedRequestReason = 'robotsTxt' | 'limit' | 'filters' | 'redirect' | 'depth';
 
 export type SkippedRequestCallback = (args: {
     url: string;

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -177,7 +177,7 @@ export class Request<UserData extends Dictionary = Dictionary> {
             useExtendedUniqueKey = false,
             skipNavigation,
             enqueueStrategy,
-            crawlDepth = 0,
+            crawlDepth,
         } = options as RequestOptions & {
             loadedUrl?: string;
             retryCount?: number;
@@ -251,7 +251,7 @@ export class Request<UserData extends Dictionary = Dictionary> {
 
         if (skipNavigation != null) this.skipNavigation = skipNavigation;
         if (maxRetries != null) this.maxRetries = maxRetries;
-        if (crawlDepth != null && this.crawlDepth === undefined) this.crawlDepth ??= crawlDepth;
+        if (crawlDepth != null) this.userData.__crawlee.crawlDepth ??= crawlDepth;
 
         // If it's already set, don't override it (for instance when fetching from storage)
         if (enqueueStrategy) {
@@ -277,7 +277,7 @@ export class Request<UserData extends Dictionary = Dictionary> {
      * Note that this is dependent on the crawler setup and might produce unexpected results when used with multiple crawlers.
      */
     get crawlDepth(): number {
-        return this.userData.__crawlee?.crawlDepth;
+        return this.userData.__crawlee?.crawlDepth ?? 0;
     }
 
     /** Depth of the request in the current crawl tree.

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -273,14 +273,16 @@ export class Request<UserData extends Dictionary = Dictionary> {
         }
     }
 
-    /** Depth of the request in the current crawl tree.
+    /**
+     * Depth of the request in the current crawl tree.
      * Note that this is dependent on the crawler setup and might produce unexpected results when used with multiple crawlers.
      */
     get crawlDepth(): number {
         return this.userData.__crawlee?.crawlDepth ?? 0;
     }
 
-    /** Depth of the request in the current crawl tree.
+    /**
+     * Depth of the request in the current crawl tree.
      * Note that this is dependent on the crawler setup and might produce unexpected results when used with multiple crawlers.
      */
     set crawlDepth(value: number) {

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -8,8 +8,8 @@ import ow from 'ow';
 
 import { normalizeUrl } from '@apify/utilities';
 
-import type { SkippedRequestReason } from './enqueue_links/shared';
 import type { EnqueueLinksOptions } from './enqueue_links/enqueue_links';
+import type { SkippedRequestReason } from './enqueue_links/shared';
 import { log as defaultLog } from './log';
 import type { AllowedHttpMethods } from './typedefs';
 import { keys } from './typedefs';

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -8,7 +8,7 @@ import ow from 'ow';
 
 import { normalizeUrl } from '@apify/utilities';
 
-import type { SkippedRequestReason } from './enqueue_links';
+import type { SkippedRequestReason } from './enqueue_links/shared';
 import type { EnqueueLinksOptions } from './enqueue_links/enqueue_links';
 import { log as defaultLog } from './log';
 import type { AllowedHttpMethods } from './typedefs';
@@ -177,6 +177,7 @@ export class Request<UserData extends Dictionary = Dictionary> {
             useExtendedUniqueKey = false,
             skipNavigation,
             enqueueStrategy,
+            crawlDepth = 0,
         } = options as RequestOptions & {
             loadedUrl?: string;
             retryCount?: number;
@@ -250,6 +251,7 @@ export class Request<UserData extends Dictionary = Dictionary> {
 
         if (skipNavigation != null) this.skipNavigation = skipNavigation;
         if (maxRetries != null) this.maxRetries = maxRetries;
+        if (crawlDepth != null && this.crawlDepth === undefined) this.crawlDepth ??= crawlDepth;
 
         // If it's already set, don't override it (for instance when fetching from storage)
         if (enqueueStrategy) {
@@ -275,7 +277,7 @@ export class Request<UserData extends Dictionary = Dictionary> {
      * Note that this is dependent on the crawler setup and might produce unexpected results when used with multiple crawlers.
      */
     get crawlDepth(): number {
-        return this.userData.__crawlee?.crawlDepth ?? 0;
+        return this.userData.__crawlee?.crawlDepth;
     }
 
     /** Depth of the request in the current crawl tree.

--- a/packages/jsdom-crawler/src/internals/jsdom-crawler.ts
+++ b/packages/jsdom-crawler/src/internals/jsdom-crawler.ts
@@ -362,7 +362,7 @@ interface BoundEnqueueLinksInternalOptions {
 }
 
 /** @internal */
-function isEnqueueLinksBound(
+function containsEnqueueLinks(
     options: EnqueueLinksInternalOptions | BoundEnqueueLinksInternalOptions,
 ): options is BoundEnqueueLinksInternalOptions {
     return !!(options as BoundEnqueueLinksInternalOptions).enqueueLinks;
@@ -389,7 +389,7 @@ export async function domCrawlerEnqueueLinks(options: EnqueueLinksInternalOption
         enqueueLinksOptions?.baseUrl ?? finalRequestUrl ?? originalRequestUrl,
     );
 
-    if (isEnqueueLinksBound(options)) {
+    if (containsEnqueueLinks(options)) {
         return options.enqueueLinks({
             urls,
             baseUrl,

--- a/packages/linkedom-crawler/src/internals/linkedom-crawler.ts
+++ b/packages/linkedom-crawler/src/internals/linkedom-crawler.ts
@@ -245,7 +245,7 @@ interface BoundEnqueueLinksInternalOptions {
 }
 
 /** @internal */
-function isEnqueueLinksBound(
+function containsEnqueueLinks(
     options: EnqueueLinksInternalOptions | BoundEnqueueLinksInternalOptions,
 ): options is BoundEnqueueLinksInternalOptions {
     return !!(options as BoundEnqueueLinksInternalOptions).enqueueLinks;
@@ -274,7 +274,7 @@ export async function linkedomCrawlerEnqueueLinks(
         enqueueLinksOptions?.baseUrl ?? finalRequestUrl ?? originalRequestUrl,
     );
 
-    if (isEnqueueLinksBound(options)) {
+    if (containsEnqueueLinks(options)) {
         return options.enqueueLinks({
             urls,
             baseUrl,

--- a/packages/linkedom-crawler/src/internals/linkedom-crawler.ts
+++ b/packages/linkedom-crawler/src/internals/linkedom-crawler.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage } from 'node:http';
 
 import type {
+    BasicCrawlingContext,
     EnqueueLinksOptions,
     ErrorHandler,
     GetUserDataFromRequest,
@@ -226,7 +227,7 @@ export class LinkeDOMCrawler extends HttpCrawler<LinkeDOMCrawlingContext> {
 }
 
 interface EnqueueLinksInternalOptions {
-    options?: LinkeDOMCrawlerEnqueueLinksOptions;
+    options?: EnqueueLinksOptions;
     window: Window | null;
     requestQueue: RequestProvider;
     robotsTxtFile?: RobotsTxtFile;
@@ -235,40 +236,59 @@ interface EnqueueLinksInternalOptions {
     finalRequestUrl?: string;
 }
 
+interface BoundEnqueueLinksInternalOptions {
+    enqueueLinks: BasicCrawlingContext['enqueueLinks'];
+    options?: EnqueueLinksOptions;
+    window: Window | null;
+    originalRequestUrl: string;
+    finalRequestUrl?: string;
+}
+
 /** @internal */
-export async function linkedomCrawlerEnqueueLinks({
-    options,
-    window,
-    requestQueue,
-    robotsTxtFile,
-    onSkippedRequest,
-    originalRequestUrl,
-    finalRequestUrl,
-}: EnqueueLinksInternalOptions) {
+function isEnqueueLinksBound(
+    options: EnqueueLinksInternalOptions | BoundEnqueueLinksInternalOptions,
+): options is BoundEnqueueLinksInternalOptions {
+    return !!(options as BoundEnqueueLinksInternalOptions).enqueueLinks;
+}
+
+/** @internal */
+export async function linkedomCrawlerEnqueueLinks(
+    options: EnqueueLinksInternalOptions | BoundEnqueueLinksInternalOptions,
+) {
+    const { options: enqueueLinksOptions, window, originalRequestUrl, finalRequestUrl } = options;
+
     if (!window) {
         throw new Error('Cannot enqueue links because the DOM is not available.');
     }
 
     const baseUrl = resolveBaseUrlForEnqueueLinksFiltering({
-        enqueueStrategy: options?.strategy,
+        enqueueStrategy: enqueueLinksOptions?.strategy,
         finalRequestUrl,
         originalRequestUrl,
-        userProvidedBaseUrl: options?.baseUrl,
+        userProvidedBaseUrl: enqueueLinksOptions?.baseUrl,
     });
 
     const urls = extractUrlsFromWindow(
         window,
-        options?.selector ?? 'a',
-        options?.baseUrl ?? finalRequestUrl ?? originalRequestUrl,
+        enqueueLinksOptions?.selector ?? 'a',
+        enqueueLinksOptions?.baseUrl ?? finalRequestUrl ?? originalRequestUrl,
     );
 
+    if (isEnqueueLinksBound(options)) {
+        return options.enqueueLinks({
+            urls,
+            baseUrl,
+            ...enqueueLinksOptions,
+        });
+    }
+
     return enqueueLinks({
-        requestQueue,
-        robotsTxtFile,
-        onSkippedRequest,
+        requestQueue: options.requestQueue,
+        robotsTxtFile: options.robotsTxtFile,
+        onSkippedRequest: options.onSkippedRequest,
         urls,
         baseUrl,
-        ...options,
+        ...enqueueLinksOptions,
     });
 }
 

--- a/test/core/crawlers/basic_crawler.test.ts
+++ b/test/core/crawlers/basic_crawler.test.ts
@@ -170,6 +170,32 @@ describe('BasicCrawler', () => {
         ]);
     });
 
+    test.only('addRequests should respect maxCrawlDepth', async () => {
+        const processedUrls: string[] = [];
+
+        const requestHandler: RequestHandler = async ({ request, addRequests }) => {
+            processedUrls.push(request.url);
+            const url = new URL(request.url);
+            url.pathname = `${url.pathname}deep/`;
+
+            await addRequests([url.toString()]);
+        };
+
+        const crawler = new BasicCrawler({
+            maxCrawlDepth: 2,
+            maxRequestsPerCrawl: 10, // safeguard against infinite loops
+            requestHandler,
+        });
+
+        await crawler.run(['https://example.com/']);
+
+        expect(processedUrls).toEqual([
+            'https://example.com/',
+            'https://example.com/deep/',
+            'https://example.com/deep/deep/',
+        ]);
+    });
+
     test('should correctly combine shorthand and full length options', async () => {
         const shorthandOptions = {
             minConcurrency: 123,

--- a/test/core/crawlers/browser_crawler.test.ts
+++ b/test/core/crawlers/browser_crawler.test.ts
@@ -1065,4 +1065,25 @@ describe('BrowserCrawler', () => {
         expect(succeeded).toHaveLength(1);
         expect(succeeded[0]).toEqual('Redirecting outside');
     });
+
+    test('enqueueLinks should respect maxCrawlDepth', async () => {
+        const succeeded: string[] = [];
+
+        const crawler = new BrowserCrawlerTest({
+            browserPoolOptions: {
+                browserPlugins: [puppeteerPlugin],
+            },
+            maxCrawlDepth: 1,
+            maxRequestsPerCrawl: 10, // avoiding accidental runaway
+            requestHandler: async ({ page, enqueueLinks }) => {
+                succeeded.push(await page.title());
+                await enqueueLinks({ strategy: EnqueueStrategy.All });
+            },
+        });
+
+        await crawler.run([`${serverAddress}/special/html-type`]);
+
+        expect(succeeded).toHaveLength(2);
+        expect(succeeded).toEqual(['Example Domain', 'Example Domains']);
+    });
 });

--- a/test/core/crawlers/cheerio_crawler.test.ts
+++ b/test/core/crawlers/cheerio_crawler.test.ts
@@ -1374,4 +1374,22 @@ describe('CheerioCrawler', () => {
         expect(succeeded).toHaveLength(1);
         expect(succeeded[0]).toEqual('Redirecting outside');
     });
+
+    test('enqueueLinks should respect maxCrawlDepth', async () => {
+        const succeeded: string[] = [];
+
+        const crawler = new CheerioCrawler({
+            maxCrawlDepth: 1,
+            maxRequestsPerCrawl: 10, // to avoid accidental runaway
+            requestHandler: async ({ $, enqueueLinks }) => {
+                succeeded.push($('title').text());
+                await enqueueLinks({ strategy: EnqueueStrategy.All });
+            },
+        });
+
+        await crawler.run([`${serverAddress}/special/html-type`]);
+
+        expect(succeeded).toHaveLength(2);
+        expect(succeeded).toEqual(['Example Domain', 'Example Domains']);
+    });
 });

--- a/test/core/storages/request_queue.test.ts
+++ b/test/core/storages/request_queue.test.ts
@@ -708,7 +708,7 @@ describe('RequestQueue remote', () => {
         const r1 = new Request({
             url,
             method,
-            userData: { __crawlee: { skipNavigation: true, maxRetries: 10, foo: 123, bar: true } },
+            userData: { __crawlee: { skipNavigation: true, maxRetries: 10, foo: 123, bar: true, crawlDepth: 10 } },
         });
         const r2 = new Request({
             url,
@@ -723,8 +723,15 @@ describe('RequestQueue remote', () => {
         expect(desc1!.enumerable).toBe(false);
         expect(r1.skipNavigation).toBe(true);
         expect(r1.maxRetries).toBe(10);
+        expect(r1.crawlDepth).toBe(10);
         r1.maxRetries = 5;
-        expect(r1.userData.__crawlee).toMatchObject({ skipNavigation: true, maxRetries: 5, foo: 123, bar: true });
+        expect(r1.userData.__crawlee).toMatchObject({
+            skipNavigation: true,
+            maxRetries: 5,
+            foo: 123,
+            bar: true,
+            crawlDepth: 10,
+        });
         const desc2 = Object.getOwnPropertyDescriptor(r2.userData, '__crawlee');
         expect(desc2!.enumerable).toBe(false);
         expect(r2.maxRetries).toBeUndefined();


### PR DESCRIPTION
Adds `BasicCrawlerOptions.maxCrawlDepth` option. Works with `addRequests` and `enqueueLinks` **called from the crawling context** (those have the current request depth bound and can propagate this value to the new requests).

Closes #2633 