### PR TITLE
docs: fix `enqueueLinks` documentation on option interactions

### DIFF
--- a/packages/core/src/enqueue_links/enqueue_links.ts
+++ b/packages/core/src/enqueue_links/enqueue_links.ts
@@ -47,7 +47,12 @@ export interface EnqueueLinksOptions extends RequestQueueOperationOptions {
     /** Sets {@apilink Request.userData} for newly enqueued requests. */
     userData?: Dictionary;
 
-    /** Sets {@apilink Request.label} for newly enqueued requests. */
+    /**
+     * Sets {@apilink Request.label} for newly enqueued requests.
+     *
+     * Note that the request options specified in `globs`, `regexps`, or `pseudoUrls` objects
+     * have priority over this option.
+     */
     label?: string;
 
     /**
@@ -141,9 +146,9 @@ export interface EnqueueLinksOptions extends RequestQueueOperationOptions {
      * }
      * ```
      *
-     * Note that `transformRequestFunction` has a priority over request options
-     * specified in `globs`, `regexps`, or `pseudoUrls` objects,
-     * and thus some options could be over-written by `transformRequestFunction`.
+     * Note that the request options specified in `globs`, `regexps`, or `pseudoUrls` objects,
+     * have priority over this function, and thus some request options
+     * could be overwritten by those.
      */
     transformRequestFunction?: RequestTransform;
 

--- a/packages/core/src/enqueue_links/enqueue_links.ts
+++ b/packages/core/src/enqueue_links/enqueue_links.ts
@@ -146,9 +146,8 @@ export interface EnqueueLinksOptions extends RequestQueueOperationOptions {
      * }
      * ```
      *
-     * Note that the request options specified in `globs`, `regexps`, or `pseudoUrls` objects,
-     * have priority over this function, and thus some request options
-     * could be overwritten by those.
+     * Note that the request options specified in `globs`, `regexps`, or `pseudoUrls` objects
+     * have priority over this function. Some request options set by this function could be overwritten by these options.
      */
     transformRequestFunction?: RequestTransform;
 


### PR DESCRIPTION
```typescript
const crawler = new CheerioCrawler({
    requestHandler: async ({ request, $, enqueueLinks }) => {
        console.log(`Processing ${request.url} (${request.label})`);
        // Enqueue links found in the page
        await enqueueLinks({
            regexps: [{ regexp: /https:\/\/crawlee\.dev\/.*/, label: 'regexps-label' }],
            label: 'global-label',
            transformRequestFunction: (request) => {
                if (request.url.includes('api')) {
                    request.label = 'transformed-label';
                }
                return request;
            },
        });
    },
});
```

All of the links report `regexps-label`. This is not in line with the documentation ("`transformRequestFunction` has a priority over request options")