### PR TITLE
fix: retry on blocked status codes in `HttpCrawler`

### DIFF
--- a/packages/http-crawler/src/internals/http-crawler.ts
+++ b/packages/http-crawler/src/internals/http-crawler.ts
@@ -19,6 +19,7 @@ import type {
 import {
     BASIC_CRAWLER_TIMEOUT_BUFFER_SECS,
     BasicCrawler,
+    BLOCKED_STATUS_CODES,
     Configuration,
     CrawlerExtension,
     mergeCookies,
@@ -602,6 +603,18 @@ export class HttpCrawler<
                 return `Found selectors: ${foundSelectors.join(', ')}`;
             }
         }
+
+        const blockedStatusCodes =
+            // eslint-disable-next-line dot-notation
+            (this.sessionPool?.['blockedStatusCodes'].length ?? 0) > 0
+                ? // eslint-disable-next-line dot-notation
+                  this.sessionPool!['blockedStatusCodes']
+                : BLOCKED_STATUS_CODES;
+
+        if (blockedStatusCodes.includes(crawlingContext.response.statusCode!)) {
+            return `Blocked by status code ${crawlingContext.response.statusCode}`;
+        }
+
         return false;
     }
 


### PR DESCRIPTION
Enables blocked HTTP status code detection in `HttpCrawler`. This copies the behaviour from `BrowserCrawler` [here](https://github.com/apify/crawlee/blob/f68d2a95d67cc6230122dc1a5226c57ca23d0ae7/packages/browser-crawler/src/internals/browser-crawler.ts#L481-L486).

Closes #3029 