### PR TITLE
chore: fix e2e tests after the documentation cleanup

### DIFF
--- a/test/e2e/cheerio-page-info/actor/main.js
+++ b/test/e2e/cheerio-page-info/actor/main.js
@@ -40,5 +40,5 @@ await Actor.main(async () => {
         requestHandler: router,
     });
 
-    await crawler.run([{ url: 'https://crawlee.dev/js/docs/3.0/examples', userData: { label: 'START' } }]);
+    await crawler.run([{ url: 'https://crawlee.dev/js/docs/3.12/examples', userData: { label: 'START' } }]);
 }, mainOptions);

--- a/test/e2e/playwright-default/actor/main.js
+++ b/test/e2e/playwright-default/actor/main.js
@@ -21,10 +21,10 @@ await Actor.main(async () => {
             const pageTitle = await page.title();
             await Dataset.pushData({ url, pageTitle });
             await enqueueLinks({
-                globs: ['**/3.0/examples/*'],
+                globs: ['**/3.12/examples/*'],
             });
         },
     });
 
-    await crawler.run(['https://crawlee.dev/js/docs/3.0/examples/']);
+    await crawler.run(['https://crawlee.dev/js/docs/3.12/examples/']);
 }, mainOptions);

--- a/test/e2e/playwright-default/test.mjs
+++ b/test/e2e/playwright-default/test.mjs
@@ -6,5 +6,5 @@ await initialize(testActorDirname);
 const { stats, datasetItems } = await runActor(testActorDirname, 16384);
 
 await expect(stats.requestsFinished > 15, 'All requests finished');
-await expect(datasetItems.length > 15 && datasetItems.length < 25, 'Number of dataset items');
+await expect(datasetItems.length > 15 && datasetItems.length < 30, 'Number of dataset items');
 await expect(validateDataset(datasetItems, ['url', 'pageTitle']), 'Dataset items validation');

--- a/test/e2e/playwright-multi-run/actor/main.js
+++ b/test/e2e/playwright-multi-run/actor/main.js
@@ -15,16 +15,16 @@ const crawler = new PlaywrightCrawler({
         const pageTitle = await page.title();
         await Dataset.pushData({ url, pageTitle });
         await enqueueLinks({
-            globs: ['**/3.0/examples/*'],
+            globs: ['**/3.12/examples/*'],
         });
     },
 });
 
 crawler.log.info('=== Run 1 ===');
-await crawler.run(['https://crawlee.dev/js/docs/3.0/examples']);
+await crawler.run(['https://crawlee.dev/js/docs/3.12/examples']);
 crawler.log.info('=== Run 2 ===');
-await crawler.run(['https://crawlee.dev/js/docs/3.0/examples']);
+await crawler.run(['https://crawlee.dev/js/docs/3.12/examples']);
 crawler.log.info('=== Run 3 ===');
-await crawler.run(['https://crawlee.dev/js/docs/3.0/examples']);
+await crawler.run(['https://crawlee.dev/js/docs/3.12/examples']);
 
 await Actor.exit({ exit: Actor.isAtHome() });

--- a/test/e2e/puppeteer-default/actor/main.js
+++ b/test/e2e/puppeteer-default/actor/main.js
@@ -22,10 +22,10 @@ await Actor.main(async () => {
             const pageTitle = await page.title();
             await Dataset.pushData({ url, pageTitle });
             await enqueueLinks({
-                globs: ['**/3.0/examples/*'],
+                globs: ['**/3.12/examples/*'],
             });
         },
     });
 
-    await crawler.run(['https://crawlee.dev/js/docs/3.0/examples/']);
+    await crawler.run(['https://crawlee.dev/js/docs/3.12/examples/']);
 }, mainOptions);

--- a/test/e2e/puppeteer-default/test.mjs
+++ b/test/e2e/puppeteer-default/test.mjs
@@ -6,5 +6,5 @@ await initialize(testActorDirname);
 const { stats, datasetItems } = await runActor(testActorDirname, 16384);
 
 await expect(stats.requestsFinished > 15, 'All requests finished');
-await expect(datasetItems.length > 15 && datasetItems.length < 25, 'Number of dataset items');
+await expect(datasetItems.length > 15 && datasetItems.length < 30, 'Number of dataset items');
 await expect(validateDataset(datasetItems, ['url', 'pageTitle']), 'Dataset items validation');

--- a/test/e2e/puppeteer-page-info/actor/main.js
+++ b/test/e2e/puppeteer-page-info/actor/main.js
@@ -43,5 +43,5 @@ await Actor.main(async () => {
         },
     });
 
-    await crawler.run([{ url: 'https://crawlee.dev/docs/3.0/examples', userData: { label: 'START' } }]);
+    await crawler.run([{ url: 'https://crawlee.dev/docs/3.12/examples', userData: { label: 'START' } }]);
 }, mainOptions);


### PR DESCRIPTION
https://github.com/apify/crawlee/pull/3066 removed and redirected some of the pages used for e2e tests. This PR points the e2e tests to existing URLs and fixes the assertions. 