### PR TITLE
chore: don't skip docs build on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,5 +226,5 @@ jobs:
                     git config --global user.name "Apify Release Bot"
                     git config --global user.email "noreply@apify.com"
                     git add .
-                    git diff-index --quiet HEAD || git commit -m 'chore(release): update docs for ${{ inputs.version }} version [skip ci]'
+                    git diff-index --quiet HEAD || git commit -m 'docs(release): update docs for ${{ inputs.version }} version'
                     git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,5 +226,5 @@ jobs:
                     git config --global user.name "Apify Release Bot"
                     git config --global user.email "noreply@apify.com"
                     git add .
-                    git diff-index --quiet HEAD || git commit -m 'docs(release): update docs for ${{ inputs.version }} version'
+                    git diff-index --quiet HEAD || git commit -m 'docs: update docs for ${{ inputs.version }} version'
                     git push


### PR DESCRIPTION
After creating the new version snapshot with `docusaurus version x.y`, we should deploy the docs.