### PR TITLE
docs(contributing): add setup instructions and local build troubleshooting guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,19 +6,21 @@ Please note we have a code of conduct, please follow it in all your interactions
 
 For Crawlee project contributions and changes to the codebase will require some pre-requisites to ensure the project is set up properly. These are the most important dependancies you'll need to set up the project, but here are other dev dependancies you might want to take a look at [package.json](./package.json) file.
 
-- node.js version 22.17.0
+- [Node.js](https://nodejs.org/en) v22.17.0
 
-- yarn version 4.8.1
+- [yarn](./CONTRIBUTING.md/#installing-yarn) v4.8.1
 
 
 ## Crawlee Installation and Building
 
+### Installing yarn
 This project now uses yarn v4 to manage dependencies. You will need to install it, the easiest way is by using `corepack`:
 
 ```shell
 corepack enable
 ```
 
+### Building the Project
 After enabling corepack, you will need to be in the project root directory and install the dependencies before building.
 
 ```shell
@@ -31,11 +33,28 @@ After installing the dependencies, you can build the Crawlee project.
 yarn build
 ```
 
-### Module not found
+### "Module not found" Fix
 
+**Note: Be sure to build the project in its original state first before contributing new code changes and following this.*
 
+In case you rebuild the project from the project root directory with new changes by `yarn build` and you run into issues relating to a missing module of `index.js` in the relative `dist` directory, this may be caused by `rimraf` behavior with the current location of relative paths. This can be fixed by the following:
 
+1. Navigate into `package.json` under the relevant folder with code changes. 
+(e.g. If your new code changes are in `./packages/core`, go into that `package.json`)
 
+2. Update "scripts" for `yarn clean` and give it the actual relative path.
+
+Example:
+```json
+"clean": "rimraf packages/core/dist",
+```
+**Note: Do not include this as a commit.*
+
+3. If there is a `dist` folder within the relative path, delete it manually.
+
+4. Try rebuilding the Crawlee project again using `yarn build`.
+
+If the fix is successful, you should be able to build the project without any issues. You do not need to manually delete the generated `dist` folder again.
 
 ## Submission guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,41 @@
 
 Please note we have a code of conduct, please follow it in all your interactions with the project.
 
+## Crawlee Project Pre-requisites
+
+For Crawlee project contributions and changes to the codebase will require some pre-requisites to ensure the project is set up properly. These are the most important dependancies you'll need to set up the project, but here are other dev dependancies you might want to take a look at [package.json](./package.json) file.
+
+- node.js version 22.17.0
+
+- yarn version 4.8.1
+
+
+## Crawlee Installation and Building
+
+This project now uses yarn v4 to manage dependencies. You will need to install it, the easiest way is by using `corepack`:
+
+```shell
+corepack enable
+```
+
+After enabling corepack, you will need to be in the project root directory and install the dependencies before building.
+
+```shell
+yarn install
+```
+
+After installing the dependencies, you can build the Crawlee project.
+
+```shell
+yarn build
+```
+
+### Module not found
+
+
+
+
+
 ## Submission guidelines
 
 ### Submitting an issue
@@ -33,14 +68,6 @@ Before you submit your pull request, consider the following guidelines:
     - Commit them and push. Don't rebase after you get a review, so it is clear what changes you did in the last commit. The PR will be squash merged, so its history is irrelevant.
 
 That's it! Thank you for your contribution!
-
-### Yarn
-
-This project now uses yarn v4 to manage dependencies. You will need to install it, the easiest way is by using `corepack`:
-
-```shell
-corepack enable
-```
 
 ### macOS
 


### PR DESCRIPTION
**Summary**  
This PR adds detailed setup and build instructions to help contributors initialize the Crawlee project locally and resolve common build issues. It documents required dependencies, Yarn installation via Corepack, and guidance on using `yarn build` successfully.

**Key Changes**  
**Documentation Additions:**  
- Added **Crawlee Project Pre-requisites** section listing required Node.js and Yarn versions.  
- Included a **Crawlee Installation and Building** guide with Corepack instructions and `yarn` commands.  
- Documented a common **"Module not found"** build error and a suggested local workaround by modifying `yarn clean` scripts and manually handling the `dist` directory.

**Important Notes:**  
- The workaround involving `rimraf` should be applied **locally only** and **must not** be committed.  
- These updates aim to streamline the developer onboarding and build process.

**Contributors:**  
1. Salvador Nunez: @SalvadorN323
2. Alexander Manalad: @axmanalad
3. Bao Truong: @baotruong04