### PR TITLE
feat: add `collectAllKeys` option for `BasicCrawler.exportData`

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -1240,7 +1240,22 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
         const items = await dataset.export(options);
 
         if (format === 'csv') {
-            const value = stringify([Object.keys(items[0]), ...items.map((item) => Object.values(item))]);
+            let value: string;
+            if (items.length === 0) {
+                value = '';
+            } else {
+                const keys = options?.collectAllKeys
+                    ? Array.from(new Set(items.flatMap(Object.keys)))
+                    : Object.keys(items[0]);
+
+                value = stringify([
+                    keys,
+                    ...items.map((item) => {
+                        return keys.map((k) => item[k]);
+                    }),
+                ]);
+            }
+
             await ensureDir(dirname(path));
             await writeFile(path, value);
             this.log.info(`Export to ${path} finished!`);

--- a/packages/core/src/storages/dataset.ts
+++ b/packages/core/src/storages/dataset.ts
@@ -141,7 +141,13 @@ export interface DatasetDataOptions {
     skipEmpty?: boolean;
 }
 
-export interface DatasetExportOptions extends Omit<DatasetDataOptions, 'offset' | 'limit'> {}
+export interface DatasetExportOptions extends Omit<DatasetDataOptions, 'offset' | 'limit'> {
+    /**
+     * If true, includes all unique keys from all dataset items in the CSV export header.
+     * If omitted or false, only keys from the first item are used.
+     */
+    collectAllKeys?: boolean;
+}
 
 export interface DatasetIteratorOptions
     extends Omit<DatasetDataOptions, 'offset' | 'limit' | 'clean' | 'skipHidden' | 'skipEmpty'> {
@@ -170,11 +176,6 @@ export interface DatasetIteratorOptions
 export interface DatasetExportToOptions extends DatasetExportOptions {
     fromDataset?: string;
     toKVS?: string;
-    /**
-     * If true, includes all unique keys from all dataset items in the CSV export.
-     * If omitted or false, only keys from the first item are used.
-     */
-    collectAllKeys?: boolean;
 }
 
 /**

--- a/test/core/crawlers/basic_crawler.test.ts
+++ b/test/core/crawlers/basic_crawler.test.ts
@@ -1730,6 +1730,19 @@ describe('BasicCrawler', () => {
             expect((await crawler.getData()).items).toEqual(payload);
         });
 
+        test('crawler.exportData works with `collectAllKeys`', async () => {
+            const crawler = new BasicCrawler();
+            await crawler.pushData([{ foo: 'bar', baz: 123 }]);
+            await crawler.pushData([{ foo: 'baz', qux: 456 }]);
+
+            await crawler.exportData(`${tmpDir}/result.csv`, 'csv', { collectAllKeys: true });
+
+            const csv = await readFile(`${tmpDir}/result.csv`);
+            expect(csv.toString()).toBe('foo,baz,qux\nbar,123,\nbaz,,456\n');
+
+            await rm(`${tmpDir}/result.csv`);
+        });
+
         test("Crawlers with different Configurations don't share Datasets", async () => {
             const crawlerA = new BasicCrawler({}, new Configuration({ persistStorage: false }));
             const crawlerB = new BasicCrawler({}, new Configuration({ persistStorage: false }));


### PR DESCRIPTION
Ports the `collectAllKeys` option from #3007 to the `BasicCrawler.exportData` method. `Dataset.exportTo` and `BasicCrawler.exportData` seem way too similar for this omission to be intentional. If it is so, feel free to close this PR.