### PR TITLE
docs: fix `utilities` card link on homepage

### DIFF
--- a/website/src/pages/js.js
+++ b/website/src/pages/js.js
@@ -215,7 +215,7 @@ function OtherFeaturesSection() {
                             title: 'Handy scraping utils',
                             description:
                                 'Sitemaps, infinite scroll, contact extraction, large asset blocking and many more utils included.',
-                            to: '/js/docs/guides/avoid-blocking',
+                            to: '/js/api/utils',
                         },
                         {
                             icon: (


### PR DESCRIPTION
The box with "Handy scraping utils" on Crawlee JS homepage (https://crawlee.dev/js) leads to avoid-blocking instead of utils