### PR TITLE
fix: correctly apply `launchOptions` with `useIncognitoPages`

### DIFF
--- a/packages/browser-pool/src/playwright/playwright-controller.ts
+++ b/packages/browser-pool/src/playwright/playwright-controller.ts
@@ -48,21 +48,29 @@ export class PlaywrightController extends BrowserController<
 
         let close = async () => {};
 
-        if (this.launchContext.useIncognitoPages && contextOptions?.proxy) {
-            const [anonymizedProxyUrl, closeProxy] = await anonymizeProxySugar(
-                contextOptions.proxy.server,
-                contextOptions.proxy.username,
-                contextOptions.proxy.password,
-            );
+        if (this.launchContext.useIncognitoPages) {
+            // Each page requires to have all the context options applied
+            contextOptions = {
+                ...this.launchContext.launchOptions,
+                ...contextOptions,
+            };
 
-            if (anonymizedProxyUrl) {
-                contextOptions.proxy = {
-                    server: anonymizedProxyUrl,
-                    bypass: contextOptions.proxy.bypass,
-                };
+            if (contextOptions?.proxy) {
+                const [anonymizedProxyUrl, closeProxy] = await anonymizeProxySugar(
+                    contextOptions.proxy.server,
+                    contextOptions.proxy.username,
+                    contextOptions.proxy.password,
+                );
+
+                if (anonymizedProxyUrl) {
+                    contextOptions.proxy = {
+                        server: anonymizedProxyUrl,
+                        bypass: contextOptions.proxy.bypass,
+                    };
+                }
+
+                close = closeProxy;
             }
-
-            close = closeProxy;
         }
 
         try {


### PR DESCRIPTION
`launchContext.launchOptions` are not applied with `useIncognitoPages` in `PlaywrightCrawler` because of the split between Browser and BrowserContext in Playwright.

See more details in [the comment](https://github.com/apify/crawlee/issues/3173#issuecomment-3346728227) to #3173 .

Closes #3173 