### PR TITLE
fix: handle TLSSocket errors to prevent process crashes

### DIFF
--- a/packages/core/src/http_clients/got-scraping-http-client.ts
+++ b/packages/core/src/http_clients/got-scraping-http-client.ts
@@ -59,6 +59,18 @@ export class GotScrapingHttpClient implements BaseHttpClient {
             stream.on('error', reject);
 
             stream.on('response', (response: PlainResponse) => {
+                // Handle socket errors to prevent unhandled TLS errors from crashing the process.
+                // TLS errors are emitted on the underlying socket (response.socket), not the got stream.
+                // Without this handler, errors like ERR_SSL_SSLV3_ALERT_UNEXPECTED_MESSAGE crash the process.
+                const socket = (response as any).socket;
+                if (socket && typeof socket.on === 'function') {
+                    socket.on('error', (err: Error) => {
+                        if (!stream.destroyed) {
+                            stream.destroy(err);
+                        }
+                    });
+                }
+
                 const result: StreamingHttpResponse = {
                     stream,
                     request,

--- a/packages/core/src/http_clients/got-scraping-http-client.ts
+++ b/packages/core/src/http_clients/got-scraping-http-client.ts
@@ -62,12 +62,11 @@ export class GotScrapingHttpClient implements BaseHttpClient {
                 // Handle socket errors to prevent unhandled TLS errors from crashing the process.
                 // TLS errors are emitted on the underlying socket (response.socket), not the got stream.
                 // Without this handler, errors like ERR_SSL_SSLV3_ALERT_UNEXPECTED_MESSAGE crash the process.
+                // Using `once` to avoid memory leaks from accumulated listeners on pooled sockets.
                 const socket = (response as any).socket;
-                if (socket && typeof socket.on === 'function') {
-                    socket.on('error', (err: Error) => {
-                        if (!stream.destroyed) {
-                            stream.destroy(err);
-                        }
+                if (socket && typeof socket.once === 'function') {
+                    socket.once('error', (err: Error) => {
+                        stream.destroy(err);
                     });
                 }
 

--- a/packages/core/src/http_clients/got-scraping-http-client.ts
+++ b/packages/core/src/http_clients/got-scraping-http-client.ts
@@ -42,32 +42,17 @@ export class GotScrapingHttpClient implements BaseHttpClient {
     /**
      * @inheritDoc
      */
-    async stream(
-        request: HttpRequest,
-        handleRedirect?: RedirectHandler,
-    ): Promise<StreamingHttpResponse> {
+    async stream(request: HttpRequest, handleRedirect?: RedirectHandler): Promise<StreamingHttpResponse> {
         // eslint-disable-next-line no-async-promise-executor
         return new Promise(async (resolve, reject) => {
-            const stream = await Promise.resolve(
-                gotScraping({
-                    ...request,
-                    isStream: true,
-                    cookieJar: undefined,
-                }),
-            );
+            const stream = await Promise.resolve(gotScraping({ ...request, isStream: true, cookieJar: undefined }));
 
-            stream.on(
-                'redirect',
-                (updatedOptions: Options, redirectResponse: PlainResponse) => {
-                    handleRedirect?.(redirectResponse, updatedOptions);
-                },
-            );
+            stream.on('redirect', (updatedOptions: Options, redirectResponse: PlainResponse) => {
+                handleRedirect?.(redirectResponse, updatedOptions);
+            });
 
             // We need to end the stream for DELETE requests, otherwise it will hang.
-            if (
-                request.method &&
-                ['DELETE', 'delete'].includes(request.method)
-            ) {
+            if (request.method && ['DELETE', 'delete'].includes(request.method)) {
                 stream.end();
             }
 
@@ -115,10 +100,7 @@ export class GotScrapingHttpClient implements BaseHttpClient {
                     Object.assign(result.trailers, response.trailers);
 
                     (result as any).rawTrailers ??= []; // TODO BC - remove in 4.0
-                    Object.assign(
-                        (result as any).rawTrailers,
-                        response.rawTrailers,
-                    );
+                    Object.assign((result as any).rawTrailers, response.rawTrailers);
                 });
             });
         });

--- a/packages/core/src/http_clients/got-scraping-http-client.ts
+++ b/packages/core/src/http_clients/got-scraping-http-client.ts
@@ -42,17 +42,32 @@ export class GotScrapingHttpClient implements BaseHttpClient {
     /**
      * @inheritDoc
      */
-    async stream(request: HttpRequest, handleRedirect?: RedirectHandler): Promise<StreamingHttpResponse> {
+    async stream(
+        request: HttpRequest,
+        handleRedirect?: RedirectHandler,
+    ): Promise<StreamingHttpResponse> {
         // eslint-disable-next-line no-async-promise-executor
         return new Promise(async (resolve, reject) => {
-            const stream = await Promise.resolve(gotScraping({ ...request, isStream: true, cookieJar: undefined }));
+            const stream = await Promise.resolve(
+                gotScraping({
+                    ...request,
+                    isStream: true,
+                    cookieJar: undefined,
+                }),
+            );
 
-            stream.on('redirect', (updatedOptions: Options, redirectResponse: PlainResponse) => {
-                handleRedirect?.(redirectResponse, updatedOptions);
-            });
+            stream.on(
+                'redirect',
+                (updatedOptions: Options, redirectResponse: PlainResponse) => {
+                    handleRedirect?.(redirectResponse, updatedOptions);
+                },
+            );
 
             // We need to end the stream for DELETE requests, otherwise it will hang.
-            if (request.method && ['DELETE', 'delete'].includes(request.method)) {
+            if (
+                request.method &&
+                ['DELETE', 'delete'].includes(request.method)
+            ) {
                 stream.end();
             }
 
@@ -100,7 +115,10 @@ export class GotScrapingHttpClient implements BaseHttpClient {
                     Object.assign(result.trailers, response.trailers);
 
                     (result as any).rawTrailers ??= []; // TODO BC - remove in 4.0
-                    Object.assign((result as any).rawTrailers, response.rawTrailers);
+                    Object.assign(
+                        (result as any).rawTrailers,
+                        response.rawTrailers,
+                    );
                 });
             });
         });

--- a/test/core/crawlers/socket_error_handling.test.ts
+++ b/test/core/crawlers/socket_error_handling.test.ts
@@ -104,7 +104,7 @@ describe('HttpCrawler socket error handling', () => {
             maxRequestRetries: 0,
             maxConcurrency: 1,
             requestHandler: ({ body }) => {
-                results.push(body as string);
+                results.push(body.toString());
             },
         });
 
@@ -123,7 +123,7 @@ describe('HttpCrawler socket error handling', () => {
             maxRequestRetries: 0,
             maxConcurrency: 1,
             requestHandler: ({ body }) => {
-                results.push(body as string);
+                results.push(body.toString());
             },
             failedRequestHandler: (_ctx, error) => {
                 errors.push(error as Error);

--- a/test/core/crawlers/socket_error_handling.test.ts
+++ b/test/core/crawlers/socket_error_handling.test.ts
@@ -18,6 +18,7 @@ router.set('/ok', (_req, res) => {
 
 router.set('/destroy-socket-after-headers', (req, res) => {
     // Send headers, start body, then destroy the socket to simulate a mid-response error.
+    // This simulates the TLS error scenario where the socket fails after headers are sent.
     res.setHeader('content-type', 'text/html; charset=utf-8');
     res.setHeader('content-length', '10000');
     res.write('<html>');
@@ -27,11 +28,6 @@ router.set('/destroy-socket-after-headers', (req, res) => {
     setTimeout(() => {
         req.socket.destroy();
     }, 50);
-});
-
-router.set('/destroy-socket-immediately', (_req, res) => {
-    // Destroy the socket immediately without sending any response.
-    res.socket!.destroy();
 });
 
 beforeAll(async () => {
@@ -63,13 +59,6 @@ beforeAll(async () => {
     );
 });
 
-afterAll(async () => {
-    for (const socket of sockets) {
-        socket.destroy();
-    }
-    await new Promise((resolve) => server.close(resolve));
-});
-
 const localStorageEmulator = new MemoryStorageEmulator();
 
 beforeEach(async () => {
@@ -77,57 +66,15 @@ beforeEach(async () => {
 });
 
 afterAll(async () => {
+    for (const socket of sockets) {
+        socket.destroy();
+    }
+    await new Promise((resolve) => server.close(resolve));
     await localStorageEmulator.destroy();
 });
 
-describe('GotScrapingHttpClient socket error handling', () => {
-    const httpClient = new GotScrapingHttpClient();
-
-    test('socket error after response should not crash the process', async () => {
-        const response = await httpClient.stream({ url: `${url}/destroy-socket-after-headers` });
-
-        // The stream should eventually emit an error (not crash the process).
-        await new Promise<void>((resolve, reject) => {
-            const timeout = setTimeout(() => reject(new Error('Timed out waiting for stream error or end')), 10_000);
-
-            response.stream.on('error', () => {
-                clearTimeout(timeout);
-                resolve();
-            });
-
-            response.stream.on('end', () => {
-                clearTimeout(timeout);
-                // It's also acceptable if the stream ends without error
-                // (depends on timing), but the key thing is: no process crash.
-                resolve();
-            });
-
-            response.stream.resume();
-        });
-    });
-
-    test('socket destroyed immediately should reject the stream promise', async () => {
-        await expect(httpClient.stream({ url: `${url}/destroy-socket-immediately` })).rejects.toThrow();
-    });
-
-    test('normal request via stream works correctly', async () => {
-        const response = await httpClient.stream({ url: `${url}/ok` });
-
-        const chunks: Buffer[] = [];
-        await new Promise<void>((resolve, reject) => {
-            response.stream.on('data', (chunk: Buffer) => chunks.push(chunk));
-            response.stream.on('end', resolve);
-            response.stream.on('error', reject);
-        });
-
-        const body = Buffer.concat(chunks).toString();
-        expect(body).toContain('OK');
-        expect(response.statusCode).toBe(200);
-    });
-});
-
 describe('HttpCrawler socket error handling', () => {
-    test('should handle mid-response socket destruction gracefully', async () => {
+    test('should handle mid-response socket destruction gracefully without crashing', async () => {
         const errors: Error[] = [];
 
         const crawler = new HttpCrawler({
@@ -135,7 +82,7 @@ describe('HttpCrawler socket error handling', () => {
             maxRequestRetries: 0,
             maxConcurrency: 1,
             requestHandler: () => {
-                // Should not reach here for the error case
+                // Should not complete successfully for the error case
             },
             failedRequestHandler: (_ctx, error) => {
                 errors.push(error as Error);
@@ -145,29 +92,29 @@ describe('HttpCrawler socket error handling', () => {
         await crawler.run([`${url}/destroy-socket-after-headers`]);
 
         // The request should have failed (not crashed the process).
+        // The key assertion is that we reach this point without process crash.
         expect(errors.length).toBe(1);
     });
 
-    test('should handle socket destruction without response gracefully', async () => {
-        const errors: Error[] = [];
+    test('normal requests still work correctly', async () => {
+        const results: string[] = [];
 
         const crawler = new HttpCrawler({
             httpClient: new GotScrapingHttpClient(),
             maxRequestRetries: 0,
             maxConcurrency: 1,
-            requestHandler: () => {},
-            failedRequestHandler: (_ctx, error) => {
-                errors.push(error as Error);
+            requestHandler: ({ body }) => {
+                results.push(body as string);
             },
         });
 
-        await crawler.run([`${url}/destroy-socket-immediately`]);
+        await crawler.run([`${url}/ok`]);
 
-        // The request should have failed gracefully.
-        expect(errors.length).toBe(1);
+        expect(results.length).toBe(1);
+        expect(results[0]).toContain('OK');
     });
 
-    test('normal requests still work after socket errors', async () => {
+    test('crawler recovers after socket error and processes next request', async () => {
         const results: string[] = [];
         const errors: Error[] = [];
 

--- a/test/core/crawlers/socket_error_handling.test.ts
+++ b/test/core/crawlers/socket_error_handling.test.ts
@@ -137,7 +137,7 @@ describe('HttpCrawler socket error handling', () => {
             requestHandler: () => {
                 // Should not reach here for the error case
             },
-            failedRequestHandler: ({ request }, error) => {
+            failedRequestHandler: (_ctx, error) => {
                 errors.push(error as Error);
             },
         });
@@ -156,7 +156,7 @@ describe('HttpCrawler socket error handling', () => {
             maxRequestRetries: 0,
             maxConcurrency: 1,
             requestHandler: () => {},
-            failedRequestHandler: ({ request }, error) => {
+            failedRequestHandler: (_ctx, error) => {
                 errors.push(error as Error);
             },
         });

--- a/test/core/crawlers/socket_error_handling.test.ts
+++ b/test/core/crawlers/socket_error_handling.test.ts
@@ -1,0 +1,196 @@
+import http from 'node:http';
+import type { AddressInfo, Socket } from 'node:net';
+
+import { GotScrapingHttpClient, HttpCrawler } from '@crawlee/http';
+import { MemoryStorageEmulator } from 'test/shared/MemoryStorageEmulator';
+
+let server: http.Server;
+let url: string;
+
+const sockets = new Set<Socket>();
+
+const router = new Map<string, http.RequestListener>();
+
+router.set('/ok', (_req, res) => {
+    res.setHeader('content-type', 'text/html; charset=utf-8');
+    res.end('<html><body>OK</body></html>');
+});
+
+router.set('/destroy-socket-after-headers', (req, res) => {
+    // Send headers, start body, then destroy the socket to simulate a mid-response error.
+    res.setHeader('content-type', 'text/html; charset=utf-8');
+    res.setHeader('content-length', '10000');
+    res.write('<html>');
+
+    // Destroy the underlying socket after a short delay to trigger an error
+    // after the 'response' event has already fired.
+    setTimeout(() => {
+        req.socket.destroy();
+    }, 50);
+});
+
+router.set('/destroy-socket-immediately', (_req, res) => {
+    // Destroy the socket immediately without sending any response.
+    res.socket!.destroy();
+});
+
+beforeAll(async () => {
+    server = http.createServer((request, response) => {
+        try {
+            const requestUrl = new URL(request.url!, 'http://localhost');
+            const handler = router.get(requestUrl.pathname);
+            if (handler) {
+                handler(request, response);
+            } else {
+                response.statusCode = 404;
+                response.end();
+            }
+        } catch {
+            response.destroy();
+        }
+    });
+
+    server.on('connection', (socket) => {
+        sockets.add(socket);
+        socket.on('close', () => sockets.delete(socket));
+    });
+
+    await new Promise<void>((resolve) =>
+        server.listen(() => {
+            url = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+            resolve();
+        }),
+    );
+});
+
+afterAll(async () => {
+    for (const socket of sockets) {
+        socket.destroy();
+    }
+    await new Promise((resolve) => server.close(resolve));
+});
+
+const localStorageEmulator = new MemoryStorageEmulator();
+
+beforeEach(async () => {
+    await localStorageEmulator.init();
+});
+
+afterAll(async () => {
+    await localStorageEmulator.destroy();
+});
+
+describe('GotScrapingHttpClient socket error handling', () => {
+    const httpClient = new GotScrapingHttpClient();
+
+    test('socket error after response should not crash the process', async () => {
+        const response = await httpClient.stream({ url: `${url}/destroy-socket-after-headers` });
+
+        // The stream should eventually emit an error (not crash the process).
+        await new Promise<void>((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('Timed out waiting for stream error or end')), 10_000);
+
+            response.stream.on('error', () => {
+                clearTimeout(timeout);
+                resolve();
+            });
+
+            response.stream.on('end', () => {
+                clearTimeout(timeout);
+                // It's also acceptable if the stream ends without error
+                // (depends on timing), but the key thing is: no process crash.
+                resolve();
+            });
+
+            response.stream.resume();
+        });
+    });
+
+    test('socket destroyed immediately should reject the stream promise', async () => {
+        await expect(httpClient.stream({ url: `${url}/destroy-socket-immediately` })).rejects.toThrow();
+    });
+
+    test('normal request via stream works correctly', async () => {
+        const response = await httpClient.stream({ url: `${url}/ok` });
+
+        const chunks: Buffer[] = [];
+        await new Promise<void>((resolve, reject) => {
+            response.stream.on('data', (chunk: Buffer) => chunks.push(chunk));
+            response.stream.on('end', resolve);
+            response.stream.on('error', reject);
+        });
+
+        const body = Buffer.concat(chunks).toString();
+        expect(body).toContain('OK');
+        expect(response.statusCode).toBe(200);
+    });
+});
+
+describe('HttpCrawler socket error handling', () => {
+    test('should handle mid-response socket destruction gracefully', async () => {
+        const errors: Error[] = [];
+
+        const crawler = new HttpCrawler({
+            httpClient: new GotScrapingHttpClient(),
+            maxRequestRetries: 0,
+            maxConcurrency: 1,
+            requestHandler: () => {
+                // Should not reach here for the error case
+            },
+            failedRequestHandler: ({ request }, error) => {
+                errors.push(error as Error);
+            },
+        });
+
+        await crawler.run([`${url}/destroy-socket-after-headers`]);
+
+        // The request should have failed (not crashed the process).
+        expect(errors.length).toBe(1);
+    });
+
+    test('should handle socket destruction without response gracefully', async () => {
+        const errors: Error[] = [];
+
+        const crawler = new HttpCrawler({
+            httpClient: new GotScrapingHttpClient(),
+            maxRequestRetries: 0,
+            maxConcurrency: 1,
+            requestHandler: () => {},
+            failedRequestHandler: ({ request }, error) => {
+                errors.push(error as Error);
+            },
+        });
+
+        await crawler.run([`${url}/destroy-socket-immediately`]);
+
+        // The request should have failed gracefully.
+        expect(errors.length).toBe(1);
+    });
+
+    test('normal requests still work after socket errors', async () => {
+        const results: string[] = [];
+        const errors: Error[] = [];
+
+        const crawler = new HttpCrawler({
+            httpClient: new GotScrapingHttpClient(),
+            maxRequestRetries: 0,
+            maxConcurrency: 1,
+            requestHandler: ({ body }) => {
+                results.push(body as string);
+            },
+            failedRequestHandler: (_ctx, error) => {
+                errors.push(error as Error);
+            },
+        });
+
+        await crawler.run([
+            `${url}/destroy-socket-after-headers`,
+            `${url}/ok`,
+        ]);
+
+        // One should fail and one should succeed, but no process crash.
+        expect(errors.length).toBe(1);
+        expect(results.length).toBe(1);
+        expect(results[0]).toContain('OK');
+    });
+});

--- a/test/core/crawlers/socket_error_handling.test.ts
+++ b/test/core/crawlers/socket_error_handling.test.ts
@@ -130,10 +130,7 @@ describe('HttpCrawler socket error handling', () => {
             },
         });
 
-        await crawler.run([
-            `${url}/destroy-socket-after-headers`,
-            `${url}/ok`,
-        ]);
+        await crawler.run([`${url}/destroy-socket-after-headers`, `${url}/ok`]);
 
         // One should fail and one should succeed, but no process crash.
         expect(errors.length).toBe(1);


### PR DESCRIPTION
Handle unhandled TLS errors that crash the entire Node.js process.

When an SSL/TLS error occurs after the HTTP response is received (e.g., ERR_SSL_SSLV3_ALERT_UNEXPECTED_MESSAGE), it's emitted on the underlying TLSSocket, not the got stream. Without an error handler on the socket, this causes the entire process to crash with an unhandled 'error' event.

The fix attaches an error handler to response.socket that forwards any socket errors to the stream, allowing them to be caught and handled gracefully by the crawler's error handling logic.

Slack thread: https://apify.slack.com/archives/C0L33UM7Z/p1773164573254719?thread_ts=1770229918.703079&cid=C0L33UM7Z

https://claude.ai/code/session_012AxrDZSUiDu2WU4CVuvwXG