### PR TITLE
fix: improve ServiceConflictError message readability

### DIFF
--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -65,9 +65,16 @@ export class RequestHandlerError extends Error {
  */
 export class ServiceConflictError extends Error {
     constructor(serviceName: string, newValue: unknown, existingValue: unknown) {
+        const describe = (value: unknown): string => {
+            if (typeof value === 'object' && value !== null) {
+                return value.constructor.name;
+            }
+            return String(value);
+        };
+
         super(
             `Service ${serviceName} is already in use. ` +
-                `Existing value: ${existingValue}, attempted new value: ${newValue}.`,
+                `Existing value: ${describe(existingValue)}, attempted new value: ${describe(newValue)}.`,
         );
     }
 }


### PR DESCRIPTION
```
ServiceConflictError: Service Logger is already in use. Existing value: [object Object], attempted new value: [object Object].
```
- use constructor.name if possible to get rid of [object Object]