### PR TITLE
feat(`session-pool`): add `sessionReuseStrategy` option

### DIFF
--- a/docs/guides/session_management.mdx
+++ b/docs/guides/session_management.mdx
@@ -86,7 +86,7 @@ The `sessionReuseStrategy` option controls how sessions are picked from the pool
 
 **`random`** (default) — the pool fills up to `maxPoolSize` by creating a new session for every request, then picks randomly from the available sessions. Best for maximising fingerprint and IP diversity.
 
-**`round-robin`** — the pool reuses existing sessions immediately, cycling through them in order. A new session is only created when all existing ones have been retired. Best when you want even load distribution across sessions, for example when combined with `maxUsageCount` to ensure all sessions expire at roughly the same time.
+**`round-robin`** — like `random`, the pool fills up to `maxPoolSize` first, then cycles through the sessions in order instead of picking randomly. Best when you want even load distribution across sessions, for example when combined with `maxUsageCount` to ensure all sessions expire at roughly the same time.
 
 **`use-until-failure`** — the same session is returned on every call until it is retired, then the next available one is used. Best for proxy session stickiness, where you want to keep the same IP for as long as possible before rotating.
 

--- a/docs/guides/session_management.mdx
+++ b/docs/guides/session_management.mdx
@@ -24,8 +24,8 @@ The main benefit of using Session pool is that we can filter out blocked or non-
 so our actor does not retry requests over known blocked/non-working proxies.
 Another benefit of using SessionPool is that we can store information tied tightly to an IP address,
 such as cookies, auth tokens, and particular headers. Having our cookies and other identifiers used only with a specific IP will reduce the chance of being blocked.
-The last but not least benefit is the even rotation of IP addresses - SessionPool  picks the session randomly,
-which should prevent burning out a small pool of available IPs.
+The last but not least benefit is the even rotation of IP addresses - by default, SessionPool picks sessions randomly,
+which should prevent burning out a small pool of available IPs. The selection strategy is configurable — see below.
 
 Check out the [avoid blocking guide](./avoid-blocking) for more information about blocking.
 
@@ -79,3 +79,19 @@ Now let's take a look at the examples of how to use Session pool:
 These are the basics of configuring SessionPool.
 Please, bear in mind that a Session pool needs time to find working IPs and build up the pool,
 so we will probably see a lot of errors until it becomes stabilized.
+
+## Session reuse strategy
+
+The `sessionReuseStrategy` option controls how sessions are picked from the pool. Three strategies are available:
+
+**`random`** (default) — the pool fills up to `maxPoolSize` by creating a new session for every request, then picks randomly from the available sessions. Best for maximising fingerprint and IP diversity.
+
+**`round-robin`** — the pool reuses existing sessions immediately, cycling through them in order. A new session is only created when all existing ones have been retired. Best when you want even load distribution across sessions, for example when combined with `maxUsageCount` to ensure all sessions expire at roughly the same time.
+
+**`use-until-failure`** — the same session is returned on every call until it is retired, then the next available one is used. Best for proxy session stickiness, where you want to keep the same IP for as long as possible before rotating.
+
+```js
+const sessionPool = new SessionPool({
+    sessionReuseStrategy: 'use-until-failure',
+});
+```

--- a/packages/core/src/session_pool/session_pool.ts
+++ b/packages/core/src/session_pool/session_pool.ts
@@ -503,6 +503,7 @@ export class SessionPool extends EventEmitter {
         }
 
         if (this.sessionReuseStrategy === 'round-robin') {
+            if (this._hasSpaceForSession()) return undefined;
             this.roundRobinIndex = this.roundRobinIndex % usable.length;
             return usable[this.roundRobinIndex++];
         }

--- a/packages/core/src/session_pool/session_pool.ts
+++ b/packages/core/src/session_pool/session_pool.ts
@@ -491,32 +491,19 @@ export class SessionPool extends EventEmitter {
         if (this.sessionReuseStrategy !== 'use-until-failure' && this._hasSpaceForSession()) return undefined;
 
         if (this.sessionReuseStrategy === 'use-until-failure') {
-            for (const session of this.sessions) {
-                if (session.isUsable()) return session;
-            }
-            return undefined;
+            return this.sessions.find((session) => session.isUsable());
         }
 
-        // For random and round-robin: if any session in a full pool is retired, trigger cleanup
-        // by returning undefined so getSession calls _removeRetiredSessions + _createSession.
-        for (const session of this.sessions) {
-            if (!session.isUsable()) return undefined;
-        }
-
+        let picked: Session;
         if (this.sessionReuseStrategy === 'round-robin') {
-            const { length } = this.sessions;
-            const index = this.roundRobinIndex % length;
+            const index = this.roundRobinIndex % this.sessions.length;
             this.roundRobinIndex = index + 1;
-            return this.sessions[index];
+            picked = this.sessions[index];
+        } else {
+            picked = this.sessions[this._getRandomIndex()];
         }
 
-        // random: reservoir sampling over sessions (all usable at this point)
-        let selected: Session | undefined;
-        let count = 0;
-        for (const session of this.sessions) {
-            if (++count === 1 || Math.random() < 1 / count) selected = session;
-        }
-        return selected;
+        return picked.isUsable() ? picked : undefined;
     }
 
     /**

--- a/packages/core/src/session_pool/session_pool.ts
+++ b/packages/core/src/session_pool/session_pool.ts
@@ -488,25 +488,19 @@ export class SessionPool extends EventEmitter {
      * Returns `undefined` when no session should be reused and a new one should be created instead.
      */
     protected _pickSession(): Session | undefined {
-        if (this.sessionReuseStrategy === 'random') {
-            if (this._hasSpaceForSession()) return undefined;
-            const usable = this.sessions.filter((s) => s.isUsable());
-            if (usable.length === 0) return undefined;
-            return usable[Math.floor(Math.random() * usable.length)];
-        }
+        if (this.sessionReuseStrategy !== 'use-until-failure' && this._hasSpaceForSession()) return undefined;
 
         const usable = this.sessions.filter((s) => s.isUsable());
         if (usable.length === 0) return undefined;
 
-        if (this.sessionReuseStrategy === 'use-until-failure') {
-            return usable[0];
-        }
+        if (this.sessionReuseStrategy === 'use-until-failure') return usable[0];
 
         if (this.sessionReuseStrategy === 'round-robin') {
-            if (this._hasSpaceForSession()) return undefined;
             this.roundRobinIndex = this.roundRobinIndex % usable.length;
             return usable[this.roundRobinIndex++];
         }
+
+        return usable[Math.floor(Math.random() * usable.length)];
     }
 
     /**

--- a/packages/core/src/session_pool/session_pool.ts
+++ b/packages/core/src/session_pool/session_pool.ts
@@ -64,7 +64,7 @@ export interface SessionPoolOptions {
     /**
      * Strategy for picking sessions from the pool.
      * - `'random'` (default): fills the pool up to `maxPoolSize`, then picks a random usable session
-     * - `'round-robin'`: reuses existing sessions cycling through them in order, only creates new ones when all are retired
+     * - `'round-robin'`: fills the pool up to `maxPoolSize`, then reuses sessions cycling through them in order
      * - `'use-until-failure'`: always reuses the same session until it is retired, then moves to the next one
      * @default 'random'
      */
@@ -490,17 +490,33 @@ export class SessionPool extends EventEmitter {
     protected _pickSession(): Session | undefined {
         if (this.sessionReuseStrategy !== 'use-until-failure' && this._hasSpaceForSession()) return undefined;
 
-        const usable = this.sessions.filter((s) => s.isUsable());
-        if (usable.length === 0) return undefined;
-
-        if (this.sessionReuseStrategy === 'use-until-failure') return usable[0];
-
-        if (this.sessionReuseStrategy === 'round-robin') {
-            this.roundRobinIndex = this.roundRobinIndex % usable.length;
-            return usable[this.roundRobinIndex++];
+        if (this.sessionReuseStrategy === 'use-until-failure') {
+            for (const session of this.sessions) {
+                if (session.isUsable()) return session;
+            }
+            return undefined;
         }
 
-        return usable[Math.floor(Math.random() * usable.length)];
+        // For random and round-robin: if any session in a full pool is retired, trigger cleanup
+        // by returning undefined so getSession calls _removeRetiredSessions + _createSession.
+        for (const session of this.sessions) {
+            if (!session.isUsable()) return undefined;
+        }
+
+        if (this.sessionReuseStrategy === 'round-robin') {
+            const { length } = this.sessions;
+            const index = this.roundRobinIndex % length;
+            this.roundRobinIndex = index + 1;
+            return this.sessions[index];
+        }
+
+        // random: reservoir sampling over sessions (all usable at this point)
+        let selected: Session | undefined;
+        let count = 0;
+        for (const session of this.sessions) {
+            if (++count === 1 || Math.random() < 1 / count) selected = session;
+        }
+        return selected;
     }
 
     /**

--- a/packages/core/src/session_pool/session_pool.ts
+++ b/packages/core/src/session_pool/session_pool.ts
@@ -14,6 +14,9 @@ import { MAX_POOL_SIZE, PERSIST_STATE_KEY } from './consts.js';
 import type { SessionOptions } from './session.js';
 import { Session } from './session.js';
 
+const SESSION_REUSE_STRATEGIES = ['random', 'round-robin', 'use-until-failure'] as const;
+export type SessionReuseStrategy = (typeof SESSION_REUSE_STRATEGIES)[number];
+
 /**
  * Factory user-function which creates customized {@apilink Session} instances.
  */
@@ -57,6 +60,15 @@ export interface SessionPoolOptions {
      * Function receives `SessionPool` instance as a parameter
      */
     createSessionFunction?: CreateSession;
+
+    /**
+     * Strategy for picking sessions from the pool.
+     * - `'random'` (default): fills the pool up to `maxPoolSize`, then picks a random usable session
+     * - `'round-robin'`: reuses existing sessions cycling through them in order, only creates new ones when all are retired
+     * - `'use-until-failure'`: always reuses the same session until it is retired, then moves to the next one
+     * @default 'random'
+     */
+    sessionReuseStrategy?: SessionReuseStrategy;
 
     /** @internal */
     log?: CrawleeLogger;
@@ -136,9 +148,11 @@ export class SessionPool extends EventEmitter {
     protected _listener?: () => Promise<void>;
     protected events: EventManager;
     protected persistenceOptions: PersistenceOptions;
+    protected sessionReuseStrategy: SessionReuseStrategy;
 
     private initPromise?: Promise<void>;
     private queue = new AsyncQueue();
+    private roundRobinIndex = 0;
 
     constructor(options: SessionPoolOptions = {}) {
         super();
@@ -154,6 +168,7 @@ export class SessionPool extends EventEmitter {
                 sessionOptions: ow.optional.object,
                 log: ow.optional.object,
                 persistenceOptions: ow.optional.object,
+                sessionReuseStrategy: ow.optional.string.oneOf([...SESSION_REUSE_STRATEGIES]),
             }),
         );
 
@@ -168,9 +183,11 @@ export class SessionPool extends EventEmitter {
             persistenceOptions = {
                 enable: true,
             },
+            sessionReuseStrategy = 'random',
         } = options;
 
         this.id = id != null ? String(id) : String(SessionPool.nextId++);
+        this.sessionReuseStrategy = sessionReuseStrategy;
         this.events = serviceLocator.getEventManager();
         this.log = log.child({ prefix: 'SessionPool' });
         this.persistenceOptions = persistenceOptions;
@@ -314,13 +331,11 @@ export class SessionPool extends EventEmitter {
                 return undefined;
             }
 
+            const pickedSession = this._pickSession();
+            if (pickedSession) return pickedSession;
+
             if (this._hasSpaceForSession()) {
                 return await this._createSession();
-            }
-
-            const pickedSession = this._pickSession();
-            if (pickedSession.isUsable()) {
-                return pickedSession;
             }
 
             this._removeRetiredSessions();
@@ -469,11 +484,28 @@ export class SessionPool extends EventEmitter {
     }
 
     /**
-     * Picks random session from the `SessionPool`.
-     * @returns Picked `Session`.
+     * Picks a session from the `SessionPool` according to the configured `sessionReuseStrategy`.
+     * Returns `undefined` when no session should be reused and a new one should be created instead.
      */
-    protected _pickSession(): Session {
-        return this.sessions[this._getRandomIndex()]; // Or maybe we should let the developer to customize the picking algorithm
+    protected _pickSession(): Session | undefined {
+        if (this.sessionReuseStrategy === 'random') {
+            if (this._hasSpaceForSession()) return undefined;
+            const usable = this.sessions.filter((s) => s.isUsable());
+            if (usable.length === 0) return undefined;
+            return usable[Math.floor(Math.random() * usable.length)];
+        }
+
+        const usable = this.sessions.filter((s) => s.isUsable());
+        if (usable.length === 0) return undefined;
+
+        if (this.sessionReuseStrategy === 'use-until-failure') {
+            return usable[0];
+        }
+
+        if (this.sessionReuseStrategy === 'round-robin') {
+            this.roundRobinIndex = this.roundRobinIndex % usable.length;
+            return usable[this.roundRobinIndex++];
+        }
     }
 
     /**

--- a/test/core/session_pool/session_pool.test.ts
+++ b/test/core/session_pool/session_pool.test.ts
@@ -426,6 +426,68 @@ describe('SessionPool - testing session pool', () => {
         expect(sessionPool.sessions.length).toEqual(sessionPool.sessionMap.size);
     });
 
+    describe('sessionReuseStrategy', () => {
+        test('random should fill pool before reusing sessions', async () => {
+            sessionPool = new SessionPool({ sessionReuseStrategy: 'random', maxPoolSize: 3 });
+
+            const s1 = await sessionPool.getSession();
+            const s2 = await sessionPool.getSession();
+            const s3 = await sessionPool.getSession();
+
+            expect(new Set([s1.id, s2.id, s3.id]).size).toBe(3);
+
+            const s4 = await sessionPool.getSession();
+            expect([s1.id, s2.id, s3.id]).toContain(s4.id);
+        });
+
+        test('round-robin should cycle through sessions in order', async () => {
+            sessionPool = new SessionPool({ sessionReuseStrategy: 'round-robin' });
+            await sessionPool.addSession({ id: 'session-a' });
+            await sessionPool.addSession({ id: 'session-b' });
+            await sessionPool.addSession({ id: 'session-c' });
+
+            const ids: string[] = [];
+            for (let i = 0; i < 6; i++) {
+                ids.push((await sessionPool.getSession()).id);
+            }
+
+            expect(ids).toEqual(['session-a', 'session-b', 'session-c', 'session-a', 'session-b', 'session-c']);
+        });
+
+        test('round-robin should create a new session when all existing ones are retired', async () => {
+            sessionPool = new SessionPool({ sessionReuseStrategy: 'round-robin', maxPoolSize: 2 });
+            await sessionPool.addSession({ id: 'session-a' });
+
+            const s1 = await sessionPool.getSession();
+            expect(s1.id).toBe('session-a');
+            s1.retire();
+
+            const s2 = await sessionPool.getSession();
+            expect(s2.id).not.toBe('session-a');
+        });
+
+        test('use-until-failure should keep reusing the same session', async () => {
+            sessionPool = new SessionPool({ sessionReuseStrategy: 'use-until-failure' });
+
+            const s1 = await sessionPool.getSession();
+            const s2 = await sessionPool.getSession();
+            const s3 = await sessionPool.getSession();
+
+            expect(s1.id).toBe(s2.id);
+            expect(s2.id).toBe(s3.id);
+        });
+
+        test('use-until-failure should switch to a new session after the current one is retired', async () => {
+            sessionPool = new SessionPool({ sessionReuseStrategy: 'use-until-failure' });
+
+            const s1 = await sessionPool.getSession();
+            s1.retire();
+
+            const s2 = await sessionPool.getSession();
+            expect(s2.id).not.toBe(s1.id);
+        });
+    });
+
     describe('multiple SessionPool instances isolation', () => {
         test('should use unique persist keys by default', async () => {
             const pool1 = new SessionPool();

--- a/test/core/session_pool/session_pool.test.ts
+++ b/test/core/session_pool/session_pool.test.ts
@@ -440,30 +440,31 @@ describe('SessionPool - testing session pool', () => {
             expect([s1.id, s2.id, s3.id]).toContain(s4.id);
         });
 
-        test('round-robin should cycle through sessions in order', async () => {
-            sessionPool = new SessionPool({ sessionReuseStrategy: 'round-robin' });
-            await sessionPool.addSession({ id: 'session-a' });
-            await sessionPool.addSession({ id: 'session-b' });
-            await sessionPool.addSession({ id: 'session-c' });
+        test('round-robin should fill pool before cycling', async () => {
+            sessionPool = new SessionPool({ sessionReuseStrategy: 'round-robin', maxPoolSize: 3 });
+
+            const s1 = await sessionPool.getSession();
+            const s2 = await sessionPool.getSession();
+            const s3 = await sessionPool.getSession();
+
+            expect(new Set([s1.id, s2.id, s3.id]).size).toBe(3);
 
             const ids: string[] = [];
             for (let i = 0; i < 6; i++) {
                 ids.push((await sessionPool.getSession()).id);
             }
 
-            expect(ids).toEqual(['session-a', 'session-b', 'session-c', 'session-a', 'session-b', 'session-c']);
+            expect(ids).toEqual([s1.id, s2.id, s3.id, s1.id, s2.id, s3.id]);
         });
 
         test('round-robin should create a new session when all existing ones are retired', async () => {
-            sessionPool = new SessionPool({ sessionReuseStrategy: 'round-robin', maxPoolSize: 2 });
-            await sessionPool.addSession({ id: 'session-a' });
+            sessionPool = new SessionPool({ sessionReuseStrategy: 'round-robin', maxPoolSize: 1 });
 
             const s1 = await sessionPool.getSession();
-            expect(s1.id).toBe('session-a');
             s1.retire();
 
             const s2 = await sessionPool.getSession();
-            expect(s2.id).not.toBe('session-a');
+            expect(s2.id).not.toBe(s1.id);
         });
 
         test('use-until-failure should keep reusing the same session', async () => {

--- a/test/core/session_pool/session_pool.test.ts
+++ b/test/core/session_pool/session_pool.test.ts
@@ -467,6 +467,29 @@ describe('SessionPool - testing session pool', () => {
             expect(s2.id).not.toBe(s1.id);
         });
 
+        test.each(['random', 'round-robin'] as const)(
+            '%s should evict a retired session from a full pool and replenish',
+            async (strategy) => {
+                sessionPool = new SessionPool({ sessionReuseStrategy: strategy, maxPoolSize: 3 });
+
+                const s1 = await sessionPool.getSession();
+                await sessionPool.getSession();
+                await sessionPool.getSession();
+
+                s1.retire();
+
+                // @ts-expect-error private symbol
+                expect(sessionPool.sessions).toHaveLength(3);
+
+                await sessionPool.getSession();
+
+                // @ts-expect-error private symbol
+                expect(sessionPool.sessions).toHaveLength(3);
+                // @ts-expect-error private symbol
+                expect(sessionPool.sessions.find((s) => s.id === s1.id)).toBeUndefined();
+            },
+        );
+
         test('use-until-failure should keep reusing the same session', async () => {
             sessionPool = new SessionPool({ sessionReuseStrategy: 'use-until-failure' });
 

--- a/test/core/session_pool/session_pool.test.ts
+++ b/test/core/session_pool/session_pool.test.ts
@@ -481,7 +481,7 @@ describe('SessionPool - testing session pool', () => {
                 // @ts-expect-error private symbol
                 expect(sessionPool.sessions).toHaveLength(3);
 
-                await sessionPool.getSession();
+                for (let i = 0; i < 50; i++) await sessionPool.getSession();
 
                 // @ts-expect-error private symbol
                 expect(sessionPool.sessions).toHaveLength(3);


### PR DESCRIPTION
Adds `SessionPoolOptions.sessionReuseStrategy` option for better control over `Session` retrieval.

Closes https://github.com/apify/crawlee/issues/3270