### PR TITLE
ci: rebase before pushing release/version-docs commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,6 +224,7 @@ jobs:
                         echo "Error: VERSION is empty. Ensure lerna.json exists and contains a valid .version field."
                         exit 1
                     fi
+                    echo "VERSION=$VERSION" >> "$GITHUB_ENV"
                     MAJOR_MINOR=$(echo $VERSION | cut -d. -f1,2)
                     yarn docusaurus docs:version $MAJOR_MINOR
                     yarn docusaurus api:version $MAJOR_MINOR
@@ -233,6 +234,6 @@ jobs:
                     git config --global user.name "Apify Release Bot"
                     git config --global user.email "noreply@apify.com"
                     git add .
-                    git diff-index --quiet HEAD || git commit -m 'docs: update docs for ${{ inputs.version }} version'
+                    git diff-index --quiet HEAD || git commit -m "docs: update docs for $VERSION version"
                     git pull --rebase --autostash
                     git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,6 +157,7 @@ jobs:
                   author_name: Apify Release Bot
                   author_email: noreply@apify.com
                   message: 'chore(release): update internal dependencies [skip ci]'
+                  pull: '--rebase --autostash'
 
             -   name: Publish packages
                 uses: apify/workflows/execute-workflow@main
@@ -233,4 +234,5 @@ jobs:
                     git config --global user.email "noreply@apify.com"
                     git add .
                     git diff-index --quiet HEAD || git commit -m 'docs: update docs for ${{ inputs.version }} version'
+                    git pull --rebase --autostash
                     git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,10 +230,9 @@ jobs:
                     yarn docusaurus api:version $MAJOR_MINOR
 
             -   name: Commit and push the version snapshot
-                run: |
-                    git config --global user.name "Apify Release Bot"
-                    git config --global user.email "noreply@apify.com"
-                    git add .
-                    git diff-index --quiet HEAD || git commit -m "docs: update docs for $VERSION version"
-                    git pull --rebase --autostash
-                    git push
+                uses: EndBug/add-and-commit@v10
+                with:
+                    author_name: Apify Release Bot
+                    author_email: noreply@apify.com
+                    message: 'docs: update docs for ${{ env.VERSION }} version'
+                    pull: '--rebase --autostash'


### PR DESCRIPTION
## Summary
- `release` job: add `pull: '--rebase --autostash'` to the `EndBug/add-and-commit` step so the internal-deps commit survives a concurrent ref update on master.
- `version-docs` job: switch the raw-git `Commit and push the version snapshot` step over to `EndBug/add-and-commit@v10` (matching the rest of the workflow and our other repos), with `pull: '--rebase --autostash'` to handle the same race.
- `version-docs` job: also fix the commit message to use the actual version number. Previously the message used `${{ inputs.version }}`, which on this workflow is the release-type choice (`patch` / `minor` / `major` / `custom`), so the commit was landing as e.g. `docs: update docs for minor version`. The `Snapshot the current version` step already reads the real version from `lerna.json`; export it via `$GITHUB_ENV` and use `${{ env.VERSION }}` in the commit message.

## Context
Same race that bit `apify/apify-client-js` in [run 25114327598](https://github.com/apify/apify-client-js/actions/runs/25114327598/job/73597522121):

```
remote rejected (cannot lock ref 'refs/heads/master': is at <new> but expected <old>)
```

The bypass logs `remote: Bypassed rule violations for refs/heads/master` — so it's not permissions, it's just non-fast-forward because something landed on master between checkout and push. The version-docs job is especially exposed since it runs after `release` has already pushed once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
