### PR TITLE
fix(browser-pool): allow unsetting launch context proxy URL

### DIFF
--- a/packages/browser-pool/src/launch-context.ts
+++ b/packages/browser-pool/src/launch-context.ts
@@ -138,6 +138,7 @@ export class LaunchContext<
      */
     set proxyUrl(url: string | undefined) {
         if (!url) {
+            this._proxyUrl = undefined;
             return;
         }
 

--- a/test/browser-pool/browser-plugins/plugins.test.ts
+++ b/test/browser-pool/browser-plugins/plugins.test.ts
@@ -112,6 +112,17 @@ const runPluginTest = <
             expect(context.userDataDir).toEqual('test');
         });
 
+        test.concurrent('should allow unsetting launchContext proxyUrl', () => {
+            const plugin = new Plugin(library as never);
+            const context = plugin.createLaunchContext();
+
+            context.proxyUrl = 'http://proxy.com/';
+            expect(context.proxyUrl).toEqual('http://proxy.com');
+
+            context.proxyUrl = undefined;
+            expect(context.proxyUrl).toBeUndefined();
+        });
+
         test.concurrent('should create browser controller', () => {
             const plugin = new Plugin(library as never);
             const browserController = plugin.createController();


### PR DESCRIPTION
## Summary

- Fixes `LaunchContext.proxyUrl = undefined` so it clears the stored proxy URL as documented.
- Adds a regression test covering setting and unsetting `launchContext.proxyUrl`.

LaunchContext documents that assigning undefined to proxyUrl should unset
the existing proxy URL. The setter previously returned early for falsy
values without clearing the stored value, so an old proxy URL could remain
active after callers attempted to unset it.

Clear the internal proxy URL when proxyUrl is set to undefined and add a
regression test covering the set/unset behaviour.
