### PR TITLE
fix(core): apply object searchParams in HTTP request options

### DIFF
--- a/packages/utils/src/internals/url.ts
+++ b/packages/utils/src/internals/url.ts
@@ -23,7 +23,7 @@ export function applySearchParams(url: URL, searchParams: SearchParams | undefin
         newSearchParams = searchParams;
     } else {
         newSearchParams = new URLSearchParams();
-        for (const [key, value] of Object.entries(newSearchParams)) {
+        for (const [key, value] of Object.entries(searchParams)) {
             if (value === undefined) {
                 newSearchParams.delete(key);
             } else if (value === null) {

--- a/test/core/base_http_client.test.ts
+++ b/test/core/base_http_client.test.ts
@@ -1,0 +1,64 @@
+import { processHttpRequestOptions } from '@crawlee/core';
+
+describe('processHttpRequestOptions', () => {
+    test('applies search parameters to the request URL', () => {
+        const request = processHttpRequestOptions({
+            url: 'https://example.com/path?previous=value',
+            searchParams: {
+                query: 'hello world',
+                page: 2,
+                empty: null,
+                skipped: undefined,
+            },
+        });
+
+        expect(request.url.toString()).toBe('https://example.com/path?query=hello+world&page=2&empty=');
+    });
+
+    test('throws when multiple body options are provided', () => {
+        expect(() =>
+            processHttpRequestOptions({
+                url: 'https://example.com',
+                body: 'body',
+                json: { hello: 'world' },
+            }),
+        ).toThrow('At most one of `body`, `form` and `json` may be specified in sendRequest arguments');
+    });
+
+    test('serializes form body and sets default content type', () => {
+        const request = processHttpRequestOptions({
+            url: 'https://example.com',
+            form: {
+                hello: 'world',
+            },
+        });
+
+        expect(request.body).toBe('hello=world');
+        expect(request.headers).toEqual({ 'content-type': 'application/x-www-form-urlencoded' });
+    });
+
+    test('serializes JSON body and keeps user content type', () => {
+        const request = processHttpRequestOptions({
+            url: 'https://example.com',
+            headers: {
+                'content-type': 'application/vnd.api+json',
+            },
+            json: {
+                hello: 'world',
+            },
+        });
+
+        expect(request.body).toBe('{"hello":"world"}');
+        expect(request.headers).toEqual({ 'content-type': 'application/vnd.api+json' });
+    });
+
+    test('sets basic authorization header from username and password', () => {
+        const request = processHttpRequestOptions({
+            url: 'https://example.com',
+            username: 'user',
+            password: 'pass',
+        });
+
+        expect(request.headers).toEqual({ authorization: 'Basic dXNlcjpwYXNz' });
+    });
+});


### PR DESCRIPTION
## Summary

- Fixes object-based `searchParams` handling so `processHttpRequestOptions()` correctly applies query parameters to request URLs.
- Adds direct regression coverage for `processHttpRequestOptions()` request shaping behavior.

## Why this is important

`processHttpRequestOptions()` is used by crawler request flows and `sendRequest()`. Before this fix, passing `searchParams` as an object silently produced no query string, which could make requests hit the wrong URL or miss expected parameters.