### PR TITLE
fix: `handleCloudflareChallenge` skips blocked response code

### DIFF
--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -90,6 +90,12 @@ export interface BrowserCrawlingContext<
      * Helper function for extracting URLs from the current page and adding them to the request queue.
      */
     enqueueLinks: (options?: EnqueueLinksOptions) => Promise<BatchAddRequestsResult>;
+
+    /**
+     * Marker that, when set by a post-navigation hook, makes {@link BrowserCrawler.processResponse} skip
+     * the blocked-status-code check for this request. See {@link SKIP_BLOCKED_STATUS_CODE_CHECK}.
+     */
+    [SKIP_BLOCKED_STATUS_CODE_CHECK]?: boolean;
 }
 
 export type BrowserHook<Context = BrowserCrawlingContext, GoToOptions extends Dictionary | undefined = Dictionary> = (
@@ -661,7 +667,7 @@ export abstract class BrowserCrawler<
 
         if (this.sessionPool && response && session) {
             if (typeof response === 'object' && typeof response.status === 'function') {
-                if (!(crawlingContext as any)[SKIP_BLOCKED_STATUS_CODE_CHECK]) {
+                if (!crawlingContext[SKIP_BLOCKED_STATUS_CODE_CHECK]) {
                     this._throwOnBlockedRequest(response.status());
                 }
             } else {

--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -53,6 +53,13 @@ interface BaseResponse {
 
 type ContextDifference<T, U> = Omit<U, keyof T> & Partial<U>;
 
+/**
+ * Marker set on a {@link BrowserCrawlingContext} by a post-navigation hook to opt out of the
+ * blocked-status-code check in {@link BrowserCrawler.processResponse}. Used by helpers like
+ * `handleCloudflareChallenge` that recover from a "blocked" initial response.
+ */
+export const SKIP_BLOCKED_STATUS_CODE_CHECK = Symbol('SKIP_BLOCKED_STATUS_CODE_CHECK');
+
 export interface BrowserCrawlingContext<
     Page extends CommonPage = CommonPage,
     Response extends BaseResponse = BaseResponse,
@@ -654,7 +661,9 @@ export abstract class BrowserCrawler<
 
         if (this.sessionPool && response && session) {
             if (typeof response === 'object' && typeof response.status === 'function') {
-                this._throwOnBlockedRequest(response.status());
+                if (!(crawlingContext as any)[SKIP_BLOCKED_STATUS_CODE_CHECK]) {
+                    this._throwOnBlockedRequest(response.status());
+                }
             } else {
                 this.log.debug('Got a malformed Browser response.', { request, response });
             }

--- a/packages/playwright-crawler/src/internals/playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/playwright-crawler.ts
@@ -292,10 +292,17 @@ export class PlaywrightCrawler<
             compileScript: (scriptString: string, ctx?: Dictionary) => playwrightUtils.compileScript(scriptString, ctx),
             closeCookieModals: async () => playwrightUtils.closeCookieModals(context.page),
             handleCloudflareChallenge: async (options?: HandleCloudflareChallengeOptions) => {
-                await playwrightUtils.handleCloudflareChallenge(context.page, context.request.url, options);
-                // The challenge resolved without throwing, so the original (often 403) navigation response
-                // should not be treated as blocked by `BrowserCrawler.processResponse`.
-                (context as any)[SKIP_BLOCKED_STATUS_CODE_CHECK] = true;
+                const handled = await playwrightUtils.handleCloudflareChallenge(
+                    context.page,
+                    context.request.url,
+                    options,
+                );
+                if (handled) {
+                    // A challenge was detected and solved; the original (403) navigation response
+                    // should not be treated as blocked by `BrowserCrawler.processResponse`.
+                    (context as any)[SKIP_BLOCKED_STATUS_CODE_CHECK] = true;
+                }
+                return handled;
             },
         };
     }

--- a/packages/playwright-crawler/src/internals/playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/playwright-crawler.ts
@@ -300,7 +300,7 @@ export class PlaywrightCrawler<
                 if (handled) {
                     // A challenge was detected and solved; the original (403) navigation response
                     // should not be treated as blocked by `BrowserCrawler.processResponse`.
-                    (context as any)[SKIP_BLOCKED_STATUS_CODE_CHECK] = true;
+                    context[SKIP_BLOCKED_STATUS_CODE_CHECK] = true;
                 }
                 return handled;
             },

--- a/packages/playwright-crawler/src/internals/playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/playwright-crawler.ts
@@ -6,7 +6,7 @@ import type {
     RequestHandler,
     RouterRoutes,
 } from '@crawlee/browser';
-import { BrowserCrawler, RequestState, Router, serviceLocator } from '@crawlee/browser';
+import { BrowserCrawler, RequestState, Router, serviceLocator, SKIP_BLOCKED_STATUS_CODE_CHECK } from '@crawlee/browser';
 import type { BrowserPoolOptions, PlaywrightController, PlaywrightPlugin } from '@crawlee/browser-pool';
 import type { Dictionary } from '@crawlee/types';
 import ow from 'ow';
@@ -292,12 +292,10 @@ export class PlaywrightCrawler<
             compileScript: (scriptString: string, ctx?: Dictionary) => playwrightUtils.compileScript(scriptString, ctx),
             closeCookieModals: async () => playwrightUtils.closeCookieModals(context.page),
             handleCloudflareChallenge: async (options?: HandleCloudflareChallengeOptions) => {
-                return playwrightUtils.handleCloudflareChallenge(
-                    context.page,
-                    context.request.url,
-                    options,
-                    this.blockedStatusCodes,
-                );
+                await playwrightUtils.handleCloudflareChallenge(context.page, context.request.url, options);
+                // The challenge resolved without throwing, so the original (often 403) navigation response
+                // should not be treated as blocked by `BrowserCrawler.processResponse`.
+                (context as any)[SKIP_BLOCKED_STATUS_CODE_CHECK] = true;
             },
         };
     }

--- a/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
+++ b/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
@@ -716,12 +716,14 @@ export interface HandleCloudflareChallengeOptions {
  * @param page Playwright [`Page`](https://playwright.dev/docs/api/class-page) object
  * @param url current URL for request identification, only used for logging
  * @param [options]
+ * @returns `true` when a Cloudflare challenge was detected and solved, `false` when no challenge was present
+ *          (or the helper bailed out before acting). Throws `SessionError` if the challenge could not be solved.
  */
 async function handleCloudflareChallenge(
     page: Page,
     url: string,
     options: HandleCloudflareChallengeOptions = {},
-): Promise<void> {
+): Promise<boolean> {
     options.isBlockedCallback ??= async () => {
         const isBlocked = await page.evaluate(() => {
             return document.querySelector('h1')?.textContent?.trim().includes('Sorry, you have been blocked');
@@ -750,7 +752,7 @@ async function handleCloudflareChallenge(
 
     if (!(await isChallenge())) {
         await retryBlocked();
-        return;
+        return false;
     }
 
     const logLevel = options.verbose ? 'info' : 'debug';
@@ -766,7 +768,7 @@ async function handleCloudflareChallenge(
         .catch(() => undefined);
 
     if (!bb) {
-        return;
+        return false;
     }
 
     const randomOffset = (range: number) => {
@@ -819,6 +821,7 @@ async function handleCloudflareChallenge(
     }
 
     await retryBlocked();
+    return true;
 }
 
 /** @internal */
@@ -1045,7 +1048,7 @@ export interface PlaywrightContextUtils {
      *
      * @param [options]
      */
-    handleCloudflareChallenge(options?: HandleCloudflareChallengeOptions): Promise<void>;
+    handleCloudflareChallenge(options?: HandleCloudflareChallengeOptions): Promise<boolean>;
 }
 
 export { enqueueLinksByClickingElements };

--- a/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
+++ b/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
@@ -721,12 +721,7 @@ async function handleCloudflareChallenge(
     page: Page,
     url: string,
     options: HandleCloudflareChallengeOptions = {},
-    blockedStatusCodes?: Set<number>,
 ): Promise<void> {
-    // Cloudflare pages return 403, which is blocked by default — temporarily allow it during challenge handling
-    const had403 = blockedStatusCodes?.has(403);
-    blockedStatusCodes?.delete(403);
-
     options.isBlockedCallback ??= async () => {
         const isBlocked = await page.evaluate(() => {
             return document.querySelector('h1')?.textContent?.trim().includes('Sorry, you have been blocked');
@@ -753,83 +748,77 @@ async function handleCloudflareChallenge(
         return options.isChallengeCallback!(page).catch(() => false);
     };
 
-    try {
-        if (!(await isChallenge())) {
-            await retryBlocked();
-            return;
-        }
-
-        const logLevel = options.verbose ? 'info' : 'debug';
-        getLog()[logLevel](
-            `Detected Cloudflare challenge at ${url}, trying to solve it. This can take up to ${10 + (options.sleepSecs ?? 10)} seconds.`,
-        );
-
-        const bb = await page
-            .evaluate(() => {
-                const div = document.querySelector('.main-content div');
-                return div?.getBoundingClientRect();
-            })
-            .catch(() => undefined);
-
-        if (!bb) {
-            return;
-        }
-
-        const randomOffset = (range: number) => {
-            return Math.round(100 * range * Math.random()) / 100;
-        };
-
-        let x = bb.x + 30;
-        let y = bb.y + 25;
-
-        // try to click the checkbox every second
-        for (let i = 0; i < 10; i++) {
-            await sleep((options.preChallengeSleepSecs ?? 1) * 1000);
-
-            // break early if we are no longer on the CF challenge page
-            if (!(await isChallenge())) {
-                break;
-            }
-
-            if (options.clickPositionCallback) {
-                const pos = await options.clickPositionCallback(page);
-                if (pos) {
-                    x = pos.x;
-                    y = pos.y;
-                }
-            }
-
-            if (options.clickCallback) {
-                await options.clickCallback(page, { x, y });
-                continue;
-            }
-
-            // we can click on the text too, so X can be a bit larger
-            const xRandomized = x + randomOffset(10);
-            const yRandomized = y + randomOffset(10);
-
-            getLog()[logLevel](`Trying to click on the Cloudflare checkbox at ${url}`, {
-                x: xRandomized,
-                y: yRandomized,
-            });
-            await page.mouse.click(xRandomized, yRandomized);
-
-            // sometimes the checkbox is lower (could be caused by a lag when rendering the logo)
-            await page.mouse.click(xRandomized, yRandomized + 35);
-        }
-
-        await sleep((options.sleepSecs ?? 10) * 1000);
-
-        if (await isChallenge()) {
-            throw new SessionError(`Blocked by Cloudflare when processing ${url}`);
-        }
-
+    if (!(await isChallenge())) {
         await retryBlocked();
-    } finally {
-        if (had403) {
-            blockedStatusCodes?.add(403);
-        }
+        return;
     }
+
+    const logLevel = options.verbose ? 'info' : 'debug';
+    getLog()[logLevel](
+        `Detected Cloudflare challenge at ${url}, trying to solve it. This can take up to ${10 + (options.sleepSecs ?? 10)} seconds.`,
+    );
+
+    const bb = await page
+        .evaluate(() => {
+            const div = document.querySelector('.main-content div');
+            return div?.getBoundingClientRect();
+        })
+        .catch(() => undefined);
+
+    if (!bb) {
+        return;
+    }
+
+    const randomOffset = (range: number) => {
+        return Math.round(100 * range * Math.random()) / 100;
+    };
+
+    let x = bb.x + 30;
+    let y = bb.y + 25;
+
+    // try to click the checkbox every second
+    for (let i = 0; i < 10; i++) {
+        await sleep((options.preChallengeSleepSecs ?? 1) * 1000);
+
+        // break early if we are no longer on the CF challenge page
+        if (!(await isChallenge())) {
+            break;
+        }
+
+        if (options.clickPositionCallback) {
+            const pos = await options.clickPositionCallback(page);
+            if (pos) {
+                x = pos.x;
+                y = pos.y;
+            }
+        }
+
+        if (options.clickCallback) {
+            await options.clickCallback(page, { x, y });
+            continue;
+        }
+
+        // we can click on the text too, so X can be a bit larger
+        const xRandomized = x + randomOffset(10);
+        const yRandomized = y + randomOffset(10);
+
+        getLog()[logLevel](`Trying to click on the Cloudflare checkbox at ${url}`, {
+            x: xRandomized,
+            y: yRandomized,
+        });
+        await page.mouse.click(xRandomized, yRandomized);
+
+        // sometimes the checkbox is lower (could be caused by a lag when rendering the logo)
+        await page.mouse.click(xRandomized, yRandomized + 35);
+    }
+
+    await sleep((options.sleepSecs ?? 10) * 1000);
+
+    if (await isChallenge()) {
+        throw new SessionError(`Blocked by Cloudflare when processing ${url}`);
+    }
+
+    await retryBlocked();
 }
 
 /** @internal */

--- a/test/core/crawlers/playwright_crawler.test.ts
+++ b/test/core/crawlers/playwright_crawler.test.ts
@@ -3,7 +3,7 @@ import type { AddressInfo } from 'node:net';
 import os from 'node:os';
 
 import type { PlaywrightCrawlingContext, PlaywrightGotoOptions, Request } from '@crawlee/playwright';
-import { PlaywrightCrawler, RequestList } from '@crawlee/playwright';
+import { PlaywrightCrawler, RequestList, SKIP_BLOCKED_STATUS_CODE_CHECK } from '@crawlee/playwright';
 import type { Cheerio, CheerioAPI, CheerioRoot, Element } from '@crawlee/utils';
 import express from 'express';
 import playwright from 'playwright';
@@ -32,6 +32,9 @@ describe('PlaywrightCrawler', () => {
         app.get('/', (_req, res) => {
             res.send(`<html><head><title>Example Domain</title></head></html>`);
             res.status(200);
+        });
+        app.get('/blocked-403', (_req, res) => {
+            res.status(403).send(`<html><head><title>Blocked</title></head><body>nope</body></html>`);
         });
     });
 
@@ -193,6 +196,54 @@ describe('PlaywrightCrawler', () => {
             expect(reducedMotion).toBe(launchOptions.reducedMotion);
         },
     );
+
+    describe('SKIP_BLOCKED_STATUS_CODE_CHECK', () => {
+        test('reaches the request handler on a 403 when set in a postNavigationHook', async () => {
+            const requestHandler = vi.fn(async (_ctx: PlaywrightCrawlingContext) => {});
+            const failedRequestHandler = vi.fn(async () => {});
+
+            const crawler = new PlaywrightCrawler({
+                requestList: await RequestList.open(`skip-flag-set-${Math.random()}`, [
+                    `http://${HOSTNAME}:${port}/blocked-403`,
+                ]),
+                maxRequestRetries: 0,
+                maxConcurrency: 1,
+                postNavigationHooks: [
+                    async (ctx) => {
+                        ctx[SKIP_BLOCKED_STATUS_CODE_CHECK] = true;
+                    },
+                ],
+                requestHandler,
+                failedRequestHandler,
+            });
+
+            await crawler.run();
+
+            expect(requestHandler).toHaveBeenCalledOnce();
+            expect(requestHandler.mock.calls[0][0].response!.status()).toBe(403);
+            expect(failedRequestHandler).not.toHaveBeenCalled();
+        });
+
+        test('skips the request handler on a 403 when not set', async () => {
+            const requestHandler = vi.fn(async (_ctx: PlaywrightCrawlingContext) => {});
+            const failedRequestHandler = vi.fn(async () => {});
+
+            const crawler = new PlaywrightCrawler({
+                requestList: await RequestList.open(`skip-flag-unset-${Math.random()}`, [
+                    `http://${HOSTNAME}:${port}/blocked-403`,
+                ]),
+                maxRequestRetries: 0,
+                maxConcurrency: 1,
+                requestHandler,
+                failedRequestHandler,
+            });
+
+            await crawler.run();
+
+            expect(requestHandler).not.toHaveBeenCalled();
+            expect(failedRequestHandler).toHaveBeenCalledOnce();
+        });
+    });
 
     test('should have correct types in crawling context', async () => {
         const requestHandler = async (crawlingContext: PlaywrightCrawlingContext) => {


### PR DESCRIPTION
Recent `Session` related changes in `v4` accidentally broke the `handleCloudflareChallenge` helper. 

This PR adds the `SKIP_BLOCKED_STATUS_CODE_CHECK` symbol for signaling that the current request processing shouldn't fail on "blocking" status code.
This is used, e.g., with the `handleCloudflareChallenge` helper, since Cloudflare returns the challenge with `403`.

Related to https://github.com/apify/crawlee/issues/3502