### PR TITLE
chore: bump `impit` version to `0.14.0`

### DIFF
--- a/packages/impit-client/package.json
+++ b/packages/impit-client/package.json
@@ -60,7 +60,7 @@
     },
     "dependencies": {
         "@apify/datastructures": "^2.0.3",
-        "impit": "^0.13.0",
+        "impit": "^0.14.0",
         "tough-cookie": "^6.0.0"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -945,7 +945,7 @@ __metadata:
   dependencies:
     "@apify/datastructures": "npm:^2.0.3"
     "@crawlee/core": "npm:^3.16.0"
-    impit: "npm:^0.13.0"
+    impit: "npm:^0.14.0"
     tough-cookie: "npm:^6.0.0"
   peerDependencies:
     "@crawlee/core": ^3.12.1
@@ -8743,9 +8743,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"impit-darwin-arm64@npm:0.13.0":
-  version: 0.13.0
-  resolution: "impit-darwin-arm64@npm:0.13.0"
+"impit-darwin-arm64@npm:0.14.0":
+  version: 0.14.0
+  resolution: "impit-darwin-arm64@npm:0.14.0"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -8757,9 +8757,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"impit-darwin-x64@npm:0.13.0":
-  version: 0.13.0
-  resolution: "impit-darwin-x64@npm:0.13.0"
+"impit-darwin-x64@npm:0.14.0":
+  version: 0.14.0
+  resolution: "impit-darwin-x64@npm:0.14.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -8771,9 +8771,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"impit-linux-arm64-gnu@npm:0.13.0":
-  version: 0.13.0
-  resolution: "impit-linux-arm64-gnu@npm:0.13.0"
+"impit-linux-arm64-gnu@npm:0.14.0":
+  version: 0.14.0
+  resolution: "impit-linux-arm64-gnu@npm:0.14.0"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
@@ -8785,9 +8785,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"impit-linux-arm64-musl@npm:0.13.0":
-  version: 0.13.0
-  resolution: "impit-linux-arm64-musl@npm:0.13.0"
+"impit-linux-arm64-musl@npm:0.14.0":
+  version: 0.14.0
+  resolution: "impit-linux-arm64-musl@npm:0.14.0"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
@@ -8799,9 +8799,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"impit-linux-x64-gnu@npm:0.13.0":
-  version: 0.13.0
-  resolution: "impit-linux-x64-gnu@npm:0.13.0"
+"impit-linux-x64-gnu@npm:0.14.0":
+  version: 0.14.0
+  resolution: "impit-linux-x64-gnu@npm:0.14.0"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
@@ -8813,9 +8813,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"impit-linux-x64-musl@npm:0.13.0":
-  version: 0.13.0
-  resolution: "impit-linux-x64-musl@npm:0.13.0"
+"impit-linux-x64-musl@npm:0.14.0":
+  version: 0.14.0
+  resolution: "impit-linux-x64-musl@npm:0.14.0"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
@@ -8827,9 +8827,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"impit-win32-arm64-msvc@npm:0.13.0":
-  version: 0.13.0
-  resolution: "impit-win32-arm64-msvc@npm:0.13.0"
+"impit-win32-arm64-msvc@npm:0.14.0":
+  version: 0.14.0
+  resolution: "impit-win32-arm64-msvc@npm:0.14.0"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -8841,9 +8841,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"impit-win32-x64-msvc@npm:0.13.0":
-  version: 0.13.0
-  resolution: "impit-win32-x64-msvc@npm:0.13.0"
+"impit-win32-x64-msvc@npm:0.14.0":
+  version: 0.14.0
+  resolution: "impit-win32-x64-msvc@npm:0.14.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -8881,18 +8881,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"impit@npm:^0.13.0":
-  version: 0.13.0
-  resolution: "impit@npm:0.13.0"
+"impit@npm:^0.14.0":
+  version: 0.14.0
+  resolution: "impit@npm:0.14.0"
   dependencies:
-    impit-darwin-arm64: "npm:0.13.0"
-    impit-darwin-x64: "npm:0.13.0"
-    impit-linux-arm64-gnu: "npm:0.13.0"
-    impit-linux-arm64-musl: "npm:0.13.0"
-    impit-linux-x64-gnu: "npm:0.13.0"
-    impit-linux-x64-musl: "npm:0.13.0"
-    impit-win32-arm64-msvc: "npm:0.13.0"
-    impit-win32-x64-msvc: "npm:0.13.0"
+    impit-darwin-arm64: "npm:0.14.0"
+    impit-darwin-x64: "npm:0.14.0"
+    impit-linux-arm64-gnu: "npm:0.14.0"
+    impit-linux-arm64-musl: "npm:0.14.0"
+    impit-linux-x64-gnu: "npm:0.14.0"
+    impit-linux-x64-musl: "npm:0.14.0"
+    impit-win32-arm64-msvc: "npm:0.14.0"
+    impit-win32-x64-msvc: "npm:0.14.0"
   dependenciesMeta:
     impit-darwin-arm64:
       optional: true
@@ -8910,7 +8910,7 @@ __metadata:
       optional: true
     impit-win32-x64-msvc:
       optional: true
-  checksum: 10c0/633ac5ffe6f3fd2c5c690e82f8fe37bd7dfbc3f7ee878fbd9e32e1454c8a769c8f4d215bf864366712b3ba361b6a7d271feb5845e1f89b7f3a7fdef63335fe3a
+  checksum: 10c0/49ffe30377cc3e3859e0520613ec9163973b577ba540366544512a2d9b6316d9695a7159f28b943fdd05ac76b0c26051fa73235e3571e3ff8cca6baa3db8a0ca
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps the `impit` package to the latest released version.
