### PR TITLE
feat(core): add fingerprint support to Session 

### DIFF
--- a/packages/core/src/session_pool/session.ts
+++ b/packages/core/src/session_pool/session.ts
@@ -32,6 +32,7 @@ export interface SessionState {
     maxUsageCount: number;
     expiresAt: string;
     createdAt: string;
+    fingerprint?: Record<string, unknown> | unknown;
 }
 
 export interface SessionOptions {
@@ -86,6 +87,12 @@ export interface SessionOptions {
     /** SessionPool instance. Session will emit the `sessionRetired` event on this instance. */
     sessionPool?: import('./session_pool').SessionPool;
 
+    /**
+     * Browser / HTTP client fingerprint (i.e., user-agent, TLS settings, etc.).
+     * The actual format of the fingerprint is TBD.
+     */
+    fingerprint?: Record<string, unknown> | unknown;
+
     log?: Log;
     errorScore?: number;
     cookieJar?: CookieJar;
@@ -101,6 +108,11 @@ export class Session {
     readonly id: string;
     private maxAgeSecs: number;
     userData: Dictionary;
+    /**
+     * Browser / HTTP client fingerprint (i.e., user-agent, TLS settings, etc.).
+     * The actual format of the fingerprint is TBD.
+     */
+    fingerprint: Record<string, unknown> | unknown;
     private _maxErrorScore: number;
     private _errorScoreDecrement: number;
     private _createdAt: Date;
@@ -163,6 +175,7 @@ export class Session {
                 usageCount: ow.optional.number,
                 errorScore: ow.optional.number,
                 maxUsageCount: ow.optional.number,
+                fingerprint: ow.optional.object,
                 log: ow.optional.object,
             }),
         );
@@ -179,6 +192,7 @@ export class Session {
             usageCount = 0,
             errorScore = 0,
             maxUsageCount = 50,
+            fingerprint,
             log = defaultLog,
         } = options;
 
@@ -190,6 +204,7 @@ export class Session {
         this.id = id;
         this.maxAgeSecs = maxAgeSecs;
         this.userData = userData;
+        this.fingerprint = fingerprint;
         this._maxErrorScore = maxErrorScore;
         this._errorScoreDecrement = errorScoreDecrement;
 
@@ -265,6 +280,7 @@ export class Session {
             usageCount: this.usageCount,
             maxUsageCount: this.maxUsageCount,
             errorScore: this.errorScore,
+            fingerprint: this.fingerprint,
         };
     }
 
@@ -401,7 +417,9 @@ export class Session {
 
         for (const cookie of cookies) {
             try {
-                this.cookieJar.setCookieSync(cookie, url, { ignoreError: false });
+                this.cookieJar.setCookieSync(cookie, url, {
+                    ignoreError: false,
+                });
             } catch (e) {
                 const err = e as Error;
                 errorMessages.push(err.message);

--- a/test/core/session_pool/session.test.ts
+++ b/test/core/session_pool/session.test.ts
@@ -125,6 +125,7 @@ describe('Session - testing session behaviour ', () => {
     });
 
     test('should get state', () => {
+        session = new Session({ sessionPool, fingerprint: { some: 'fingerprint data' } });
         const state = session.getState();
 
         expect(state.id).toBeDefined();
@@ -136,6 +137,7 @@ describe('Session - testing session behaviour ', () => {
         expect(state.createdAt).toBeDefined();
         expect(state.usageCount).toBeDefined();
         expect(state.errorScore).toBeDefined();
+        expect(state.fingerprint).toEqual({ some: 'fingerprint data' });
 
         entries(state).forEach(([key, value]) => {
             if (session[key] instanceof Date) {

--- a/test/core/session_pool/session_pool.test.ts
+++ b/test/core/session_pool/session_pool.test.ts
@@ -163,7 +163,8 @@ describe('SessionPool - testing session pool', () => {
     });
 
     test('should persist state and recreate it from storage', async () => {
-        await sessionPool.getSession();
+        await sessionPool.addSession({ id: 'test-session-1', fingerprint: { testing: 'fingerprint data' } });
+        await sessionPool.getSession('test-session-1');
         await sessionPool.persistState();
 
         const kvStore = await KeyValueStore.open();
@@ -206,6 +207,10 @@ describe('SessionPool - testing session pool', () => {
         expect(sessionPool.maxPoolSize).toEqual(loadedSessionPool.maxPoolSize);
         // @ts-expect-error private symbol
         expect(sessionPool.persistStateKey).toEqual(loadedSessionPool.persistStateKey);
+
+        const restoredSession = await loadedSessionPool.getSession('test-session-1');
+        expect(restoredSession?.fingerprint).toEqual({ testing: 'fingerprint data' });
+
         await sessionPool.teardown();
     });
 


### PR DESCRIPTION
## Summary

Closes #3628 

This PR adds a `fingerprint` field to the `Session` class, as described in the linked issue. The goal is for a session to carry all the data necessary to make repeatable, consistent requests to a server, not just cookies and proxy, but also the browser/HTTP client fingerprint (user-agent, TLS settings, etc.).

## Changes

**`packages/core/src/session_pool/session.ts`**
- Added optional `fingerprint` field to the `SessionOptions` interface
- Added optional `fingerprint` field to the `SessionState` interface (so it persists to KeyValueStore)
- Added `fingerprint` as a class property on `Session`, initialized from constructor options
- Included `fingerprint` in `getState()` so it round-trips correctly through persistence
- Added `fingerprint: ow.optional.object` to the `ow` validation shape

**`test/core/session-pool/session.test.ts`** and **`test/core/session-pool/session_pool.test.ts`**
- Added tests covering fingerprint initialization, persistence via `getState()`, and restoration from saved state

## Notes

- The type is currently `Record<string, unknown>` - intentionally kept loose since the fingerprint format is TBD. Once the shape is decided (e.g. `BrowserFingerprintWithHeaders` from `fingerprint-generator`), this can be narrowed in a follow-up.