### PR TITLE
chore: migrate v4 to pnpm 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     },
     "homepage": "https://crawlee.dev",
     "scripts": {
-        "preinstall": "npx only-allow pnpm",
         "prepublishOnly": "turbo run copy --filter=./packages/*",
         "clean": "turbo run clean --filter=./packages/* && rimraf .turbo packages/*/.turbo packages/*/*.tsbuildinfo",
         "build": "turbo run build --filter=./packages/* && node ./scripts/typescript_fixes.mjs",
@@ -119,9 +118,16 @@
             "oxfmt --write --no-error-on-unmatched-pattern"
         ]
     },
-    "packageManager": "pnpm@10.24.0",
+    "packageManager": "pnpm@11.0.9",
+    "devEngines": {
+        "packageManager": {
+            "name": "pnpm",
+            "version": "11.0.9",
+            "onFail": "error"
+        }
+    },
     "volta": {
         "node": "24.13.0",
-        "pnpm": "10.24.0"
+        "pnpm": "11.0.9"
     }
 }

--- a/packages/stagehand-crawler/package.json
+++ b/packages/stagehand-crawler/package.json
@@ -3,7 +3,7 @@
     "version": "3.16.0",
     "description": "AI-powered web crawling with Stagehand integration for Crawlee - enables natural language browser automation with act(), extract(), and observe() methods.",
     "engines": {
-        "node": ">=16.0.0"
+        "node": ">=22.0.0"
     },
     "main": "./dist/index.js",
     "module": "./dist/index.mjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,7 @@ overrides:
   lerna>minimatch: ^3.1.4
 
 patchedDependencies:
-  '@docusaurus/core@3.9.2':
-    hash: 7e95e0e59f770d24c0e51e1e2635b0a25edf33b38938162fa8c69ab42d38b1fb
-    path: patches/@docusaurus__core@3.9.2.patch
+  '@docusaurus/core@3.9.2': 7e95e0e59f770d24c0e51e1e2635b0a25edf33b38938162fa8c69ab42d38b1fb
 
 importers:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,20 +22,27 @@ overrides:
     minimatch: "^9.0.0"
     "lerna>minimatch": "^3.1.4"
 
-onlyBuiltDependencies:
-    - "@apify/ui-icons"
-    - "@playwright/browser-chromium"
-    - "@playwright/browser-firefox"
-    - "@playwright/browser-webkit"
-    - "@swc/core"
-    - better-sqlite3
-    - bufferutil
-    - core-js
-    - esbuild
-    - nx
-    - protobufjs
-    - puppeteer
-    - unrs-resolver
+# pnpm 11 replaces `onlyBuiltDependencies` with an explicit `allowBuilds` map.
+# Each entry must be true (build allowed) or false (build skipped) — pnpm 11
+# refuses to install if any dep needs a build decision that isn't in the map
+# (combined with `strictDepBuilds: false` below so the install can still
+# proceed when new build-requesting deps appear without a manual entry).
+allowBuilds:
+    "@apify/ui-icons": true
+    "@playwright/browser-chromium": true
+    "@playwright/browser-firefox": true
+    "@playwright/browser-webkit": true
+    "@swc/core": true
+    better-sqlite3: true
+    bufferutil: true
+    core-js: true
+    esbuild: true
+    nx: true
+    protobufjs: true
+    puppeteer: true
+    unrs-resolver: true
+
+strictDepBuilds: false
 
 nodeLinker: hoisted
 linkWorkspacePackages: true


### PR DESCRIPTION
## What changes

- Bump `packageManager` pnpm@10.24.0 → pnpm@11.0.9 (and the matching `volta` hint).
- Drop `preinstall: npx only-allow pnpm` (ships in publish tarballs and breaks downstream npm consumers — see apify/apify-client-js#893; `only-allow`'s own `node_modules` guard catches the case but the `npx` bootstrap fails first in `npm install -g` context).
- Add `devEngines.packageManager: { name: pnpm, version: 11.0.9, onFail: error }`. pnpm v11 reimplemented `pnpm config / version / pkg` as native subcommands (v10 still shells to npm), so `error` is safe here.
- Migrate `pnpm-workspace.yaml` from `onlyBuiltDependencies` (pnpm 10 list) to `allowBuilds` (pnpm 11 explicit map). Add `strictDepBuilds: false` so install still proceeds if a new build-requesting dep shows up without an explicit entry; existing entries all flipped to `true` to preserve current build behavior.
- `pnpm-lock.yaml`: minor inline of `patchedDependencies` (one-line hash) — pnpm 11 lockfile reader normalizes the old `hash:` / `path:` map. Lockfile version stays at 9.0.

## Why on v4 specifically

All v4 packages require Node 22+ (the exception is `stagehand-crawler` at `>=16`, untouched here). pnpm v11 also requires Node 22+, so v4 is the natural place to land the upgrade — `master` (still supporting Node 18/20) stays on pnpm 10.

## Verified locally

- `corepack pnpm --version` after the change → `11.0.9` (Corepack picks it up from `packageManager`).
- `pnpm install --frozen-lockfile` succeeds.
- `pnpm rebuild` runs all builds in the `allowBuilds` map without errors (better-sqlite3, nx postinstall, puppeteer, etc.).

## CI notes

- All workflows use `apify/workflows/pnpm-install@main`, which corepacks pnpm from `packageManager` — picks up v11 automatically.
- Releases use `lerna version`, not `pnpm version`, so the v10 npm-shellout trap from apify/apify-client-js#895 doesn't apply.