### PR TITLE
fix: BrowserCrawler closes ctx.page before errorHandler runs on navigation errors (#3647)

### DIFF
--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -693,9 +693,8 @@ export abstract class BrowserCrawler<
 
         if (error && error.constructor.name === 'TimeoutError') {
             handleRequestTimeout({ session, errorMessage: error.message });
+            await crawlingContext.page.close();
         }
-
-        await crawlingContext.page.close();
     }
 
     /**

--- a/test/core/crawlers/browser_crawler.test.ts
+++ b/test/core/crawlers/browser_crawler.test.ts
@@ -291,6 +291,43 @@ describe('BrowserCrawler', () => {
         }
     });
 
+    test.concurrent('errorHandler has open page after non-timeout navigation error', async () => {
+        const localStorageEmulator = new MemoryStorageEmulator();
+        await localStorageEmulator.init();
+        const puppeteerPlugin = new PuppeteerPlugin(puppeteer);
+
+        try {
+            const requestList = await RequestList.open({
+                sources: [{ url: `${serverAddress}/?q=1` }],
+            });
+
+            const pageClosedStates: boolean[] = [];
+
+            const browserCrawler = new (class extends BrowserCrawlerTest {
+                protected override async _navigationHandler(): Promise<HTTPResponse | null | undefined> {
+                    throw new Error('net::ERR_NAME_NOT_RESOLVED');
+                }
+            })({
+                browserPoolOptions: {
+                    browserPlugins: [puppeteerPlugin],
+                },
+                requestList,
+                requestHandler: async () => {},
+                maxRequestRetries: 1,
+                errorHandler: async (ctx) => {
+                    pageClosedStates.push(ctx.page.isClosed());
+                },
+            });
+
+            await browserCrawler.run();
+
+            expect(pageClosedStates).toHaveLength(1);
+            expect(pageClosedStates[0]).toBe(false);
+        } finally {
+            await localStorageEmulator.destroy();
+        }
+    });
+
     test.concurrent('should correctly track request.state', async () => {
         const localStorageEmulator = new MemoryStorageEmulator();
         await localStorageEmulator.init();


### PR DESCRIPTION
## Summary
Root cause: `BrowserCrawler._handleNavigationTimeout` was called on every navigation error but unconditionally closed `crawlingContext.page`, racing user `errorHandler` access and duplicating the close already performed by `_cleanupContext` in the `finally` of `_runRequestFunction`. Change: Moved the `await crawlingContext.page.close()` inside the existing `TimeoutError` branch of `_handleNavigationTimeout` in `packages/browser-crawler/src/internals/browser-crawler.ts`, so eager close only fires when there is a hung page to release. Closes https://github.com/apify/crawlee/issues/3647