### PR TITLE
refactor: add `Configuration.reset()` static method

### DIFF
--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -206,6 +206,21 @@ export class Configuration {
     }
 
     /**
+     * Resets the global configuration (and the rest of the global service locator) so that the
+     * next `Configuration.getGlobalConfig()` call constructs a fresh instance from the current
+     * environment. Intended mainly for tests that mutate `process.env` at runtime — values are
+     * resolved eagerly at construction, so changing env vars after the singleton has been
+     * cached has no effect until the singleton is dropped.
+     *
+     * Delegates to {@link ServiceLocator.reset} since the global configuration is owned by the
+     * service locator; resetting only the configuration would leave a stale `EventManager` /
+     * `StorageClient` / logger holding the old config.
+     */
+    static reset(): void {
+        serviceLocator.reset();
+    }
+
+    /**
      * Resolves all field values once using the priority chain:
      * constructor options > env vars > crawlee.json > schema defaults.
      */

--- a/packages/core/test/core/configuration.test.ts
+++ b/packages/core/test/core/configuration.test.ts
@@ -317,4 +317,18 @@ describe('Configuration', () => {
             expect((config2 as any).customFlag).toBe(true);
         });
     });
+
+    describe('reset()', () => {
+        it('drops the cached global instance so the next `getGlobalConfig()` re-reads env vars', () => {
+            setEnv('CRAWLEE_DEFAULT_DATASET_ID', 'first');
+            expect(Configuration.getGlobalConfig().defaultDatasetId).toBe('first');
+
+            // Without resetting, the singleton keeps the value resolved at first access.
+            setEnv('CRAWLEE_DEFAULT_DATASET_ID', 'second');
+            expect(Configuration.getGlobalConfig().defaultDatasetId).toBe('first');
+
+            Configuration.reset();
+            expect(Configuration.getGlobalConfig().defaultDatasetId).toBe('second');
+        });
+    });
 });


### PR DESCRIPTION
## Summary

- Adds `Configuration.reset()` as a discoverable static method on the new v4 `Configuration` class. Delegates to `serviceLocator.reset()` so the cached configuration, event manager, storage client, and logger are all dropped together.
- Adds a test verifying that after `Configuration.reset()`, the next `Configuration.getGlobalConfig()` re-reads `process.env`.

## Motivation

v4 `Configuration` resolves env vars eagerly at construction, so tests that mutate `process.env` after the global singleton has been resolved need a way to drop the cached instance. Today that's either `serviceLocator.reset()` (works, but the name suggests "service tree" rather than "the config I just changed env vars for") or reaching into the private `Configuration.globalConfig` via type assertions (currently happening across multiple test files in `apify-sdk-js`).

A class-side `Configuration.reset()` makes the intent obvious from the call site and lives next to `Configuration.getGlobalConfig()` in autocomplete. The implementation just delegates to `serviceLocator.reset()` rather than resetting only the configuration — resetting only the config would leave a stale `EventManager` / `StorageClient` / logger holding the old config, which is the wrong contract for callers wanting to "start fresh".

## Test plan
- [x] `vitest run packages/core/test/core/configuration.test.ts -t "reset"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)