### PR TITLE
ci: disable pnpm 11's verifyDepsBeforeRun to unbreak parallel turbo copy

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -44,6 +44,17 @@ allowBuilds:
 
 strictDepBuilds: false
 
+# pnpm 11 wraps every `pnpm run X` with an automatic `pnpm install` (the
+# `runDepsStatusCheck` feature) so scripts always see fresh deps. The
+# publish workflow runs `pnpm turbo copy --force -- --canary=major` which
+# fans `pnpm run copy` out across all 23 workspace packages in parallel —
+# each invocation kicks off its own `pnpm install`, they contend on the
+# store and lockfile, and one of them gets killed with SIGINT, failing the
+# turbo task with "command exited (1)". Disabling the auto-install keeps
+# the parallel scripts deterministic; we run `pnpm install --frozen-lockfile`
+# explicitly in CI before any `pnpm run` step anyway.
+verifyDepsBeforeRun: false
+
 nodeLinker: hoisted
 linkWorkspacePackages: true
 preferWorkspacePackages: true


### PR DESCRIPTION
## What broke

The v4 publish workflow died on the canary-version-bump step: https://github.com/apify/crawlee/actions/runs/25744567788/job/75604092585

\`\`\`
ERROR  @crawlee/utils#copy: command (packages/utils) pnpm run copy --canary=major --preid=beta exited (1)
[ERROR] Command was killed with SIGINT (User interruption with CTRL-C):
  /home/runner/setup-pnpm/node_modules/.bin/global/...pnpm.mjs install
    at runDepsStatusCheck (pnpm.mjs:211947:7)
\`\`\`

## Why

pnpm 11 added \`verifyDepsBeforeRun\` (default: \`warn\`), which silently runs \`pnpm install\` before every \`pnpm run X\` to make sure installed deps match the lockfile. The publish workflow runs \`pnpm turbo copy --force -- --canary=major --preid=beta\`, which fans \`pnpm run copy\` out across all 23 workspace packages **in parallel**. So pnpm fires off 23 concurrent installs that fight over the store and the lockfile — one wins, the rest get killed with SIGINT, turbo aborts.

Regressed in #3645 (pnpm 10 → 11). pnpm 10 had no auto-install hook.

## Fix

\`\`\`yaml
# pnpm-workspace.yaml
verifyDepsBeforeRun: false
\`\`\`

CI already runs \`pnpm install --frozen-lockfile\` once at job start (via \`apify/workflows/pnpm-install\`), so disabling the per-script auto-install just removes the parallel contention without losing any guarantee.