### PR TITLE
refactor: revert Configuration.reset() static method

### DIFF
--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -206,21 +206,6 @@ export class Configuration {
     }
 
     /**
-     * Resets the global configuration (and the rest of the global service locator) so that the
-     * next `Configuration.getGlobalConfig()` call constructs a fresh instance from the current
-     * environment. Intended mainly for tests that mutate `process.env` at runtime — values are
-     * resolved eagerly at construction, so changing env vars after the singleton has been
-     * cached has no effect until the singleton is dropped.
-     *
-     * Delegates to {@link ServiceLocator.reset} since the global configuration is owned by the
-     * service locator; resetting only the configuration would leave a stale `EventManager` /
-     * `StorageClient` / logger holding the old config.
-     */
-    static reset(): void {
-        serviceLocator.reset();
-    }
-
-    /**
      * Resolves all field values once using the priority chain:
      * constructor options > env vars > crawlee.json > schema defaults.
      */

--- a/packages/core/test/core/configuration.test.ts
+++ b/packages/core/test/core/configuration.test.ts
@@ -317,18 +317,4 @@ describe('Configuration', () => {
             expect((config2 as any).customFlag).toBe(true);
         });
     });
-
-    describe('reset()', () => {
-        it('drops the cached global instance so the next `getGlobalConfig()` re-reads env vars', () => {
-            setEnv('CRAWLEE_DEFAULT_DATASET_ID', 'first');
-            expect(Configuration.getGlobalConfig().defaultDatasetId).toBe('first');
-
-            // Without resetting, the singleton keeps the value resolved at first access.
-            setEnv('CRAWLEE_DEFAULT_DATASET_ID', 'second');
-            expect(Configuration.getGlobalConfig().defaultDatasetId).toBe('first');
-
-            Configuration.reset();
-            expect(Configuration.getGlobalConfig().defaultDatasetId).toBe('second');
-        });
-    });
 });


### PR DESCRIPTION
## Summary

Reverts #3649. The added `Configuration.reset()` is a thin alias for `serviceLocator.reset()` — same scope, less honest name. The method lives on `Configuration` but doesn't reset anything *on* the Configuration; cached env-resolved values on existing instances are untouched, and the actual effect is "drop the configuration + event manager + storage client + logger that the service locator caches." Callers who want that should keep calling `serviceLocator.reset()` directly, where the name matches the behavior.

A narrower, Configuration-only reset (drop just the cached config, leave other services alone) would technically belong on `Configuration`, but it's not what callers want in practice — surviving services would still hold the stale config, leaving the runtime in an inconsistent state. The whole-tree drop is the right operation, and `serviceLocator.reset()` already provides it.

## Test plan
- [x] Existing crawlee tests still pass (the only test for `Configuration.reset()` was added in #3649 and is removed with the revert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)