### PR TITLE
chore(e2e): bump actor base images from Node 20 to Node 24

### DIFF
--- a/test/e2e/automatic-persist-value/actor/Dockerfile
+++ b/test/e2e/automatic-persist-value/actor/Dockerfile
@@ -1,4 +1,4 @@
-FROM apify/actor-node:20-beta
+FROM apify/actor-node:24-beta
 
 COPY packages ./packages
 COPY package*.json ./

--- a/test/e2e/autoscaling-max-tasks-per-minute/actor/Dockerfile
+++ b/test/e2e/autoscaling-max-tasks-per-minute/actor/Dockerfile
@@ -1,4 +1,4 @@
-FROM apify/actor-node:20-beta
+FROM apify/actor-node:24-beta
 
 COPY packages ./packages
 COPY package*.json ./

--- a/test/e2e/cheerio-default-ts/actor/Dockerfile
+++ b/test/e2e/cheerio-default-ts/actor/Dockerfile
@@ -1,5 +1,5 @@
 # using multistage build, as we need dev deps to build the TS source code
-FROM apify/actor-node:20-beta AS builder
+FROM apify/actor-node:24-beta AS builder
 
 # copy all files, install all dependencies (including dev deps) and build the project
 COPY . ./
@@ -7,7 +7,7 @@ RUN npm install --include=dev \
     && npm run build
 
 # create final image
-FROM apify/actor-node:20-beta
+FROM apify/actor-node:24-beta
 # copy only necessary files
 COPY --from=builder /usr/src/app/packages ./packages
 COPY --from=builder /usr/src/app/package.json ./

--- a/test/e2e/cheerio-default/actor/Dockerfile
+++ b/test/e2e/cheerio-default/actor/Dockerfile
@@ -1,4 +1,4 @@
-FROM apify/actor-node:20-beta
+FROM apify/actor-node:24-beta
 
 COPY packages ./packages
 COPY package*.json ./

--- a/test/e2e/cheerio-enqueue-links-base/actor/Dockerfile
+++ b/test/e2e/cheerio-enqueue-links-base/actor/Dockerfile
@@ -1,4 +1,4 @@
-FROM apify/actor-node:20-beta
+FROM apify/actor-node:24-beta
 
 COPY packages ./packages
 COPY package*.json ./

--- a/test/e2e/cheerio-enqueue-links/actor/Dockerfile
+++ b/test/e2e/cheerio-enqueue-links/actor/Dockerfile
@@ -1,4 +1,4 @@
-FROM apify/actor-node:20-beta
+FROM apify/actor-node:24-beta
 
 COPY packages ./packages
 COPY package*.json ./

--- a/test/e2e/cheerio-error-snapshot/actor/Dockerfile
+++ b/test/e2e/cheerio-error-snapshot/actor/Dockerfile
@@ -1,4 +1,4 @@
-FROM apify/actor-node:20-beta
+FROM apify/actor-node:24-beta
 
 COPY packages ./packages
 COPY package*.json ./

--- a/test/e2e/cheerio-ignore-ssl-errors/actor/Dockerfile
+++ b/test/e2e/cheerio-ignore-ssl-errors/actor/Dockerfile
@@ -1,4 +1,4 @@
-FROM apify/actor-node:20-beta
+FROM apify/actor-node:24-beta
 
 COPY packages ./packages
 COPY package*.json ./

--- a/test/e2e/cheerio-impit-ts/actor/Dockerfile
+++ b/test/e2e/cheerio-impit-ts/actor/Dockerfile
@@ -1,5 +1,5 @@
 # using multistage build, as we need dev deps to build the TS source code
-FROM apify/actor-node:20-beta AS builder
+FROM apify/actor-node:24-beta AS builder
 
 # copy all files, install all dependencies (including dev deps) and build the project
 COPY . ./
@@ -7,7 +7,7 @@ RUN npm install --include=dev \
     && npm run build
 
 # create final image
-FROM apify/actor-node:20-beta
+FROM apify/actor-node:24-beta
 # copy only necessary files
 COPY --from=builder /usr/src/app/packages ./packages
 COPY --from=builder /usr/src/app/package.json ./

--- a/test/e2e/cheerio-initial-cookies/actor/Dockerfile
+++ b/test/e2e/cheerio-initial-cookies/actor/Dockerfile
@@ -1,4 +1,4 @@
-FROM apify/actor-node:20-beta
+FROM apify/actor-node:24-beta
 
 COPY packages ./packages
 COPY package*.json ./

--- a/test/e2e/cheerio-max-requests/actor/Dockerfile
+++ b/test/e2e/cheerio-max-requests/actor/Dockerfile
@@ -1,4 +1,4 @@
-FROM apify/actor-node:20-beta
+FROM apify/actor-node:24-beta
 
 COPY packages ./packages
 COPY package*.json ./

--- a/test/e2e/cheerio-page-info/actor/Dockerfile
+++ b/test/e2e/cheerio-page-info/actor/Dockerfile
@@ -1,4 +1,4 @@
-FROM apify/actor-node:20-beta
+FROM apify/actor-node:24-beta
 
 COPY packages ./packages
 COPY package*.json ./

--- a/test/e2e/cheerio-request-queue-v2/actor/Dockerfile
+++ b/test/e2e/cheerio-request-queue-v2/actor/Dockerfile
@@ -1,4 +1,4 @@
-FROM apify/actor-node:20-beta
+FROM apify/actor-node:24-beta
 
 COPY packages ./packages
 COPY package*.json ./

--- a/test/e2e/cheerio-robots-file/actor/Dockerfile
+++ b/test/e2e/cheerio-robots-file/actor/Dockerfile
@@ -1,4 +1,4 @@
-FROM apify/actor-node:20-beta
+FROM apify/actor-node:24-beta
 
 COPY packages ./packages
 COPY package*.json ./

--- a/test/e2e/cheerio-stop-resume-ts/actor/Dockerfile
+++ b/test/e2e/cheerio-stop-resume-ts/actor/Dockerfile
@@ -1,5 +1,5 @@
 # using multistage build, as we need dev deps to build the TS source code
-FROM apify/actor-node:20-beta AS builder
+FROM apify/actor-node:24-beta AS builder
 
 # copy all files, install all dependencies (including dev deps) and build the project
 COPY . ./
@@ -7,7 +7,7 @@ RUN npm install --include=dev \
     && npm run build
 
 # create final image
-FROM apify/actor-node:20-beta
+FROM apify/actor-node:24-beta
 # copy only necessary files
 COPY --from=builder /usr/src/app/packages ./packages
 COPY --from=builder /usr/src/app/package.json ./

--- a/test/e2e/cheerio-throw-on-ssl-errors/actor/Dockerfile
+++ b/test/e2e/cheerio-throw-on-ssl-errors/actor/Dockerfile
@@ -1,4 +1,4 @@
-FROM apify/actor-node:20-beta
+FROM apify/actor-node:24-beta
 
 COPY packages ./packages
 COPY package*.json ./

--- a/test/e2e/input-json5/actor/Dockerfile
+++ b/test/e2e/input-json5/actor/Dockerfile
@@ -1,4 +1,4 @@
-FROM apify/actor-node:20-beta
+FROM apify/actor-node:24-beta
 
 COPY packages ./packages
 COPY package*.json ./

--- a/test/e2e/jsdom-default-ts/actor/Dockerfile
+++ b/test/e2e/jsdom-default-ts/actor/Dockerfile
@@ -1,5 +1,5 @@
 # using multistage build, as we need dev deps to build the TS source code
-FROM apify/actor-node:20-beta AS builder
+FROM apify/actor-node:24-beta AS builder
 
 # copy all files, install all dependencies (including dev deps) and build the project
 COPY . ./
@@ -7,7 +7,7 @@ RUN npm install --include=dev \
     && npm run build
 
 # create final image
-FROM apify/actor-node:20-beta
+FROM apify/actor-node:24-beta
 # copy only necessary files
 COPY --from=builder /usr/src/app/packages ./packages
 COPY --from=builder /usr/src/app/package.json ./

--- a/test/e2e/jsdom-react-ts/actor/Dockerfile
+++ b/test/e2e/jsdom-react-ts/actor/Dockerfile
@@ -1,5 +1,5 @@
 # using multistage build, as we need dev deps to build the TS source code
-FROM apify/actor-node:20-beta AS builder
+FROM apify/actor-node:24-beta AS builder
 
 # copy all files, install all dependencies (including dev deps) and build the project
 COPY . ./
@@ -7,7 +7,7 @@ RUN npm install --include=dev \
     && npm run build
 
 # create final image
-FROM apify/actor-node:20-beta
+FROM apify/actor-node:24-beta
 # copy only necessary files
 COPY --from=builder /usr/src/app/packages ./packages
 COPY --from=builder /usr/src/app/package.json ./

--- a/test/e2e/linkedom-default-ts/actor/Dockerfile
+++ b/test/e2e/linkedom-default-ts/actor/Dockerfile
@@ -1,5 +1,5 @@
 # using multistage build, as we need dev deps to build the TS source code
-FROM apify/actor-node:20-beta AS builder
+FROM apify/actor-node:24-beta AS builder
 
 # copy all files, install all dependencies (including dev deps) and build the project
 COPY . ./
@@ -7,7 +7,7 @@ RUN npm install --include=dev \
     && npm run build
 
 # create final image
-FROM apify/actor-node:20-beta
+FROM apify/actor-node:24-beta
 # copy only necessary files
 COPY --from=builder /usr/src/app/packages ./packages
 COPY --from=builder /usr/src/app/package.json ./

--- a/test/e2e/migration/actor/Dockerfile
+++ b/test/e2e/migration/actor/Dockerfile
@@ -1,4 +1,4 @@
-FROM apify/actor-node:20-beta
+FROM apify/actor-node:24-beta
 
 COPY packages ./packages
 COPY package*.json ./

--- a/test/e2e/proxy-rotation/actor/Dockerfile
+++ b/test/e2e/proxy-rotation/actor/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20 AS builder
+FROM node:24 AS builder
 
 COPY /packages ./packages
 COPY /package*.json ./
@@ -6,7 +6,7 @@ RUN npm --quiet set progress=false \
     && npm install --only=prod --no-optional --no-audit \
     && npm update
 
-FROM apify/actor-node-puppeteer-chrome:20-beta
+FROM apify/actor-node-puppeteer-chrome:24-beta
 
 RUN rm -r node_modules
 COPY --from=builder /node_modules ./node_modules

--- a/test/e2e/puppeteer-default/actor/Dockerfile
+++ b/test/e2e/puppeteer-default/actor/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20 AS builder
+FROM node:24 AS builder
 
 COPY /packages ./packages
 COPY /package*.json ./
@@ -6,7 +6,7 @@ RUN npm --quiet set progress=false \
     && npm install --only=prod --no-optional --no-audit \
     && npm update
 
-FROM apify/actor-node-puppeteer-chrome:20-beta
+FROM apify/actor-node-puppeteer-chrome:24-beta
 
 RUN rm -r node_modules
 COPY --from=builder /node_modules ./node_modules

--- a/test/e2e/puppeteer-enqueue-links/actor/Dockerfile
+++ b/test/e2e/puppeteer-enqueue-links/actor/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20 AS builder
+FROM node:24 AS builder
 
 COPY /packages ./packages
 COPY /package*.json ./
@@ -6,7 +6,7 @@ RUN npm --quiet set progress=false \
     && npm install --only=prod --no-optional --no-audit \
     && npm update
 
-FROM apify/actor-node-puppeteer-chrome:20-beta
+FROM apify/actor-node-puppeteer-chrome:24-beta
 
 RUN rm -r node_modules
 COPY --from=builder /node_modules ./node_modules

--- a/test/e2e/puppeteer-error-snapshot/actor/Dockerfile
+++ b/test/e2e/puppeteer-error-snapshot/actor/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20 AS builder
+FROM node:24 AS builder
 
 COPY /packages ./packages
 COPY /package*.json ./
@@ -6,7 +6,7 @@ RUN npm --quiet set progress=false \
     && npm install --only=prod --no-optional --no-audit \
     && npm update
 
-FROM apify/actor-node-puppeteer-chrome:20-beta
+FROM apify/actor-node-puppeteer-chrome:24-beta
 
 RUN rm -r node_modules
 COPY --from=builder /node_modules ./node_modules

--- a/test/e2e/puppeteer-ignore-ssl-errors/actor/Dockerfile
+++ b/test/e2e/puppeteer-ignore-ssl-errors/actor/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20 AS builder
+FROM node:24 AS builder
 
 COPY /packages ./packages
 COPY /package*.json ./
@@ -6,7 +6,7 @@ RUN npm --quiet set progress=false \
     && npm install --only=prod --no-optional --no-audit \
     && npm update
 
-FROM apify/actor-node-puppeteer-chrome:20-beta
+FROM apify/actor-node-puppeteer-chrome:24-beta
 
 RUN rm -r node_modules
 COPY --from=builder /node_modules ./node_modules

--- a/test/e2e/puppeteer-initial-cookies/actor/Dockerfile
+++ b/test/e2e/puppeteer-initial-cookies/actor/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20 AS builder
+FROM node:24 AS builder
 
 COPY /packages ./packages
 COPY /package*.json ./
@@ -6,7 +6,7 @@ RUN npm --quiet set progress=false \
     && npm install --only=prod --no-optional --no-audit \
     && npm update
 
-FROM apify/actor-node-puppeteer-chrome:20-beta
+FROM apify/actor-node-puppeteer-chrome:24-beta
 
 RUN rm -r node_modules
 COPY --from=builder /node_modules ./node_modules

--- a/test/e2e/puppeteer-page-info/actor/Dockerfile
+++ b/test/e2e/puppeteer-page-info/actor/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20 AS builder
+FROM node:24 AS builder
 
 COPY /packages ./packages
 COPY /package*.json ./
@@ -6,7 +6,7 @@ RUN npm --quiet set progress=false \
     && npm install --only=prod --no-optional --no-audit \
     && npm update
 
-FROM apify/actor-node-puppeteer-chrome:20-beta
+FROM apify/actor-node-puppeteer-chrome:24-beta
 
 RUN rm -r node_modules
 COPY --from=builder /node_modules ./node_modules

--- a/test/e2e/puppeteer-store-pagination-jquery/actor/Dockerfile
+++ b/test/e2e/puppeteer-store-pagination-jquery/actor/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20 AS builder
+FROM node:24 AS builder
 
 COPY /packages ./packages
 COPY /package*.json ./
@@ -6,7 +6,7 @@ RUN npm --quiet set progress=false \
     && npm install --only=prod --no-optional --no-audit \
     && npm update
 
-FROM apify/actor-node-puppeteer-chrome:20-beta
+FROM apify/actor-node-puppeteer-chrome:24-beta
 
 RUN rm -r node_modules
 COPY --from=builder /node_modules ./node_modules

--- a/test/e2e/puppeteer-store-pagination/actor/Dockerfile
+++ b/test/e2e/puppeteer-store-pagination/actor/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20 AS builder
+FROM node:24 AS builder
 
 COPY /packages ./packages
 COPY /package*.json ./
@@ -6,7 +6,7 @@ RUN npm --quiet set progress=false \
     && npm install --only=prod --no-optional --no-audit \
     && npm update
 
-FROM apify/actor-node-puppeteer-chrome:20-beta
+FROM apify/actor-node-puppeteer-chrome:24-beta
 
 RUN rm -r node_modules
 COPY --from=builder /node_modules ./node_modules

--- a/test/e2e/puppeteer-throw-on-ssl-errors/actor/Dockerfile
+++ b/test/e2e/puppeteer-throw-on-ssl-errors/actor/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20 AS builder
+FROM node:24 AS builder
 
 COPY /packages ./packages
 COPY /package*.json ./
@@ -6,7 +6,7 @@ RUN npm --quiet set progress=false \
     && npm install --only=prod --no-optional --no-audit \
     && npm update
 
-FROM apify/actor-node-puppeteer-chrome:20-beta
+FROM apify/actor-node-puppeteer-chrome:24-beta
 
 RUN rm -r node_modules
 COPY --from=builder /node_modules ./node_modules

--- a/test/e2e/request-queue-with-concurrency/actor/Dockerfile
+++ b/test/e2e/request-queue-with-concurrency/actor/Dockerfile
@@ -1,4 +1,4 @@
-FROM apify/actor-node:20-beta
+FROM apify/actor-node:24-beta
 
 COPY packages ./packages
 COPY package*.json ./

--- a/test/e2e/request-queue-zero-concurrency/actor/Dockerfile
+++ b/test/e2e/request-queue-zero-concurrency/actor/Dockerfile
@@ -1,4 +1,4 @@
-FROM apify/actor-node:20-beta
+FROM apify/actor-node:24-beta
 
 COPY packages ./packages
 COPY package*.json ./

--- a/test/e2e/request-skip-navigation/actor/Dockerfile
+++ b/test/e2e/request-skip-navigation/actor/Dockerfile
@@ -1,4 +1,4 @@
-FROM apify/actor-node:20-beta
+FROM apify/actor-node:24-beta
 
 COPY packages ./packages
 COPY package*.json ./

--- a/test/e2e/storage-open-return-storage-object/actor/Dockerfile
+++ b/test/e2e/storage-open-return-storage-object/actor/Dockerfile
@@ -1,4 +1,4 @@
-FROM apify/actor-node:20-beta
+FROM apify/actor-node:24-beta
 
 COPY packages ./packages
 COPY package*.json ./


### PR DESCRIPTION
The `automatic-persist-value` e2e test was failing on the Apify platform: `better-sqlite3@12.4.1` (pulled in transitively via `camoufox-js`) has no musl prebuilds for Node 20, and the Alpine base image has no Python for the `node-gyp` fallback. Node 24 variants ship prebuilds for it.

Bumps all 35 e2e actor Dockerfiles still on Node 20:
- `apify/actor-node:20-beta` → `:24-beta`
- `apify/actor-node-puppeteer-chrome:20-beta` → `:24-beta`
- `node:20 AS builder` → `node:24 AS builder`

Playwright/Camoufox e2e actors were already on Node 24. Templates under `packages/templates/` are out of scope here.