### PR TITLE
chore(templates): bump actor base images to Node 24

### DIFF
--- a/docs/guides/docker_images.mdx
+++ b/docs/guides/docker_images.mdx
@@ -38,18 +38,18 @@ Each image is tagged with up to 2 version tags, depending on the type of the ima
 
 ### Node.js versioning
 
-Our images are built with multiple Node.js versions to ensure backwards compatibility. Currently, Node.js **versions 16 and 18 are supported** (legacy versions still exist, see DockerHub). To select the preferred version, use the appropriate number as the image tag.
+Our images are built with multiple Node.js versions to ensure backwards compatibility. Currently, Node.js **versions 20, 22, and 24 are supported** (legacy versions still exist, see DockerHub). To select the preferred version, use the appropriate number as the image tag.
 
 ```dockerfile
-# Use Node.js 20
-FROM apify/actor-node:20
+# Use Node.js 24
+FROM apify/actor-node:24
 ```
 
 ### Automation library versioning
 
-Images that include a pre-installed automation library, which means all images that include `puppeteer` or `playwright` in their name, are also tagged with the pre-installed version of the library. For example, `apify/actor-node-puppeteer-chrome:20-22.1.0` comes with Node.js 20 and Puppeteer v22.1.0. If you try to install a different version of Puppeteer into this image, you may run into compatibility issues, because the Chromium version bundled with `puppeteer` will not match the version of Chromium that's pre-installed.
+Images that include a pre-installed automation library, which means all images that include `puppeteer` or `playwright` in their name, are also tagged with the pre-installed version of the library. For example, `apify/actor-node-puppeteer-chrome:24-24.43.1` comes with Node.js 24 and Puppeteer v24.43.1. If you try to install a different version of Puppeteer into this image, you may run into compatibility issues, because the Chromium version bundled with `puppeteer` will not match the version of Chromium that's pre-installed.
 
-Similarly `apify/actor-node-playwright-firefox:14-1.21.1` runs on Node.js 14 and is pre-installed with the Firefox version that comes with v1.21.1.
+Similarly `apify/actor-node-playwright-firefox:24-1.60.0` runs on Node.js 24 and is pre-installed with the Firefox version that comes with v1.60.0.
 
 Installing `apify/actor-node-puppeteer-chrome` (without a tag) will install the latest available version of Node.js and `puppeteer`.
 
@@ -59,12 +59,12 @@ We also build pre-release versions of the images to test the changes we make. Th
 
 ```dockerfile
 # Without library version.
-FROM apify/actor-node:20-beta
+FROM apify/actor-node:24-beta
 ```
 
 ```dockerfile
 # With library version.
-FROM apify/actor-node-playwright-chrome:20-1.10.0-beta
+FROM apify/actor-node-playwright-chrome:24-1.60.0-beta
 ```
 
 ## Best practices
@@ -76,21 +76,21 @@ For production crawlers, we recommend pinning both the Node.js version **and** t
 Match the automation library version in your `package.json` with the version in your Docker image tag:
 
 ```dockerfile
-FROM apify/actor-node-playwright-chrome:22-1.52.0
+FROM apify/actor-node-playwright-chrome:24-1.60.0
 ```
 
 ```json
 {
     "dependencies": {
         "crawlee": "^3.0.0",
-        "playwright": "1.52.0"
+        "playwright": "1.60.0"
     }
 }
 ```
 
 :::warning Why version matching matters
 
-If you pin the Docker image to `22-1.52.0` but install a different Playwright version via `package.json`, you may encounter browser compatibility issues. The browsers pre-installed in the image are specifically built for that Playwright version.
+If you pin the Docker image to `24-1.60.0` but install a different Playwright version via `package.json`, you may encounter browser compatibility issues. The browsers pre-installed in the image are specifically built for that Playwright version.
 
 :::
 
@@ -99,7 +99,7 @@ If you pin the Docker image to `22-1.52.0` but install a different Playwright ve
 You can also use asterisk `*` as the automation library version in your `package.json`:
 
 ```dockerfile
-FROM apify/actor-node-playwright-chrome:22
+FROM apify/actor-node-playwright-chrome:24
 ```
 
 ```json
@@ -147,7 +147,7 @@ This is the smallest image we have based on Alpine Linux. It does not include an
 &#8203;<ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink>, <ApiLink to="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink> and other browser based features will **NOT** work with this image.
 
 ```dockerfile
-FROM apify/actor-node:20
+FROM apify/actor-node:24
 ```
 
 ### actor-node-puppeteer-chrome
@@ -157,7 +157,7 @@ This image includes Puppeteer (Chromium) and the Chrome browser. It can be used 
 The image supports XVFB by default, so you can run both `headless` and `headful` browsers with it.
 
 ```dockerfile
-FROM apify/actor-node-puppeteer-chrome:20
+FROM apify/actor-node-puppeteer-chrome:24
 ```
 
 ### actor-node-playwright
@@ -165,7 +165,7 @@ FROM apify/actor-node-puppeteer-chrome:20
 A very large and slow image that can run all Playwright browsers: Chromium, Chrome, Firefox, WebKit. Everything is installed. If you need to develop or test with multiple browsers, this is the image to choose, but in most cases, it's better to use the specialized images below.
 
 ```dockerfile
-FROM apify/actor-node-playwright:20
+FROM apify/actor-node-playwright:24
 ```
 
 ### actor-node-playwright-chrome
@@ -177,7 +177,7 @@ It uses the [`PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD`](https://playwright.dev/docs/api
 The image supports XVFB by default, so we can run both `headless` and `headful` browsers with it.
 
 ```dockerfile
-FROM apify/actor-node-playwright-chrome:20
+FROM apify/actor-node-playwright-chrome:24
 ```
 
 ### actor-node-playwright-firefox
@@ -186,7 +186,7 @@ Same idea as [`actor-node-playwright-chrome`](#actor-node-playwright-chrome), bu
 pre-installed.
 
 ```dockerfile
-FROM apify/actor-node-playwright-firefox:20
+FROM apify/actor-node-playwright-firefox:24
 ```
 
 ### actor-node-playwright-webkit
@@ -195,7 +195,7 @@ Same idea as [`actor-node-playwright-chrome`](#actor-node-playwright-chrome), bu
 pre-installed.
 
 ```dockerfile
-FROM apify/actor-node-playwright-webkit:20
+FROM apify/actor-node-playwright-webkit:24
 ```
 
 ## Example Dockerfile

--- a/packages/templates/templates/cheerio-js/Dockerfile
+++ b/packages/templates/templates/cheerio-js/Dockerfile
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://crawlee.dev/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node:20
+FROM apify/actor-node:24
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.

--- a/packages/templates/templates/cheerio-ts/Dockerfile
+++ b/packages/templates/templates/cheerio-ts/Dockerfile
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://crawlee.dev/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node:20 AS builder
+FROM apify/actor-node:24 AS builder
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.
@@ -19,7 +19,7 @@ COPY . ./
 RUN npm run build
 
 # Create final image
-FROM apify/actor-node:20
+FROM apify/actor-node:24
 
 # Copy only built JS files from builder image
 COPY --from=builder /usr/src/app/dist ./dist

--- a/packages/templates/templates/empty-js/Dockerfile
+++ b/packages/templates/templates/empty-js/Dockerfile
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://crawlee.dev/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node:20
+FROM apify/actor-node:24
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.

--- a/packages/templates/templates/empty-ts/Dockerfile
+++ b/packages/templates/templates/empty-ts/Dockerfile
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://crawlee.dev/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node:20 AS builder
+FROM apify/actor-node:24 AS builder
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.
@@ -19,7 +19,7 @@ COPY . ./
 RUN npm run build
 
 # Create final image
-FROM apify/actor-node:20
+FROM apify/actor-node:24
 
 # Copy only built JS files from builder image
 COPY --from=builder /usr/src/app/dist ./dist

--- a/packages/templates/templates/puppeteer-js/Dockerfile
+++ b/packages/templates/templates/puppeteer-js/Dockerfile
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://crawlee.dev/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node-puppeteer-chrome:20
+FROM apify/actor-node-puppeteer-chrome:24
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.

--- a/packages/templates/templates/puppeteer-ts/Dockerfile
+++ b/packages/templates/templates/puppeteer-ts/Dockerfile
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://crawlee.dev/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node-puppeteer-chrome:20 AS builder
+FROM apify/actor-node-puppeteer-chrome:24 AS builder
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.
@@ -19,7 +19,7 @@ COPY --chown=myuser . ./
 RUN npm run build
 
 # Create final image
-FROM apify/actor-node-puppeteer-chrome:20
+FROM apify/actor-node-puppeteer-chrome:24
 
 # Copy only built JS files from builder image
 COPY --from=builder --chown=myuser /home/myuser/dist ./dist

--- a/website/versioned_docs/version-3.16/guides/docker_images.mdx
+++ b/website/versioned_docs/version-3.16/guides/docker_images.mdx
@@ -38,18 +38,18 @@ Each image is tagged with up to 2 version tags, depending on the type of the ima
 
 ### Node.js versioning
 
-Our images are built with multiple Node.js versions to ensure backwards compatibility. Currently, Node.js **versions 16 and 18 are supported** (legacy versions still exist, see DockerHub). To select the preferred version, use the appropriate number as the image tag.
+Our images are built with multiple Node.js versions to ensure backwards compatibility. Currently, Node.js **versions 20, 22, and 24 are supported** (legacy versions still exist, see DockerHub). To select the preferred version, use the appropriate number as the image tag.
 
 ```dockerfile
-# Use Node.js 20
-FROM apify/actor-node:20
+# Use Node.js 24
+FROM apify/actor-node:24
 ```
 
 ### Automation library versioning
 
-Images that include a pre-installed automation library, which means all images that include `puppeteer` or `playwright` in their name, are also tagged with the pre-installed version of the library. For example, `apify/actor-node-puppeteer-chrome:20-22.1.0` comes with Node.js 20 and Puppeteer v22.1.0. If you try to install a different version of Puppeteer into this image, you may run into compatibility issues, because the Chromium version bundled with `puppeteer` will not match the version of Chromium that's pre-installed.
+Images that include a pre-installed automation library, which means all images that include `puppeteer` or `playwright` in their name, are also tagged with the pre-installed version of the library. For example, `apify/actor-node-puppeteer-chrome:24-24.43.1` comes with Node.js 24 and Puppeteer v24.43.1. If you try to install a different version of Puppeteer into this image, you may run into compatibility issues, because the Chromium version bundled with `puppeteer` will not match the version of Chromium that's pre-installed.
 
-Similarly `apify/actor-node-playwright-firefox:14-1.21.1` runs on Node.js 14 and is pre-installed with the Firefox version that comes with v1.21.1.
+Similarly `apify/actor-node-playwright-firefox:24-1.60.0` runs on Node.js 24 and is pre-installed with the Firefox version that comes with v1.60.0.
 
 Installing `apify/actor-node-puppeteer-chrome` (without a tag) will install the latest available version of Node.js and `puppeteer`.
 
@@ -59,12 +59,12 @@ We also build pre-release versions of the images to test the changes we make. Th
 
 ```dockerfile
 # Without library version.
-FROM apify/actor-node:20-beta
+FROM apify/actor-node:24-beta
 ```
 
 ```dockerfile
 # With library version.
-FROM apify/actor-node-playwright-chrome:20-1.10.0-beta
+FROM apify/actor-node-playwright-chrome:24-1.60.0-beta
 ```
 
 ## Best practices
@@ -76,21 +76,21 @@ For production crawlers, we recommend pinning both the Node.js version **and** t
 Match the automation library version in your `package.json` with the version in your Docker image tag:
 
 ```dockerfile
-FROM apify/actor-node-playwright-chrome:22-1.52.0
+FROM apify/actor-node-playwright-chrome:24-1.60.0
 ```
 
 ```json
 {
     "dependencies": {
         "crawlee": "^3.0.0",
-        "playwright": "1.52.0"
+        "playwright": "1.60.0"
     }
 }
 ```
 
 :::warning Why version matching matters
 
-If you pin the Docker image to `22-1.52.0` but install a different Playwright version via `package.json`, you may encounter browser compatibility issues. The browsers pre-installed in the image are specifically built for that Playwright version.
+If you pin the Docker image to `24-1.60.0` but install a different Playwright version via `package.json`, you may encounter browser compatibility issues. The browsers pre-installed in the image are specifically built for that Playwright version.
 
 :::
 
@@ -99,7 +99,7 @@ If you pin the Docker image to `22-1.52.0` but install a different Playwright ve
 You can also use asterisk `*` as the automation library version in your `package.json`:
 
 ```dockerfile
-FROM apify/actor-node-playwright-chrome:22
+FROM apify/actor-node-playwright-chrome:24
 ```
 
 ```json
@@ -147,7 +147,7 @@ This is the smallest image we have based on Alpine Linux. It does not include an
 &#8203;<ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink>, <ApiLink to="playwright-crawler/class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink> and other browser based features will **NOT** work with this image.
 
 ```dockerfile
-FROM apify/actor-node:20
+FROM apify/actor-node:24
 ```
 
 ### actor-node-puppeteer-chrome
@@ -157,7 +157,7 @@ This image includes Puppeteer (Chromium) and the Chrome browser. It can be used 
 The image supports XVFB by default, so you can run both `headless` and `headful` browsers with it.
 
 ```dockerfile
-FROM apify/actor-node-puppeteer-chrome:20
+FROM apify/actor-node-puppeteer-chrome:24
 ```
 
 ### actor-node-playwright
@@ -165,7 +165,7 @@ FROM apify/actor-node-puppeteer-chrome:20
 A very large and slow image that can run all Playwright browsers: Chromium, Chrome, Firefox, WebKit. Everything is installed. If you need to develop or test with multiple browsers, this is the image to choose, but in most cases, it's better to use the specialized images below.
 
 ```dockerfile
-FROM apify/actor-node-playwright:20
+FROM apify/actor-node-playwright:24
 ```
 
 ### actor-node-playwright-chrome
@@ -177,7 +177,7 @@ It uses the [`PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD`](https://playwright.dev/docs/api
 The image supports XVFB by default, so we can run both `headless` and `headful` browsers with it.
 
 ```dockerfile
-FROM apify/actor-node-playwright-chrome:20
+FROM apify/actor-node-playwright-chrome:24
 ```
 
 ### actor-node-playwright-firefox
@@ -186,7 +186,7 @@ Same idea as [`actor-node-playwright-chrome`](#actor-node-playwright-chrome), bu
 pre-installed.
 
 ```dockerfile
-FROM apify/actor-node-playwright-firefox:20
+FROM apify/actor-node-playwright-firefox:24
 ```
 
 ### actor-node-playwright-webkit
@@ -195,7 +195,7 @@ Same idea as [`actor-node-playwright-chrome`](#actor-node-playwright-chrome), bu
 pre-installed.
 
 ```dockerfile
-FROM apify/actor-node-playwright-webkit:20
+FROM apify/actor-node-playwright-webkit:24
 ```
 
 ## Example Dockerfile


### PR DESCRIPTION
Aligns the cheerio, empty, and puppeteer project templates with the playwright/camoufox templates, which already ship on Node 24.

- `apify/actor-node:20` → `:24`
- `apify/actor-node-puppeteer-chrome:20` → `:24`

Affected: `cheerio-js`, `cheerio-ts`, `empty-js`, `empty-ts`, `puppeteer-js`, `puppeteer-ts`.