### PR TITLE
fix(core): release storage open queue slot on failure

### DIFF
--- a/packages/core/src/storages/storage_manager.ts
+++ b/packages/core/src/storages/storage_manager.ts
@@ -70,32 +70,34 @@ export class StorageManager<T extends IStorage = IStorage> {
     async openStorage(idOrName?: string | null, client?: StorageClient): Promise<T> {
         await this.storageOpenQueue.wait();
 
-        if (!idOrName) {
-            const defaultIdConfigKey = DEFAULT_ID_CONFIG_KEYS[this.name];
-            idOrName = this.config.get(defaultIdConfigKey) as string;
+        try {
+            if (!idOrName) {
+                const defaultIdConfigKey = DEFAULT_ID_CONFIG_KEYS[this.name];
+                idOrName = this.config.get(defaultIdConfigKey) as string;
+            }
+
+            const cacheKey = idOrName;
+            let storage = this.cache.get(cacheKey);
+
+            if (!storage) {
+                client ??= this.config.getStorageClient();
+                const storageObject = await this._getOrCreateStorage(idOrName, this.name, client);
+                storage = new this.StorageConstructor(
+                    {
+                        id: storageObject.id,
+                        name: storageObject.name,
+                        storageObject,
+                        client,
+                    },
+                    this.config,
+                );
+                this._addStorageToCache(storage);
+            }
+
+            return storage;
+        } finally {
+            this.storageOpenQueue.shift();
         }
-
-        const cacheKey = idOrName;
-        let storage = this.cache.get(cacheKey);
-
-        if (!storage) {
-            client ??= this.config.getStorageClient();
-            const storageObject = await this._getOrCreateStorage(idOrName, this.name, client);
-            storage = new this.StorageConstructor(
-                {
-                    id: storageObject.id,
-                    name: storageObject.name,
-                    storageObject,
-                    client,
-                },
-                this.config,
-            );
-            this._addStorageToCache(storage);
-        }
-
-        this.storageOpenQueue.shift();
-
-        return storage;
     }
 
     closeStorage(storage: { id: string; name?: string }): void {

--- a/test/core/storages/storage_manager.test.ts
+++ b/test/core/storages/storage_manager.test.ts
@@ -1,0 +1,37 @@
+import { Configuration, Dataset } from '@crawlee/core';
+
+import { MemoryStorageEmulator } from '../../shared/MemoryStorageEmulator';
+
+const localStorageEmulator = new MemoryStorageEmulator();
+
+beforeEach(async () => {
+    await localStorageEmulator.init();
+});
+
+afterAll(async () => {
+    await localStorageEmulator.destroy();
+});
+
+describe('StorageManager', () => {
+    test('failed openStorage call does not block subsequent calls (#3661)', async () => {
+        const goodClient = Configuration.getStorageClient();
+        const failingClient = {
+            ...goodClient,
+            datasets: () => {
+                throw new Error('boom');
+            },
+            dataset: () => {
+                throw new Error('boom');
+            },
+        };
+
+        await expect(Dataset.open('will-fail', { storageClient: failingClient as any })).rejects.toThrow('boom');
+
+        await expect(
+            Promise.race([
+                Dataset.open('fallback'),
+                new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), 1000)),
+            ]),
+        ).resolves.toBeDefined();
+    });
+});


### PR DESCRIPTION
A failing `StorageManager.openStorage()` call (e.g. invalid storage client token) left its slot in `storageOpenQueue` held forever, deadlocking every subsequent `openStorage` call on the same manager. The body now runs inside a `try/finally` so the slot is always released. Includes a regression test that times out against the unpatched code.

Closes #3661