### PR TITLE
fix: move EventEmitter.defaultMaxListeners side effect out of Configuration constructor

### DIFF
--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -1,5 +1,4 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
-import { EventEmitter } from 'node:events';
 import { join } from 'node:path';
 
 import type { MemoryStorageOptions } from '@crawlee/memory-storage';
@@ -317,9 +316,6 @@ export class Configuration {
      */
     constructor(options: ConfigurationOptions = {}) {
         this.buildOptions(options);
-
-        // Increase the global limit for event emitter memory leak warnings.
-        EventEmitter.defaultMaxListeners = 50;
 
         // set the log level to support CRAWLEE_ prefixed env var too
         const logLevel = this.get('logLevel');

--- a/packages/core/src/session_pool/session_pool.ts
+++ b/packages/core/src/session_pool/session_pool.ts
@@ -161,6 +161,9 @@ export class SessionPool extends EventEmitter {
     ) {
         super();
 
+        // Increase max listeners for this instance to avoid warnings when many sessions are active
+        this.setMaxListeners(50);
+
         ow(
             options,
             ow.object.exactShape({


### PR DESCRIPTION
## Summary

Removes the `EventEmitter.defaultMaxListeners = 50` call from the `Configuration` constructor. Importing `Configuration` is now a pure, side-effect-free operation. The same limit is applied locally to `SessionPool`, which is the Crawlee-owned `EventEmitter` subclass that most needs it (it manages many session listeners).

## Problem

The `Configuration` constructor was calling `EventEmitter.defaultMaxListeners = 50` at module import time. This is an opaque global side effect triggered just by importing a value-object class — surprising and hard to discover. The issue suggested moving this to `setMaxListeners(50)` on specific Crawlee-owned `EventEmitter` instances instead.

Reported in: https://github.com/apify/crawlee/issues/3615

## Solution

1. **Removed** the global `EventEmitter.defaultMaxListeners = 50` call and the now-unused `EventEmitter` import from `packages/core/src/configuration.ts`
2. **Added** `this.setMaxListeners(50)` in `SessionPool` constructor (`packages/core/src/session_pool/session_pool.ts`) — the one Crawlee `EventEmitter` subclass that accumulates many listeners over its lifetime

## Changes

- `packages/core/src/configuration.ts`: Removed `EventEmitter.defaultMaxListeners = 50` from constructor; removed unused `EventEmitter` import
- `packages/core/src/session_pool/session_pool.ts`: Added `this.setMaxListeners(50)` after `super()` call

## Tests

```bash
npx tsc --noEmit -p packages/core/tsconfig.json
npx tsc --noEmit -p packages/basic-crawler/tsconfig.json
```

Both compile cleanly.

## Compatibility / Risk

- **Risk**: Low — removes a global side effect and replaces it with a targeted per-instance call
- **Compatibility**: Fully backwards-compatible; no public API changes
- **Scope**: Only affects internal initialization timing of event listener limits. Existing code that relies on the global default being bumped will no longer get that behavior — but the new approach is more correct (targeted vs global)

## Notes for maintainers

The fix only covers `SessionPool` since it is the only Crawlee `EventEmitter` subclass that creates enough listeners to hit the old threshold. If other classes (`PlaywrightBrowser`, `ObservableSet`, etc.) also need this, they can be updated in follow-up PRs. The direction follows the issue's suggestion: "set `setMaxListeners(50)` on the specific `EventEmitter` instances Crawlee owns."