### PR TITLE
docs: clarify tieredProxyUrls behavior for standalone newUrl() calls

### DIFF
--- a/docs/guides/proxy_management.mdx
+++ b/docs/guides/proxy_management.mdx
@@ -105,9 +105,11 @@ You can also provide a list of proxy tiers to the `ProxyConfiguration` class. Th
 
 :::warning
 
-Note that the `tieredProxyUrls` option requires `ProxyConfiguration` to be used from a crawler instance ([see below](#crawler-integration)). 
+The `tieredProxyUrls` option requires `ProxyConfiguration` to be used from a crawler instance ([see below](#crawler-integration)).
 
-Using this configuration through the `newUrl` calls will not yield the expected results.
+Calling `newUrl()` or `newProxyInfo()` directly on the `ProxyConfiguration` object will not activate tier logic — it will simply rotate through all provided URLs in round-robin fashion, ignoring tier associations and blocking detection. This is because tiered proxy behavior relies on session state and per-domain error tracking that only exist within a running crawler.
+
+For standalone usage, use `proxyUrls` (simple rotation) instead, or use `newUrlFunction` to implement custom logic.
 
 :::
 


### PR DESCRIPTION
## Summary

Expands the warning for `tieredProxyUrls` in the proxy management docs to explain exactly what happens when `newUrl()` / `newProxyInfo()` are called outside a crawler context — and why.

## Why this matters

The existing warning was vague: *"Using this configuration through the `newUrl` calls will not yield the expected results."* This leaves users confused about what "unexpected" actually means. The expanded warning now explains:

- **What happens**: Tier logic is bypassed; behavior falls back to flat round-robin through all provided URLs in all tiers
- **Why**: Tier tracking depends on session state and per-domain error tracking that only exist within a running crawler
- **What to use instead**: `proxyUrls` (simple round-robin) or `newUrlFunction` (custom logic)

## Changes

- `docs/guides/proxy_management.mdx`: Expanded the warning block in the "Tiered proxies" section (lines 106-114) to explain the technical mechanism and provide actionable alternatives

## Validation

- `npx tsc --noEmit` on `packages/core/` passes (no code changes)
- Markdown preview: warning renders correctly in Docusaurus
- No broken links — all internal references (`#crawler-integration`) are preserved