### PR TITLE
fix(browser-pool): preserve caller's AbortContext across p-limit queue

### DIFF
--- a/packages/browser-pool/src/browser-pool.ts
+++ b/packages/browser-pool/src/browser-pool.ts
@@ -1,3 +1,5 @@
+import { AsyncResource } from 'node:async_hooks';
+
 import type { TieredProxy } from '@crawlee/core';
 import type { BrowserFingerprintWithHeaders } from 'fingerprint-generator';
 import { FingerprintGenerator } from 'fingerprint-generator';
@@ -8,7 +10,7 @@ import pLimit from 'p-limit';
 import QuickLRU from 'quick-lru';
 import { TypedEmitter } from 'tiny-typed-emitter';
 
-import { addTimeoutToPromise, storage as timeoutAbortStorage, tryCancel } from '@apify/timeout';
+import { addTimeoutToPromise, tryCancel } from '@apify/timeout';
 
 import type { BrowserController } from './abstract-classes/browser-controller';
 import type { BrowserPlugin } from './abstract-classes/browser-plugin';
@@ -445,15 +447,15 @@ export class BrowserPool<
             throw new Error('Provided browserPlugin is not one of the plugins used by BrowserPool.');
         }
 
-        // Capture caller's AbortContext before entering p-limit: queued limiter
-        // callbacks otherwise inherit the previous task's AsyncLocalStorage context
-        // via p-limit's internal promise chain, leaking aborted cancelTasks across
-        // unrelated requests (https://github.com/apify/crawlee/issues/3670).
-        const callerContext = timeoutAbortStorage.getStore();
-
+        // Bind the limiter callback to the current async-hooks context. p-limit
+        // otherwise resumes queued callbacks in the previous task's
+        // AsyncLocalStorage context, leaking aborted cancelTasks across unrelated
+        // requests (https://github.com/apify/crawlee/issues/3670). Mirrors the
+        // fix p-limit landed upstream in v5 (sindresorhus/p-limit#71); we can't
+        // bump to v5 directly because it's a breaking release.
         // Limiter is necessary - https://github.com/apify/crawlee/issues/1126
-        return this.limiter(async () => {
-            const work = async () => {
+        return this.limiter(
+            AsyncResource.bind(async () => {
                 let browserController = this._pickBrowserWithFreeCapacity(browserPlugin, { proxyTier, proxyUrl });
 
                 if (!browserController)
@@ -461,10 +463,8 @@ export class BrowserPool<
                 tryCancel();
 
                 return await this._createPageForBrowser(id, browserController, pageOptions, proxyUrl);
-            };
-
-            return callerContext ? timeoutAbortStorage.run(callerContext, work) : timeoutAbortStorage.exit(work);
-        });
+            }),
+        );
     }
 
     /**

--- a/packages/browser-pool/src/browser-pool.ts
+++ b/packages/browser-pool/src/browser-pool.ts
@@ -8,7 +8,7 @@ import pLimit from 'p-limit';
 import QuickLRU from 'quick-lru';
 import { TypedEmitter } from 'tiny-typed-emitter';
 
-import { addTimeoutToPromise, tryCancel } from '@apify/timeout';
+import { addTimeoutToPromise, storage as timeoutAbortStorage, tryCancel } from '@apify/timeout';
 
 import type { BrowserController } from './abstract-classes/browser-controller';
 import type { BrowserPlugin } from './abstract-classes/browser-plugin';
@@ -445,15 +445,25 @@ export class BrowserPool<
             throw new Error('Provided browserPlugin is not one of the plugins used by BrowserPool.');
         }
 
+        // Capture caller's AbortContext before entering p-limit: queued limiter
+        // callbacks otherwise inherit the previous task's AsyncLocalStorage context
+        // via p-limit's internal promise chain, leaking aborted cancelTasks across
+        // unrelated requests (https://github.com/apify/crawlee/issues/3670).
+        const callerContext = timeoutAbortStorage.getStore();
+
         // Limiter is necessary - https://github.com/apify/crawlee/issues/1126
         return this.limiter(async () => {
-            let browserController = this._pickBrowserWithFreeCapacity(browserPlugin, { proxyTier, proxyUrl });
+            const work = async () => {
+                let browserController = this._pickBrowserWithFreeCapacity(browserPlugin, { proxyTier, proxyUrl });
 
-            if (!browserController)
-                browserController = await this._launchBrowser(id, { browserPlugin, proxyTier, proxyUrl });
-            tryCancel();
+                if (!browserController)
+                    browserController = await this._launchBrowser(id, { browserPlugin, proxyTier, proxyUrl });
+                tryCancel();
 
-            return await this._createPageForBrowser(id, browserController, pageOptions, proxyUrl);
+                return await this._createPageForBrowser(id, browserController, pageOptions, proxyUrl);
+            };
+
+            return callerContext ? timeoutAbortStorage.run(callerContext, work) : timeoutAbortStorage.exit(work);
         });
     }
 

--- a/packages/browser-pool/src/browser-pool.ts
+++ b/packages/browser-pool/src/browser-pool.ts
@@ -451,8 +451,9 @@ export class BrowserPool<
         // otherwise resumes queued callbacks in the previous task's
         // AsyncLocalStorage context, leaking aborted cancelTasks across unrelated
         // requests (https://github.com/apify/crawlee/issues/3670). Mirrors the
-        // fix p-limit landed upstream in v5 (sindresorhus/p-limit#71); we can't
-        // bump to v5 directly because it's a breaking release.
+        // fix p-limit landed upstream in v5 (sindresorhus/p-limit#71); v5 is an
+        // ESM-only rewrite, so we can't bump it in Crawlee v3.
+        // TODO(crawlee@v4): bump p-limit to v5 and drop this AsyncResource.bind wrapper.
         // Limiter is necessary - https://github.com/apify/crawlee/issues/1126
         return this.limiter(
             AsyncResource.bind(async () => {

--- a/test/browser-pool/browser-pool.test.ts
+++ b/test/browser-pool/browser-pool.test.ts
@@ -123,6 +123,38 @@ describe.each([
             expect(page.close).toBeDefined();
         });
 
+        // https://github.com/apify/crawlee/issues/3670
+        test('should not leak aborted cancelTask between concurrent newPage calls', async () => {
+            const previousTimeout = browserPool.operationTimeoutMillis;
+            browserPool.operationTimeoutMillis = 1;
+
+            // Each newPage call is wrapped in its own outer addTimeoutToPromise,
+            // matching how BasicCrawler wraps _runRequestHandler. Without the fix,
+            // queued limiter callbacks inherit the previous task's aborted
+            // cancelTask via AsyncLocalStorage propagation through p-limit, causing
+            // their first tryCancel() to throw InternalTimeoutError pre-emptively;
+            // that error then gets silently swallowed by the outer wrap.
+            const results = await Promise.allSettled(
+                Array.from({ length: 5 }, () =>
+                    addTimeoutToPromise(async () => browserPool.newPage(), 60_000, 'outer timed out'),
+                ),
+            );
+
+            browserPool.operationTimeoutMillis = previousTimeout;
+            browserPool.retireAllBrowsers();
+
+            // All calls must reject — none should silently resolve with undefined.
+            expect(results.every((r) => r.status === 'rejected')).toBe(true);
+
+            // Each rejection should reflect this call's own newPage timeout, not
+            // a leaked "canceled due to a timeout" from a sibling's aborted context.
+            for (const r of results) {
+                expect(r.status === 'rejected' && (r.reason as Error).message).toMatch(
+                    /browserController\.newPage\(\) (failed|timed out)/,
+                );
+            }
+        });
+
         // TODO: this test is very flaky in the CI
         test.skip('should allow early aborting in case of outer timeout', async () => {
             const timeout = browserPool.operationTimeoutMillis;

--- a/test/core/crawlers/playwright_crawler.test.ts
+++ b/test/core/crawlers/playwright_crawler.test.ts
@@ -141,6 +141,41 @@ describe('PlaywrightCrawler', () => {
         });
     });
 
+    // https://github.com/apify/crawlee/issues/3670
+    test('should not silently drop requests when BrowserPool.newPage() times out', async () => {
+        const success: string[] = [];
+        const failure: string[] = [];
+
+        const crawler = new PlaywrightCrawler({
+            maxRequestRetries: 0,
+            browserPoolOptions: {
+                operationTimeoutSecs: 0.001,
+            },
+            requestHandler: async ({ request }) => {
+                success.push(request.url);
+            },
+            failedRequestHandler: async ({ request }) => {
+                failure.push(request.url);
+            },
+        });
+
+        const urls = [
+            `http://${HOSTNAME}:${port}/?q=1`,
+            `http://${HOSTNAME}:${port}/?q=2`,
+            `http://${HOSTNAME}:${port}/?q=3`,
+            `http://${HOSTNAME}:${port}/?q=4`,
+            `http://${HOSTNAME}:${port}/?q=5`,
+        ];
+
+        const stats = await crawler.run(urls);
+
+        // Every request must be accounted for by either requestHandler or failedRequestHandler.
+        expect(success.length + failure.length).toBe(urls.length);
+        // With operationTimeoutSecs=0.001, no request can actually succeed, so every one must fail.
+        expect(stats.requestsFinished).toBe(0);
+        expect(stats.requestsFailed).toBe(urls.length);
+    });
+
     test('should override goto timeout with navigationTimeoutSecs', async () => {
         const timeoutSecs = 10;
         let options: PlaywrightGotoOptions;


### PR DESCRIPTION
`BrowserPool.newPage()` serializes calls through `pLimit(1)`. `p-limit` resumes queued callbacks in the previous task's AsyncLocalStorage context, so a queued `newPage` call can inherit a sibling's aborted `cancelTask` and its
first `tryCancel()` throws `InternalTimeoutError` pre-emptively.

This fix explicitly passes the correct `AsyncLocalStorage` context into the `pLimit` arrow function to ensure task isolation.

Closes #3670
