### PR TITLE
chore: cache Playwright browsers and add install timeout in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,9 +71,19 @@ jobs:
                         turbo-${{ github.job }}-${{ github.ref_name }}-
 
             -   name: Install Dependencies
-                run: |
-                    yarn
-                    yarn playwright install --with-deps
+                run: yarn
+
+            -   name: Cache Playwright browsers
+                uses: actions/cache@v5
+                with:
+                    path: ~/.cache/ms-playwright
+                    key: playwright-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+                    restore-keys: |
+                        playwright-${{ runner.os }}-
+
+            -   name: Install Playwright browsers
+                timeout-minutes: 10
+                run: yarn playwright install --with-deps
 
             -   name: Build
                 run: yarn ci:build

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -59,9 +59,21 @@ jobs:
                         turbo-${{ github.job }}-${{ matrix.node-version }}-${{ github.ref_name }}-
 
             -   name: Install Dependencies
-                run: |
-                    yarn
-                    yarn playwright install --with-deps
+                run: yarn
+                env:
+                    YARN_IGNORE_NODE: 1
+
+            -   name: Cache Playwright browsers
+                uses: actions/cache@v5
+                with:
+                    path: ~/.cache/ms-playwright
+                    key: playwright-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+                    restore-keys: |
+                        playwright-${{ runner.os }}-
+
+            -   name: Install Playwright browsers
+                timeout-minutes: 10
+                run: yarn playwright install --with-deps
                 env:
                     YARN_IGNORE_NODE: 1
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -66,8 +66,18 @@ jobs:
             -   name: Install Dependencies
                 run: yarn
 
+            -   name: Cache Playwright browsers
+                if: (matrix.storage != 'PLATFORM')
+                uses: actions/cache@v5
+                with:
+                    path: ~/.cache/ms-playwright
+                    key: playwright-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+                    restore-keys: |
+                        playwright-${{ runner.os }}-
+
             -   name: Install Playwright Dependencies
                 if: (matrix.storage != 'PLATFORM')
+                timeout-minutes: 10
                 run: yarn playwright install --with-deps
 
             -   name: Build


### PR DESCRIPTION
`playwright install --with-deps` re-downloaded all browsers from `cdn.playwright.dev` on every CI run, with no browser cache and no timeout. When the CDN stalls, the step hangs until the 6h job limit instead of failing fast — which is why many PRs get stuck on `Install Playwright browsers` simultaneously (it's CDN-driven, not PR-specific).

This caches `~/.cache/ms-playwright` keyed by the lockfile so warm runs skip the download entirely, and caps the install step at `timeout-minutes: 10` so a stalled download fails fast and can be retried. Applied to `test-ci.yml`, `release.yml`, and `test-e2e.yml`. Browser set is unchanged (still installs all browsers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)