### PR TITLE
chore: bump impit to 0.14.1 (drops broken preinstall)

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -8,6 +8,7 @@ npmPreapprovedPackages:
     - "apify-client"
     - "apify"
     - "crawlee"
+    - "camoufox-js"
     - "got-scraping"
     - "impit"
     - "impit-*"

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -9,3 +9,5 @@ npmPreapprovedPackages:
     - "apify"
     - "crawlee"
     - "got-scraping"
+    - "impit"
+    - "impit-*"

--- a/packages/impit-client/package.json
+++ b/packages/impit-client/package.json
@@ -60,7 +60,7 @@
     },
     "dependencies": {
         "@apify/datastructures": "^2.0.3",
-        "impit": "^0.14.0",
+        "impit": "^0.14.1",
         "tough-cookie": "^6.0.0"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -991,7 +991,7 @@ __metadata:
   dependencies:
     "@apify/datastructures": "npm:^2.0.3"
     "@crawlee/core": "npm:^3.16.0"
-    impit: "npm:^0.14.0"
+    impit: "npm:^0.14.1"
     tough-cookie: "npm:^6.0.0"
   peerDependencies:
     "@crawlee/core": ^3.12.1
@@ -8394,9 +8394,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"impit-darwin-arm64@npm:0.14.0":
-  version: 0.14.0
-  resolution: "impit-darwin-arm64@npm:0.14.0"
+"impit-darwin-arm64@npm:0.14.1":
+  version: 0.14.1
+  resolution: "impit-darwin-arm64@npm:0.14.1"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -8408,9 +8408,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"impit-darwin-x64@npm:0.14.0":
-  version: 0.14.0
-  resolution: "impit-darwin-x64@npm:0.14.0"
+"impit-darwin-x64@npm:0.14.1":
+  version: 0.14.1
+  resolution: "impit-darwin-x64@npm:0.14.1"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -8422,9 +8422,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"impit-linux-arm64-gnu@npm:0.14.0":
-  version: 0.14.0
-  resolution: "impit-linux-arm64-gnu@npm:0.14.0"
+"impit-linux-arm64-gnu@npm:0.14.1":
+  version: 0.14.1
+  resolution: "impit-linux-arm64-gnu@npm:0.14.1"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
@@ -8436,9 +8436,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"impit-linux-arm64-musl@npm:0.14.0":
-  version: 0.14.0
-  resolution: "impit-linux-arm64-musl@npm:0.14.0"
+"impit-linux-arm64-musl@npm:0.14.1":
+  version: 0.14.1
+  resolution: "impit-linux-arm64-musl@npm:0.14.1"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
@@ -8450,9 +8450,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"impit-linux-x64-gnu@npm:0.14.0":
-  version: 0.14.0
-  resolution: "impit-linux-x64-gnu@npm:0.14.0"
+"impit-linux-x64-gnu@npm:0.14.1":
+  version: 0.14.1
+  resolution: "impit-linux-x64-gnu@npm:0.14.1"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
@@ -8464,9 +8464,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"impit-linux-x64-musl@npm:0.14.0":
-  version: 0.14.0
-  resolution: "impit-linux-x64-musl@npm:0.14.0"
+"impit-linux-x64-musl@npm:0.14.1":
+  version: 0.14.1
+  resolution: "impit-linux-x64-musl@npm:0.14.1"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
@@ -8478,9 +8478,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"impit-win32-arm64-msvc@npm:0.14.0":
-  version: 0.14.0
-  resolution: "impit-win32-arm64-msvc@npm:0.14.0"
+"impit-win32-arm64-msvc@npm:0.14.1":
+  version: 0.14.1
+  resolution: "impit-win32-arm64-msvc@npm:0.14.1"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -8492,9 +8492,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"impit-win32-x64-msvc@npm:0.14.0":
-  version: 0.14.0
-  resolution: "impit-win32-x64-msvc@npm:0.14.0"
+"impit-win32-x64-msvc@npm:0.14.1":
+  version: 0.14.1
+  resolution: "impit-win32-x64-msvc@npm:0.14.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -8532,18 +8532,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"impit@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "impit@npm:0.14.0"
+"impit@npm:^0.14.1":
+  version: 0.14.1
+  resolution: "impit@npm:0.14.1"
   dependencies:
-    impit-darwin-arm64: "npm:0.14.0"
-    impit-darwin-x64: "npm:0.14.0"
-    impit-linux-arm64-gnu: "npm:0.14.0"
-    impit-linux-arm64-musl: "npm:0.14.0"
-    impit-linux-x64-gnu: "npm:0.14.0"
-    impit-linux-x64-musl: "npm:0.14.0"
-    impit-win32-arm64-msvc: "npm:0.14.0"
-    impit-win32-x64-msvc: "npm:0.14.0"
+    impit-darwin-arm64: "npm:0.14.1"
+    impit-darwin-x64: "npm:0.14.1"
+    impit-linux-arm64-gnu: "npm:0.14.1"
+    impit-linux-arm64-musl: "npm:0.14.1"
+    impit-linux-x64-gnu: "npm:0.14.1"
+    impit-linux-x64-musl: "npm:0.14.1"
+    impit-win32-arm64-msvc: "npm:0.14.1"
+    impit-win32-x64-msvc: "npm:0.14.1"
   dependenciesMeta:
     impit-darwin-arm64:
       optional: true
@@ -8561,7 +8561,7 @@ __metadata:
       optional: true
     impit-win32-x64-msvc:
       optional: true
-  checksum: 10c0/49ffe30377cc3e3859e0520613ec9163973b577ba540366544512a2d9b6316d9695a7159f28b943fdd05ac76b0c26051fa73235e3571e3ff8cca6baa3db8a0ca
+  checksum: 10c0/5f99d491239bbad0bd2e92508a6e46721861c69a95acdd25501fd04d23d378a385c65e654ec239564c97765633e35f3dafbb5001e6178dd9a79477dde7b93d90
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
impit 0.14.1 removes the `preinstall: npx only-allow pnpm` that shipped in the published package and intermittently broke `yarn install` in CI (apify/impit#464).

impit + its platform binaries (`impit-*`) are added to `npmPreapprovedPackages` so the freshly-published 0.14.1 isn't held back by the 24h `npmMinimalAgeGate` — consistent with the other first-party packages (`apify`, `crawlee`, `got-scraping`) already on that list. camoufox-js's impit `0.13.1` is untouched (it has no preinstall).