### PR TITLE
chore: pin Node.JS `24.15.0` in CI for `v4`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
             -   name: Use Node.js 24
                 uses: actions/setup-node@v6
                 with:
-                    node-version: 24
+                    node-version: '24.15.0'
                     package-manager-cache: false
 
             -   uses: apify/workflows/pnpm-install@main

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -46,7 +46,7 @@ jobs:
             - name: Use Node.js 24
               uses: actions/setup-node@v6
               with:
-                  node-version: 24
+                  node-version: '24.15.0'
                   package-manager-cache: false
 
             - name: Turbo cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
             matrix:
                 # We don't test on Windows as the tests are flaky
                 os: [ ubuntu-22.04 ]
-                node-version: [ 22, 24 ]
+                node-version: [ 22, '24.15.0' ]
 
         runs-on: ${{ matrix.os }}
 
@@ -87,7 +87,7 @@ jobs:
             -   name: Use Node.js 24
                 uses: actions/setup-node@v6
                 with:
-                    node-version: 24
+                    node-version: '24.15.0'
                     package-manager-cache: false
 
             -   name: Turbo cache
@@ -171,7 +171,7 @@ jobs:
             -   name: Use Node.js 24
                 uses: actions/setup-node@v6
                 with:
-                    node-version: 24
+                    node-version: '24.15.0'
                     package-manager-cache: false
 
             -   name: Install jq

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -25,7 +25,7 @@ jobs:
                 # tests on windows are extremely unstable
                 # os: [ ubuntu-22.04, windows-2019 ]
                 os: [ ubuntu-22.04 ]
-                node-version: [ 22, 24 ]
+                node-version: [ 22, '24.15.0' ]
 
         steps:
             -   name: Checkout repository
@@ -78,7 +78,7 @@ jobs:
             -   name: Use Node.js 24
                 uses: actions/setup-node@v6
                 with:
-                    node-version: 24
+                    node-version: '24.15.0'
                     package-manager-cache: false
 
             -   name: Turbo cache
@@ -111,7 +111,7 @@ jobs:
             -   name: Use Node.js 24
                 uses: actions/setup-node@v6
                 with:
-                    node-version: 24
+                    node-version: '24.15.0'
                     package-manager-cache: false
 
             -   name: Turbo cache
@@ -147,7 +147,7 @@ jobs:
             -   name: Use Node.js 24
                 uses: actions/setup-node@v6
                 with:
-                    node-version: 24
+                    node-version: '24.15.0'
                     package-manager-cache: false
 
             -   name: Turbo cache

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -27,7 +27,7 @@ jobs:
             -   name: Use Node.js 24
                 uses: actions/setup-node@v6
                 with:
-                    node-version: 24
+                    node-version: '24.15.0'
                     package-manager-cache: false
 
             -   name: Turbo cache


### PR DESCRIPTION
Pins the Node.JS version in CI to avoid installation hang-ups (caused by a change in `24.16.0`, causing the `extract-zip` package to freeze).

Trying to pin other dependencies (`puppeteer`, `playwright`) 

See also https://github.com/nodejs/node/issues/63495 , https://github.com/puppeteer/puppeteer/issues/14957