### PR TITLE
chore: drop Node 18 tests in CI release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
             matrix:
                 # We don't test on Windows as the tests are flaky
                 os: [ ubuntu-22.04 ]
-                node-version: [ 18, 20, 22, 24 ]
+                node-version: [ 20, 22, 24 ]
 
         runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Drops Node 18 CI tests from the `release.yml` workflow. Related to https://github.com/apify/crawlee/pull/3679
