### PR TITLE
fix(core): respect Retry-After header on 429 without retiring session

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -41,6 +41,7 @@ import {
     mergeCookies,
     NonRetryableError,
     purgeDefaultStorages,
+    RateLimitError,
     RequestListAdapter,
     RequestManagerTandem,
     RequestProvider,
@@ -1834,6 +1835,13 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
 
             if (error instanceof SessionError) {
                 await this._rotateSession(crawlingContext);
+            } else if (error instanceof RateLimitError) {
+                const domain = getDomain(request.url);
+                // We default to 1 minute if retryAfterMs is not provided
+                const cooldown = error.retryAfterMs ?? 60000;
+                if (domain) {
+                    this.domainAccessedTime.set(domain, Date.now() + cooldown - this.sameDomainDelayMillis);
+                }
             }
 
             if (!request.noRetry) {
@@ -1932,7 +1940,8 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
         }
 
         // User requested retry (we ignore retry count here as its explicitly told by the user to retry)
-        if (error instanceof RetryRequestError) {
+        // Rate limit errors are also explicitly retried (with cooldown).
+        if (error instanceof RetryRequestError || error instanceof RateLimitError) {
             return true;
         }
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -35,3 +35,15 @@ export class SessionError extends RetryRequestError {
         super(`Detected a session error, rotating session... ${message ? `\n${message}` : ''}`);
     }
 }
+
+/**
+ * Errors of `RateLimitError` type will trigger a cooldown before the request is retried.
+ */
+export class RateLimitError extends Error {
+    constructor(
+        message?: string,
+        public readonly retryAfterMs?: number,
+    ) {
+        super(message ?? 'Rate limit exceeded');
+    }
+}

--- a/packages/core/src/session_pool/consts.ts
+++ b/packages/core/src/session_pool/consts.ts
@@ -1,3 +1,3 @@
-export const BLOCKED_STATUS_CODES = [401, 403, 429];
+export const BLOCKED_STATUS_CODES = [401, 403];
 export const PERSIST_STATE_KEY = 'SDK_SESSION_POOL_STATE';
 export const MAX_POOL_SIZE = 1000;

--- a/packages/core/src/session_pool/session.ts
+++ b/packages/core/src/session_pool/session.ts
@@ -296,10 +296,10 @@ export class Session {
     }
 
     /**
-     * With certain status codes: `401`, `403` or `429` we can be certain
-     * that the target website is blocking us. This function helps to do this conveniently
-     * by retiring the session when such code is received. Optionally the default status
-     * codes can be extended in the second parameter.
+     * Retires session based on status code.
+     * With certain status codes: `401` or `403` we can be certain
+     * that the IP is blocked.
+     *
      * @param statusCode HTTP status code.
      * @returns Whether the session was retired.
      */

--- a/packages/core/src/session_pool/session_pool.ts
+++ b/packages/core/src/session_pool/session_pool.ts
@@ -56,7 +56,7 @@ export interface SessionPoolOptions {
     /**
      * Specifies which response status codes are considered as blocked.
      * Session connected to such request will be marked as retired.
-     * @default [401, 403, 429]
+     * @default [401, 403]
      */
     blockedStatusCodes?: number[];
 

--- a/packages/http-crawler/src/internals/http-crawler.ts
+++ b/packages/http-crawler/src/internals/http-crawler.ts
@@ -26,6 +26,8 @@ import {
     processHttpRequestOptions,
     RequestState,
     Router,
+    NonRetryableError,
+    RateLimitError,
     SessionError,
     validators,
 } from '@crawlee/basic';
@@ -516,6 +518,23 @@ export class HttpCrawler<
         if (!request.skipNavigation) {
             await this._handleNavigation(crawlingContext);
             tryCancel();
+
+            if (crawlingContext.response?.statusCode === 429) {
+                const retryAfterHeader = crawlingContext.response.headers['retry-after'];
+                let retryAfterMs: number | undefined = undefined;
+                if (retryAfterHeader) {
+                    const retryAfterStr = String(retryAfterHeader);
+                    if (/^\d+$/.test(retryAfterStr)) {
+                        retryAfterMs = parseInt(retryAfterStr, 10) * 1000;
+                    } else {
+                        const date = Date.parse(retryAfterStr);
+                        if (!Number.isNaN(date)) {
+                            retryAfterMs = Math.max(0, date - Date.now());
+                        }
+                    }
+                }
+                throw new RateLimitError(`Rate limit exceeded (HTTP 429)`, retryAfterMs);
+            }
 
             const parsed = await this._parseResponse(request, crawlingContext.response!, crawlingContext);
             const response = parsed.response!;

--- a/test/core/crawlers/http_crawler.test.ts
+++ b/test/core/crawlers/http_crawler.test.ts
@@ -61,6 +61,21 @@ router.set('/403-with-octet-stream', (req, res) => {
     res.end();
 });
 
+let rateLimitHit = 0;
+router.set('/429', (req, res) => {
+    if (rateLimitHit === 0) {
+        rateLimitHit++;
+        res.setHeader('content-type', 'text/html');
+        res.setHeader('retry-after', '1');
+        res.statusCode = 429;
+        res.end();
+    } else {
+        res.setHeader('content-type', 'text/html');
+        res.statusCode = 200;
+        res.end('ok');
+    }
+});
+
 let server: http.Server;
 let url: string;
 
@@ -89,6 +104,7 @@ afterAll(async () => {
 const localStorageEmulator = new MemoryStorageEmulator();
 
 beforeEach(async () => {
+    rateLimitHit = 0;
     await localStorageEmulator.init();
 });
 
@@ -476,5 +492,22 @@ describe.each(
 
         expect(results[0].includes('Schmexample Domain')).toBeTruthy();
         expect(results[1].includes('Hello')).toBeTruthy();
+    });
+    test('should respect 429 RateLimitError and retry', async () => {
+        const results: string[] = [];
+        const crawler = new HttpCrawler({
+            httpClient,
+            maxRequestRetries: 1,
+            requestHandler: async ({ body }) => {
+                results.push(body.toString());
+            },
+        });
+
+        const start = Date.now();
+        await crawler.run([`${url}/429`]);
+        const duration = Date.now() - start;
+
+        expect(results).toStrictEqual(['ok']);
+        expect(duration).toBeGreaterThanOrEqual(800); // Because of retry-after: 1, allow some tolerance
     });
 });


### PR DESCRIPTION
**Motivation:**
Currently, when a crawler encounters an HTTP `429 Too Many Requests` status code, the `SessionPool` interprets it as an IP block and permanently retires the session. This leads to premature session churn and IP exhaustion, completely ignoring the HTTP standard `Retry-After` header.

**Changes:**
1. **Removed `429` from `BLOCKED_STATUS_CODES`** in `session_pool/consts.ts` so the session isn't automatically retired.
2. **Introduced `RateLimitError`** in `errors.ts` to capture the `retryAfterMs` duration.
3. **Intercepted 429s in `http-crawler`**, parsing the `Retry-After` header (both seconds and date strings) to throw the new `RateLimitError`.
4. **Added domain cooldown in `basic-crawler`**: Caught `RateLimitError` inside `_requestFunctionErrorHandler` to automatically update `domainAccessedTime`. This elegantly delays the next request to that domain by the specified cooldown without burning the session.

**Testing:**
- Added a new unit test in `http_crawler.test.ts` (`should respect 429 RateLimitError and retry`). It creates a mock endpoint that returns a 429 with `Retry-After: 1` on the first hit, and 200 OK on the second. The test verifies that the crawler waits for the cooldown (~1000ms) and successfully retries.
- Verified that all other tests (`vitest run test/core/crawlers/http_crawler.test.ts`) are still passing successfully.


Closes #3623 