### PR TITLE
perf(core): improve `RequestList` initialization speed on large arrays

### DIFF
--- a/packages/core/src/storages/request_list.ts
+++ b/packages/core/src/storages/request_list.ts
@@ -488,9 +488,12 @@ export class RequestList implements IRequestList {
                 const sourcesFromFunction = await this.sourcesFunction();
                 const sourcesFromFunctionCount = sourcesFromFunction.length;
                 for (let i = 0; i < sourcesFromFunctionCount; i++) {
-                    const source = sourcesFromFunction.shift();
-                    this._addRequest(source!);
+                    const source = sourcesFromFunction[i];
+                    delete sourcesFromFunction[i];
+                    this._addRequest(source);
                 }
+
+                sourcesFromFunction.length = 0;
             } catch (e) {
                 const err = e as Error;
                 throw new Error(`Loading requests with sourcesFunction failed.\nCause: ${err.message}`);

--- a/test/core/request_list.test.ts
+++ b/test/core/request_list.test.ts
@@ -146,25 +146,6 @@ describe('RequestList', () => {
         expect(await newList.isEmpty()).toBe(true);
     });
 
-    test('should load sourcesFunction results without shifting the returned array', async () => {
-        const urls = ['https://example.com/1', 'https://example.com/2', 'https://example.com/3'];
-        const sourcesFromFunction = [...urls];
-        const shiftSpy = vitest.spyOn(sourcesFromFunction, 'shift');
-
-        const requestList = await RequestList.open({
-            sourcesFunction: async () => sourcesFromFunction,
-        });
-
-        expect(shiftSpy).not.toBeCalled();
-        expect(sourcesFromFunction).toHaveLength(0);
-        expect(requestList.length()).toBe(urls.length);
-
-        for (const url of urls) {
-            expect(await requestList.fetchNextRequest()).toMatchObject({ url });
-        }
-        expect(await requestList.fetchNextRequest()).toBe(null);
-    });
-
     test('`RequestList` is `for .. await` iterable', async () => {
         const sources = [
             'https://example.com/1',

--- a/test/core/request_list.test.ts
+++ b/test/core/request_list.test.ts
@@ -146,6 +146,25 @@ describe('RequestList', () => {
         expect(await newList.isEmpty()).toBe(true);
     });
 
+    test('should load sourcesFunction results without shifting the returned array', async () => {
+        const urls = ['https://example.com/1', 'https://example.com/2', 'https://example.com/3'];
+        const sourcesFromFunction = [...urls];
+        const shiftSpy = vitest.spyOn(sourcesFromFunction, 'shift');
+
+        const requestList = await RequestList.open({
+            sourcesFunction: async () => sourcesFromFunction,
+        });
+
+        expect(shiftSpy).not.toBeCalled();
+        expect(sourcesFromFunction).toHaveLength(0);
+        expect(requestList.length()).toBe(urls.length);
+
+        for (const url of urls) {
+            expect(await requestList.fetchNextRequest()).toMatchObject({ url });
+        }
+        expect(await requestList.fetchNextRequest()).toBe(null);
+    });
+
     test('`RequestList` is `for .. await` iterable', async () => {
         const sources = [
             'https://example.com/1',


### PR DESCRIPTION
Summary:
- Replace `RequestList` `sourcesFunction` result consumption with index iteration instead of repeated `shift()` calls.
- Clear processed array slots while preserving request order and add a regression test.

Fixes #3750.
