### PR TITLE
fix(cli): correct module entrypoint

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,11 +9,11 @@
         "crawlee": "./src/index.ts"
     },
     "main": "./dist/index.js",
-    "module": "./dist/index.mjs",
+    "module": "./dist/index.js",
     "types": "./dist/index.d.ts",
     "exports": {
         ".": {
-            "import": "./dist/index.mjs",
+            "import": "./dist/index.js",
             "require": "./dist/index.js",
             "types": "./dist/index.d.ts"
         },


### PR DESCRIPTION
### Description

`@crawlee/cli` currently advertises `./dist/index.mjs` as the ESM/module entry, but the TypeScript build emits `dist/index.js` and `dist/index.d.ts` only. During publish, `scripts/copy.ts` rewrites `dist/` out of the copied manifest, so this becomes a published `./index.mjs` pointer that is not present in the npm tarball.

This PR points `module` and the `exports["."].import` condition at `./dist/index.js`, matching the emitted file and the existing `main`/`require` entry.

### Verification

- `npm pack @crawlee/cli@3.17.0 --json`
- confirmed the published tarball contains `package/index.js` and `package/index.d.ts`
- confirmed the published tarball does not contain `package/index.mjs`, despite current `module`/`exports.import` pointing there after publish rewrite
- node assertion that `packages/cli/package.json` now has `module` and `exports["."].import` set to `./dist/index.js`
- `git diff --check`