### PR TITLE
refactor!: Centralize KVS value semantics in @crawlee/core

### DIFF
--- a/docs/upgrading/upgrading_v4.md
+++ b/docs/upgrading/upgrading_v4.md
@@ -619,6 +619,10 @@ The high-level storage classes (`Dataset`, `KeyValueStore`, `RequestQueue`) now 
 
 `timeoutSecs` and `doNotRetryTimeouts` were removed from `RecordOptions` (used by `KeyValueStore.setValue`). Only `contentType` remains.
 
+### `maybeStringify` is removed
+
+The `maybeStringify` helper exported from `@crawlee/core` has been removed. Value (de)serialization now lives entirely in the `KeyValueStore` frontend: writing serializes the value (and infers its content type), reading parses it back, and the storage client is a plain byte transport. If you imported `maybeStringify` directly, use the `serializeValue` / `parseValue` functions exported from `@crawlee/core` instead.
+
 ### `KeyValueStoreIteratorOptions` simplified
 
 `exclusiveStartKey` and `collection` were removed. Only `prefix` remains.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,6 +59,7 @@
         "@crawlee/utils": "workspace:*",
         "@sapphire/async-queue": "^1.5.5",
         "@vladfrangu/async_event_emitter": "^2.4.6",
+        "content-type": "^1.0.5",
         "csv-stringify": "^6.5.2",
         "json5": "^2.2.3",
         "minimatch": "^10.0.1",

--- a/packages/core/src/storages/index.ts
+++ b/packages/core/src/storages/index.ts
@@ -1,5 +1,6 @@
 export * from './dataset.js';
 export * from './key_value_store.js';
+export * from './key_value_store_codec.js';
 export * from './request_list.js';
 export type * from './request_loader.js';
 export type * from './request_manager.js';

--- a/packages/core/src/storages/key_value_store.ts
+++ b/packages/core/src/storages/key_value_store.ts
@@ -199,7 +199,7 @@ export class KeyValueStore {
         ow(key, ow.string.nonEmpty);
         const record = await this.client.getValue(key);
 
-        const parsed = record ? parseValue(record.value, record.contentType ?? '') : undefined;
+        const parsed = record ? parseValue(record.value, record.contentType ?? null) : undefined;
 
         return (parsed as T) ?? defaultValue ?? null;
     }
@@ -230,7 +230,7 @@ export class KeyValueStore {
      *   Unique key of the record. It can be at most 256 characters long and only consist
      *   of the following characters: `a`-`z`, `A`-`Z`, `0`-`9` and `!-_.'()`
      */
-    async getRecord(key: string): Promise<{ value: Buffer; contentType: string } | null> {
+    async getRecord(key: string): Promise<{ value: Buffer; contentType: string | null } | null> {
         checkStorageAccess();
 
         ow(key, ow.string.nonEmpty);
@@ -239,7 +239,7 @@ export class KeyValueStore {
 
         return {
             value: record.value as Buffer,
-            contentType: record.contentType ?? '',
+            contentType: record.contentType ?? null,
         };
     }
 
@@ -309,7 +309,7 @@ export class KeyValueStore {
             const results: T[] = [];
             for (const item of page) {
                 const record = await this.client.getValue(item.key);
-                if (record) results.push(mapRecord(item.key, parseValue(record.value, record.contentType ?? '')));
+                if (record) results.push(mapRecord(item.key, parseValue(record.value, record.contentType ?? null)));
             }
             yield results;
         }

--- a/packages/core/src/storages/key_value_store.ts
+++ b/packages/core/src/storages/key_value_store.ts
@@ -200,11 +200,8 @@ export class KeyValueStore {
         ow(key, ow.string.nonEmpty);
         const record = await this.client.getValue(key);
 
-        // Storage clients are byte transports: the read path yields bytes (or an already-decoded
-        // string from the fs no-extension fallback), never a stream. Narrow to what parseValue accepts.
-        const parsed = record
-            ? parseValue(record.value as Buffer | ArrayBuffer | string, record.contentType ?? null)
-            : undefined;
+        // Storage clients are byte transports — the value is raw bytes; the frontend parses it here.
+        const parsed = record ? parseValue(record.value, record.contentType ?? null) : undefined;
 
         return (parsed as T) ?? defaultValue ?? null;
     }
@@ -242,10 +239,8 @@ export class KeyValueStore {
         const record = await this.client.getValue(key);
         if (!record) return null;
 
-        // Storage clients are byte transports, so the read path yields raw bytes. The record type is
-        // a write/read union, so narrow to the bytes the read contract actually guarantees.
         return {
-            value: record.value as Buffer | ArrayBuffer,
+            value: record.value,
             contentType: record.contentType ?? null,
         };
     }
@@ -317,11 +312,7 @@ export class KeyValueStore {
             for (const item of page) {
                 const record = await this.client.getValue(item.key);
                 if (record) {
-                    // Read path yields bytes or a decoded string, never a stream; narrow accordingly.
-                    const parsed = parseValue(
-                        record.value as Buffer | ArrayBuffer | string,
-                        record.contentType ?? null,
-                    );
+                    const parsed = parseValue(record.value, record.contentType ?? null);
                     results.push(mapRecord(item.key, parsed));
                 }
             }

--- a/packages/core/src/storages/key_value_store.ts
+++ b/packages/core/src/storages/key_value_store.ts
@@ -6,12 +6,12 @@ import JSON5 from 'json5';
 import ow, { ArgumentError } from 'ow';
 
 import { KEY_VALUE_STORE_KEY_REGEX } from '@apify/consts';
-import { jsonStringifyExtended } from '@apify/utilities';
 
 import { Configuration } from '../configuration.js';
 import { serviceLocator } from '../service_locator.js';
 import type { Awaitable } from '../typedefs.js';
 import { checkStorageAccess } from './access_checking.js';
+import { parseValue, serializeValue } from './key_value_store_codec.js';
 import type { StorageIdentifier } from './storage_instance_manager.js';
 import type { StorageOpenOptions } from './utils.js';
 import { resolveStorageIdentifier } from './storage_instance_manager.js';
@@ -19,39 +19,6 @@ import { createDualIterable, purgeDefaultStorages } from './utils.js';
 
 /** @internal */
 const KVS_KEYS_DEFAULT_LIMIT = 1000;
-
-/**
- * Helper function to possibly stringify value if options.contentType is not set.
- *
- * @ignore
- */
-export const maybeStringify = <T>(value: T, options: { contentType?: string }) => {
-    // If contentType is missing, value will be stringified to JSON
-    if (options.contentType === null || options.contentType === undefined) {
-        options.contentType = 'application/json; charset=utf-8';
-
-        try {
-            // Format JSON to simplify debugging, the overheads with compression is negligible
-            value = jsonStringifyExtended(value as Dictionary, null, 2) as unknown as T;
-        } catch (e) {
-            const error = e as Error;
-            // Give more meaningful error message
-            if (error.message?.includes('Invalid string length')) {
-                error.message = 'Object is too large';
-            }
-            throw new Error(`The "value" parameter cannot be stringified to JSON: ${error.message}`);
-        }
-
-        if (value === undefined) {
-            throw new Error(
-                'The "value" parameter was stringified to JSON and returned undefined. ' +
-                    "Make sure you're not trying to stringify an undefined value.",
-            );
-        }
-    }
-
-    return value;
-};
 
 /**
  * The `KeyValueStore` class represents a key-value store, a simple data storage that is used
@@ -232,7 +199,9 @@ export class KeyValueStore {
         ow(key, ow.string.nonEmpty);
         const record = await this.client.getValue(key);
 
-        return (record?.value as T) ?? defaultValue ?? null;
+        const parsed = record ? parseValue(record.value, record.contentType ?? '') : undefined;
+
+        return (parsed as T) ?? defaultValue ?? null;
     }
 
     /**
@@ -301,7 +270,7 @@ export class KeyValueStore {
             const results: T[] = [];
             for (const item of page) {
                 const record = await this.client.getValue(item.key);
-                if (record) results.push(mapRecord(item.key, record.value));
+                if (record) results.push(mapRecord(item.key, parseValue(record.value, record.contentType ?? '')));
             }
             yield results;
         }
@@ -417,12 +386,12 @@ export class KeyValueStore {
         // In this case delete the record.
         if (value === null) return this.client.deleteValue(key);
 
-        value = maybeStringify(value, optionsCopy);
+        const serialized = serializeValue(value, optionsCopy.contentType);
 
         return this.client.setValue({
             key,
-            value,
-            contentType: optionsCopy.contentType,
+            value: serialized.value,
+            contentType: serialized.contentType,
         });
     }
 

--- a/packages/core/src/storages/key_value_store.ts
+++ b/packages/core/src/storages/key_value_store.ts
@@ -205,6 +205,45 @@ export class KeyValueStore {
     }
 
     /**
+     * Reads a record from the key-value store without parsing the value.
+     *
+     * Use this when you need the raw bytes and the content type — for example, to run your own
+     * parser (`simdjson`, a custom XML library, etc.) or to forward the bytes verbatim.
+     *
+     * There is no symmetric `setRecord` method, because {@apilink KeyValueStore.setValue} already
+     * passes a `Buffer` (or `string` / `Stream`) through unchanged when an explicit `contentType`
+     * is provided. To write pre-serialized bytes, call
+     * `setValue(key, buffer, { contentType: 'application/json; charset=utf-8' })`.
+     *
+     * Returns `null` if the record does not exist.
+     *
+     * **Example usage:**
+     * ```javascript
+     * const store = await KeyValueStore.open();
+     * const record = await store.getRecord('huge.json');
+     * if (record) {
+     *     const data = simdjson.parse(record.value);
+     * }
+     * ```
+     *
+     * @param key
+     *   Unique key of the record. It can be at most 256 characters long and only consist
+     *   of the following characters: `a`-`z`, `A`-`Z`, `0`-`9` and `!-_.'()`
+     */
+    async getRecord(key: string): Promise<{ value: Buffer; contentType: string } | null> {
+        checkStorageAccess();
+
+        ow(key, ow.string.nonEmpty);
+        const record = await this.client.getValue(key);
+        if (!record) return null;
+
+        return {
+            value: record.value as Buffer,
+            contentType: record.contentType ?? '',
+        };
+    }
+
+    /**
      * Tests whether a record with the given key exists in the key-value store without retrieving its value.
      *
      * @param key The queried record key.

--- a/packages/core/src/storages/key_value_store.ts
+++ b/packages/core/src/storages/key_value_store.ts
@@ -200,7 +200,11 @@ export class KeyValueStore {
         ow(key, ow.string.nonEmpty);
         const record = await this.client.getValue(key);
 
-        const parsed = record ? parseValue(record.value, record.contentType ?? null) : undefined;
+        // Storage clients are byte transports: the read path yields bytes (or an already-decoded
+        // string from the fs no-extension fallback), never a stream. Narrow to what parseValue accepts.
+        const parsed = record
+            ? parseValue(record.value as Buffer | ArrayBuffer | string, record.contentType ?? null)
+            : undefined;
 
         return (parsed as T) ?? defaultValue ?? null;
     }
@@ -312,7 +316,14 @@ export class KeyValueStore {
             const results: T[] = [];
             for (const item of page) {
                 const record = await this.client.getValue(item.key);
-                if (record) results.push(mapRecord(item.key, parseValue(record.value, record.contentType ?? null)));
+                if (record) {
+                    // Read path yields bytes or a decoded string, never a stream; narrow accordingly.
+                    const parsed = parseValue(
+                        record.value as Buffer | ArrayBuffer | string,
+                        record.contentType ?? null,
+                    );
+                    results.push(mapRecord(item.key, parsed));
+                }
             }
             yield results;
         }

--- a/packages/core/src/storages/key_value_store.ts
+++ b/packages/core/src/storages/key_value_store.ts
@@ -231,15 +231,17 @@ export class KeyValueStore {
      *   Unique key of the record. It can be at most 256 characters long and only consist
      *   of the following characters: `a`-`z`, `A`-`Z`, `0`-`9` and `!-_.'()`
      */
-    async getRecord(key: string): Promise<{ value: Buffer; contentType: string | null } | null> {
+    async getRecord(key: string): Promise<{ value: Buffer | ArrayBuffer; contentType: string | null } | null> {
         checkStorageAccess();
 
         ow(key, ow.string.nonEmpty);
         const record = await this.client.getValue(key);
         if (!record) return null;
 
+        // Storage clients are byte transports, so the read path yields raw bytes. The record type is
+        // a write/read union, so narrow to the bytes the read contract actually guarantees.
         return {
-            value: record.value as Buffer,
+            value: record.value as Buffer | ArrayBuffer,
             contentType: record.contentType ?? null,
         };
     }

--- a/packages/core/src/storages/key_value_store.ts
+++ b/packages/core/src/storages/key_value_store.ts
@@ -200,10 +200,14 @@ export class KeyValueStore {
         ow(key, ow.string.nonEmpty);
         const record = await this.client.getValue(key);
 
-        // Storage clients are byte transports — the value is raw bytes; the frontend parses it here.
-        const parsed = record ? parseValue(record.value, record.contentType ?? null) : undefined;
+        // A missing record falls back to the default; a record that parses to a falsy value (including
+        // a stored literal `null`) is returned verbatim, so callers can tell "stored null" from "absent".
+        if (!record) {
+            return defaultValue ?? null;
+        }
 
-        return (parsed as T) ?? defaultValue ?? null;
+        // Storage clients are byte transports — the value is raw bytes; the frontend parses it here.
+        return parseValue(record.value, record.contentType ?? null) as T;
     }
 
     /**
@@ -232,7 +236,7 @@ export class KeyValueStore {
      *   Unique key of the record. It can be at most 256 characters long and only consist
      *   of the following characters: `a`-`z`, `A`-`Z`, `0`-`9` and `!-_.'()`
      */
-    async getRecord(key: string): Promise<{ value: Buffer | ArrayBuffer; contentType: string | null } | null> {
+    async getRecord(key: string): Promise<KeyValueStoreRawRecord | null> {
         checkStorageAccess();
 
         ow(key, ow.string.nonEmpty);
@@ -753,6 +757,23 @@ export class KeyValueStore {
     }
 
     /**
+     * Reads a record from the default {@apilink KeyValueStore} associated with the current crawler run
+     * without parsing the value.
+     *
+     * This is just a convenient shortcut for {@apilink KeyValueStore.getRecord}. Returns `null` if the
+     * record does not exist.
+     *
+     * @param key
+     *   Unique key of the record. It can be at most 256 characters long and only consist
+     *   of the following characters: `a`-`z`, `A`-`Z`, `0`-`9` and `!-_.'()`
+     * @ignore
+     */
+    static async getRecord(key: string): Promise<KeyValueStoreRawRecord | null> {
+        const store = await this.open();
+        return store.getRecord(key);
+    }
+
+    /**
      * Tests whether a record with the given key exists in the default {@apilink KeyValueStore} associated with the current crawler run.
      * @param key The queried record key.
      * @returns `true` if the record exists, `false` if it does not.
@@ -870,6 +891,15 @@ export interface KeyValueStoreOptions {
     id: string;
     name?: string;
     client: KeyValueStoreClient;
+}
+
+/**
+ * A raw, unparsed key-value store record as returned by {@apilink KeyValueStore.getRecord}: the
+ * verbatim bytes plus the content type, with parsing left to the caller.
+ */
+export interface KeyValueStoreRawRecord {
+    value: Buffer | ArrayBuffer;
+    contentType: string | null;
 }
 
 export interface RecordOptions {

--- a/packages/core/src/storages/key_value_store.ts
+++ b/packages/core/src/storages/key_value_store.ts
@@ -16,6 +16,7 @@ import type { StorageIdentifier } from './storage_instance_manager.js';
 import type { StorageOpenOptions } from './utils.js';
 import { resolveStorageIdentifier } from './storage_instance_manager.js';
 import { createDualIterable, purgeDefaultStorages } from './utils.js';
+import { isBuffer, isStream } from '@crawlee/utils';
 
 /** @internal */
 const KVS_KEYS_DEFAULT_LIMIT = 1000;
@@ -383,15 +384,9 @@ export class KeyValueStore {
                 message: `The "key" argument "${key}" must be at most 256 characters long and only contain the following characters: a-zA-Z0-9!-_.'()`,
             })),
         );
-        if (
-            options.contentType &&
-            !(
-                ow.isValid(value, ow.any(ow.string, ow.uint8Array)) ||
-                (ow.isValid(value, ow.object) && typeof (value as Dictionary).pipe === 'function')
-            )
-        ) {
+        if (options.contentType && !(typeof value === 'string' || isBuffer(value) || isStream(value))) {
             throw new ArgumentError(
-                'The "value" parameter must be a String, Buffer or Stream when "options.contentType" is specified.',
+                'The "value" parameter must be a String, Buffer, ArrayBuffer, TypedArray, or Stream when "options.contentType" is specified.',
                 this.setValue,
             );
         }

--- a/packages/core/src/storages/key_value_store_codec.ts
+++ b/packages/core/src/storages/key_value_store_codec.ts
@@ -81,10 +81,10 @@ export function serializeValue(
  * Backend-independent — this is the canonical read path for the {@apilink KeyValueStore} frontend.
  */
 export function parseValue(
-    body: Buffer | ArrayBuffer,
+    body: Buffer | ArrayBuffer | string,
     contentTypeHeader: string | null,
 ): string | Buffer | ArrayBuffer | Record<string, unknown> {
-    // No content type at all → we have no basis for interpretation; hand back the raw bytes.
+    // No content type at all → we have no basis for interpretation; hand back the raw value.
     if (contentTypeHeader === null) return body;
 
     let contentType: string;
@@ -94,14 +94,16 @@ export function parseValue(
         contentType = result.type;
         charset = result.parameters.charset as BufferEncoding;
     } catch {
-        // Unparseable header → keep the original buffer rather than a mangled string.
+        // Unparseable header → keep the original value rather than a mangled string.
         return body;
     }
 
-    // If we can't successfully parse it, we return
-    // the original buffer rather than a mangled string.
+    // If we can't successfully interpret it, we return the original value rather than mangling it.
     if (!areDataStringifiable(contentType, charset)) return body;
-    const dataString = isomorphicBufferToString(body, charset);
+
+    // A backend may hand us an already-decoded string (e.g. the fs-storage no-extension fallback).
+    // Otherwise decode the raw bytes using the resolved charset.
+    const dataString = typeof body === 'string' ? body : isomorphicBufferToString(body, charset);
 
     return contentType === CONTENT_TYPE_JSON ? JSON5.parse(dataString) : dataString;
 }

--- a/packages/core/src/storages/key_value_store_codec.ts
+++ b/packages/core/src/storages/key_value_store_codec.ts
@@ -1,8 +1,56 @@
+import type { Dictionary } from '@crawlee/types';
 import contentTypeParser from 'content-type';
 import JSON5 from 'json5';
 
+import { jsonStringifyExtended } from '@apify/utilities';
+
 const CONTENT_TYPE_JSON = 'application/json';
 const STRINGIFIABLE_CONTENT_TYPE_RXS = [new RegExp(`^${CONTENT_TYPE_JSON}$`, 'i'), /^application\/.*xml$/i, /^text\//i];
+
+/**
+ * Canonical write path for key-value store records. When a content type is provided, the value is
+ * taken as-is; when it is absent, the value is serialized to JSON and the content type is set to
+ * `application/json; charset=utf-8`.
+ *
+ * Does NOT drain streams — that is storage mechanics and stays in the storage client.
+ *
+ * Backend-independent.
+ */
+export function serializeValue(
+    value: unknown,
+    contentType?: string,
+): { value: Buffer | string | NodeJS.ReadableStream; contentType: string } {
+    // When an explicit content type is provided, the value is taken as-is — it is the caller's
+    // responsibility to pass a String/Buffer/Stream (the frontend validates this). When no content
+    // type is provided, the value is serialized to JSON.
+    if (contentType !== null && contentType !== undefined) {
+        return { value: value as Buffer | string | NodeJS.ReadableStream, contentType };
+    }
+
+    const resolvedContentType = 'application/json; charset=utf-8';
+
+    let serialized: string;
+    try {
+        // Format JSON to simplify debugging, the overheads with compression is negligible
+        serialized = jsonStringifyExtended(value as Dictionary, null, 2);
+    } catch (e) {
+        const error = e as Error;
+        // Give more meaningful error message
+        if (error.message?.includes('Invalid string length')) {
+            error.message = 'Object is too large';
+        }
+        throw new Error(`The "value" parameter cannot be stringified to JSON: ${error.message}`);
+    }
+
+    if (serialized === undefined) {
+        throw new Error(
+            'The "value" parameter was stringified to JSON and returned undefined. ' +
+                "Make sure you're not trying to stringify an undefined value.",
+        );
+    }
+
+    return { value: serialized, contentType: resolvedContentType };
+}
 
 /**
  * Parses a Buffer or ArrayBuffer using the provided content type header.
@@ -13,8 +61,10 @@ const STRINGIFIABLE_CONTENT_TYPE_RXS = [new RegExp(`^${CONTENT_TYPE_JSON}$`, 'i'
  *
  * If the header includes a charset, the body will be stringified only
  * if the charset represents a known encoding to Node.js or Browser.
+ *
+ * Backend-independent — this is the canonical read path for the {@apilink KeyValueStore} frontend.
  */
-export function maybeParseBody(
+export function parseValue(
     body: Buffer | ArrayBuffer,
     contentTypeHeader: string,
 ): string | Buffer | ArrayBuffer | Record<string, unknown> {

--- a/packages/core/src/storages/key_value_store_codec.ts
+++ b/packages/core/src/storages/key_value_store_codec.ts
@@ -82,8 +82,11 @@ export function serializeValue(
  */
 export function parseValue(
     body: Buffer | ArrayBuffer,
-    contentTypeHeader: string,
+    contentTypeHeader: string | null,
 ): string | Buffer | ArrayBuffer | Record<string, unknown> {
+    // No content type at all → we have no basis for interpretation; hand back the raw bytes.
+    if (contentTypeHeader === null) return body;
+
     let contentType: string;
     let charset: BufferEncoding;
     try {
@@ -91,7 +94,7 @@ export function parseValue(
         contentType = result.type;
         charset = result.parameters.charset as BufferEncoding;
     } catch {
-        // can't parse, keep original body
+        // Unparseable header → keep the original buffer rather than a mangled string.
         return body;
     }
 

--- a/packages/core/src/storages/key_value_store_codec.ts
+++ b/packages/core/src/storages/key_value_store_codec.ts
@@ -8,9 +8,15 @@ const CONTENT_TYPE_JSON = 'application/json';
 const STRINGIFIABLE_CONTENT_TYPE_RXS = [new RegExp(`^${CONTENT_TYPE_JSON}$`, 'i'), /^application\/.*xml$/i, /^text\//i];
 
 /**
- * Canonical write path for key-value store records. When a content type is provided, the value is
- * taken as-is; when it is absent, the value is serialized to JSON and the content type is set to
- * `application/json; charset=utf-8`.
+ * Canonical write path for key-value store records.
+ *
+ * When a content type is provided, the value passes through unchanged — it is the caller's
+ * responsibility to supply a String/Buffer/Stream (the frontend validates this).
+ *
+ * When no content type is provided, it is inferred from the value's shape:
+ * - Buffer / typed array / ArrayBuffer / stream → `application/octet-stream` (passthrough)
+ * - `string` → `text/plain; charset=utf-8` (passthrough)
+ * - anything else → `application/json; charset=utf-8` (serialized via `jsonStringifyExtended`)
  *
  * Does NOT drain streams — that is storage mechanics and stays in the storage client.
  *
@@ -20,14 +26,24 @@ export function serializeValue(
     value: unknown,
     contentType?: string,
 ): { value: Buffer | string | NodeJS.ReadableStream; contentType: string } {
-    // When an explicit content type is provided, the value is taken as-is — it is the caller's
-    // responsibility to pass a String/Buffer/Stream (the frontend validates this). When no content
-    // type is provided, the value is serialized to JSON.
     if (contentType !== null && contentType !== undefined) {
         return { value: value as Buffer | string | NodeJS.ReadableStream, contentType };
     }
 
-    const resolvedContentType = 'application/json; charset=utf-8';
+    const isStream = typeof value === 'object' && value !== null && typeof (value as Dictionary).pipe === 'function';
+    const isBytes =
+        Buffer.isBuffer(value as unknown as Buffer) || value instanceof ArrayBuffer || ArrayBuffer.isView(value);
+
+    if (isStream || isBytes) {
+        return {
+            value: value as Buffer | NodeJS.ReadableStream,
+            contentType: 'application/octet-stream',
+        };
+    }
+
+    if (typeof value === 'string') {
+        return { value, contentType: 'text/plain; charset=utf-8' };
+    }
 
     let serialized: string;
     try {
@@ -49,7 +65,7 @@ export function serializeValue(
         );
     }
 
-    return { value: serialized, contentType: resolvedContentType };
+    return { value: serialized, contentType: 'application/json; charset=utf-8' };
 }
 
 /**

--- a/packages/core/src/storages/key_value_store_codec.ts
+++ b/packages/core/src/storages/key_value_store_codec.ts
@@ -110,12 +110,17 @@ export function parseValue(
 
 function isomorphicBufferToString(buffer: Buffer | ArrayBuffer, encoding: BufferEncoding): string {
     if (buffer.constructor.name !== ArrayBuffer.name) {
-        return buffer.toString(encoding);
+        return (buffer as Buffer).toString(encoding);
     }
 
-    // Browser decoding only works with UTF-8.
-    const utf8decoder = new TextDecoder();
-    return utf8decoder.decode(new Uint8Array(buffer));
+    // In Node, wrap the ArrayBuffer in a Buffer so the resolved charset is honored (the caller already
+    // checked it via `Buffer.isEncoding`). Only the browser, which lacks Buffer, is limited to UTF-8.
+    if (typeof Buffer !== 'undefined') {
+        return Buffer.from(buffer as ArrayBuffer).toString(encoding);
+    }
+
+    const decoder = new TextDecoder(encoding);
+    return decoder.decode(new Uint8Array(buffer as ArrayBuffer));
 }
 
 function isCharsetStringifiable(charset: string): charset is BufferEncoding {

--- a/packages/core/src/storages/key_value_store_codec.ts
+++ b/packages/core/src/storages/key_value_store_codec.ts
@@ -1,5 +1,6 @@
 import type { Dictionary } from '@crawlee/types';
 import contentTypeParser from 'content-type';
+import { isBuffer, isStream } from '@crawlee/utils';
 import JSON5 from 'json5';
 
 import { jsonStringifyExtended } from '@apify/utilities';
@@ -25,18 +26,17 @@ const STRINGIFIABLE_CONTENT_TYPE_RXS = [new RegExp(`^${CONTENT_TYPE_JSON}$`, 'i'
 export function serializeValue(
     value: unknown,
     contentType?: string,
-): { value: Buffer | string | NodeJS.ReadableStream; contentType: string } {
+): {
+    value: Buffer | ArrayBuffer | ArrayBufferView | string | NodeJS.ReadableStream | ReadableStream;
+    contentType: string;
+} {
     if (contentType !== null && contentType !== undefined) {
-        return { value: value as Buffer | string | NodeJS.ReadableStream, contentType };
+        return { value: value as Buffer | string | NodeJS.ReadableStream | ReadableStream, contentType };
     }
 
-    const isStream = typeof value === 'object' && value !== null && typeof (value as Dictionary).pipe === 'function';
-    const isBytes =
-        Buffer.isBuffer(value as unknown as Buffer) || value instanceof ArrayBuffer || ArrayBuffer.isView(value);
-
-    if (isStream || isBytes) {
+    if (isStream(value) || isBuffer(value)) {
         return {
-            value: value as Buffer | NodeJS.ReadableStream,
+            value,
             contentType: 'application/octet-stream',
         };
     }

--- a/packages/core/src/storages/key_value_store_codec.ts
+++ b/packages/core/src/storages/key_value_store_codec.ts
@@ -101,8 +101,8 @@ export function parseValue(
     // If we can't successfully interpret it, we return the original value rather than mangling it.
     if (!areDataStringifiable(contentType, charset)) return body;
 
-    // A backend may hand us an already-decoded string (e.g. the fs-storage no-extension fallback).
-    // Otherwise decode the raw bytes using the resolved charset.
+    // Decode raw bytes using the resolved charset. An already-decoded string passes through (callers
+    // may hand us one directly), avoiding a needless re-encode round-trip.
     const dataString = typeof body === 'string' ? body : isomorphicBufferToString(body, charset);
 
     return contentType === CONTENT_TYPE_JSON ? JSON5.parse(dataString) : dataString;

--- a/packages/fs-storage/package.json
+++ b/packages/fs-storage/package.json
@@ -43,6 +43,7 @@
     },
     "dependencies": {
         "@crawlee/types": "workspace:*",
+        "@crawlee/utils": "workspace:*",
         "@sapphire/async-queue": "^1.5.5",
         "@sapphire/shapeshift": "^4.0.0",
         "content-type": "^1.0.5",

--- a/packages/fs-storage/src/fs/key-value-store/fs.ts
+++ b/packages/fs-storage/src/fs/key-value-store/fs.ts
@@ -30,14 +30,15 @@ export class KeyValueFileSystemEntry implements StorageImplementation<InternalKe
 
     async get(): Promise<InternalKeyRecord> {
         await this.fsQueue.wait();
-        let file: Buffer | string;
+        let file: Buffer;
 
         try {
             file = await readFile(this.filePath);
         } catch {
             try {
                 const noExtFilePath = resolve(this.storeDirectory, this.rawRecord.key);
-                // Try without extension
+                // Try without extension. Keep the raw bytes — interpretation (text vs. JSON) is the
+                // KeyValueStore frontend's job; this client is a plain byte transport.
                 file = await readFile(noExtFilePath);
                 this.logger?.warning(
                     [
@@ -47,7 +48,6 @@ export class KeyValueFileSystemEntry implements StorageImplementation<InternalKe
                         'If you want to have correct interpretation of the file, you should add a file extension to the entry.',
                     ].join('\n'),
                 );
-                file = file.toString('utf-8');
                 this.filePath = noExtFilePath;
             } catch {
                 // This is impossible to happen, but just in case

--- a/packages/fs-storage/src/resource-clients/key-value-store.ts
+++ b/packages/fs-storage/src/resource-clients/key-value-store.ts
@@ -10,7 +10,7 @@ import { scheduleBackgroundTask } from '../background-handler/index.js';
 import type { StorageImplementation } from '../fs/common.js';
 import { createKeyValueStorageImplementation } from '../fs/key-value-store/index.js';
 import type { FileSystemStorageClient } from '../index.js';
-import { isBuffer, isStream } from '../utils.js';
+import { isBuffer, isStream, toBuffer } from '../utils.js';
 import { BaseClient } from './common/base-client.js';
 import mime from 'mime-types';
 
@@ -228,16 +228,21 @@ export class KeyValueStoreClient extends BaseClient implements storage.KeyValueS
 
         if (valueIsStream) {
             const chunks = [];
-            for await (const chunk of value) {
+            for await (const chunk of value as NodeJS.ReadableStream) {
                 chunks.push(chunk);
             }
-            value = Buffer.concat(chunks);
+            value = Buffer.concat(chunks as Buffer[]);
         }
+
+        // The on-disk record holds raw bytes (or a string). Streams were drained above, so any
+        // remaining non-string value is byte-like; normalize ArrayBuffer / typed-array views to Buffer.
+        const normalizedValue: Buffer | string =
+            typeof value === 'string' ? value : toBuffer(value as Buffer | ArrayBuffer | ArrayBufferView);
 
         const _record = {
             extension,
             key,
-            value,
+            value: normalizedValue,
             contentType,
         } satisfies InternalKeyRecord;
 

--- a/packages/fs-storage/src/resource-clients/key-value-store.ts
+++ b/packages/fs-storage/src/resource-clients/key-value-store.ts
@@ -175,7 +175,7 @@ export class KeyValueStoreClient extends BaseClient implements storage.KeyValueS
         // reconstructs the content type for on-disk records that lack one.
         const record: storage.KeyValueStoreRecord = {
             key: entry.key,
-            value: entry.value,
+            value: typeof entry.value === 'string' ? Buffer.from(entry.value, 'utf-8') : entry.value,
             contentType: entry.contentType ?? (mime.contentType(entry.extension) as string),
         };
 
@@ -184,7 +184,7 @@ export class KeyValueStoreClient extends BaseClient implements storage.KeyValueS
         return record;
     }
 
-    async setValue(record: storage.KeyValueStoreRecord): Promise<void> {
+    async setValue(record: storage.KeyValueStoreInputRecord): Promise<void> {
         s.object({
             key: s.string().lengthGreaterThan(0),
             value: s.union([

--- a/packages/fs-storage/src/resource-clients/key-value-store.ts
+++ b/packages/fs-storage/src/resource-clients/key-value-store.ts
@@ -7,7 +7,6 @@ import type * as storage from '@crawlee/types';
 import { s } from '@sapphire/shapeshift';
 
 import { scheduleBackgroundTask } from '../background-handler/index.js';
-import { maybeParseBody } from '../body-parser.js';
 import type { StorageImplementation } from '../fs/common.js';
 import { createKeyValueStorageImplementation } from '../fs/key-value-store/index.js';
 import type { FileSystemStorageClient } from '../index.js';
@@ -171,14 +170,14 @@ export class KeyValueStoreClient extends BaseClient implements storage.KeyValueS
 
         const entry = await storageEntry.get();
 
+        // Return raw bytes + verbatim content type. Parsing is the frontend's job (see the
+        // KeyValueStore codec); this client is a plain byte transport. The mime fallback
+        // reconstructs the content type for on-disk records that lack one.
         const record: storage.KeyValueStoreRecord = {
             key: entry.key,
             value: entry.value,
             contentType: entry.contentType ?? (mime.contentType(entry.extension) as string),
         };
-
-        // Auto-parse the body (JSON → object, text → string, etc.)
-        record.value = maybeParseBody(record.value, record.contentType!);
 
         this.updateTimestamps(false);
 

--- a/packages/fs-storage/src/resource-clients/key-value-store.ts
+++ b/packages/fs-storage/src/resource-clients/key-value-store.ts
@@ -10,7 +10,7 @@ import { scheduleBackgroundTask } from '../background-handler/index.js';
 import type { StorageImplementation } from '../fs/common.js';
 import { createKeyValueStorageImplementation } from '../fs/key-value-store/index.js';
 import type { FileSystemStorageClient } from '../index.js';
-import { isBuffer, isStream, toBuffer } from '../utils.js';
+import { isStream, toBuffer } from '../utils.js';
 import { BaseClient } from './common/base-client.js';
 import mime from 'mime-types';
 
@@ -176,7 +176,9 @@ export class KeyValueStoreClient extends BaseClient implements storage.KeyValueS
         const record: storage.KeyValueStoreRecord = {
             key: entry.key,
             value: typeof entry.value === 'string' ? Buffer.from(entry.value, 'utf-8') : entry.value,
-            contentType: entry.contentType ?? (mime.contentType(entry.extension) as string),
+            // mime.contentType returns `false` for unknown extensions; fall back to undefined so the
+            // frontend treats it as "no content type" rather than a bogus value.
+            contentType: entry.contentType ?? (mime.contentType(entry.extension) || undefined),
         };
 
         this.updateTimestamps(false);
@@ -201,34 +203,17 @@ export class KeyValueStoreClient extends BaseClient implements storage.KeyValueS
         }).parse(record);
 
         const { key } = record;
-        let { value, contentType } = record;
-
-        const valueIsStream = isStream(value);
-
-        const isValueStreamOrBuffer = valueIsStream || isBuffer(value);
-        // To allow saving Objects to JSON without providing content type
-        if (!contentType) {
-            if (isValueStreamOrBuffer) contentType = 'application/octet-stream';
-            else if (typeof value === 'string') contentType = 'text/plain; charset=utf-8';
-            else contentType = 'application/json; charset=utf-8';
-        }
+        let { value } = record;
+        // The frontend (KeyValueStore codec) serializes the value and resolves its content type
+        // before it reaches the client. We only need it here for on-disk extension bookkeeping.
+        const contentType = record.contentType ?? 'application/octet-stream';
 
         const extension = mime.extension(contentType) || DEFAULT_LOCAL_FILE_EXTENSION;
 
-        const isContentTypeJson = extension === 'json';
-
-        if (isContentTypeJson && !isValueStreamOrBuffer && typeof value !== 'string') {
-            try {
-                value = JSON.stringify(value, null, 2);
-            } catch (err: any) {
-                const msg = `The record value cannot be stringified to JSON. Please provide other content type.\nCause: ${err.message}`;
-                throw new Error(msg);
-            }
-        }
-
-        if (valueIsStream) {
+        // Draining a stream into a Buffer for storage is the client's responsibility.
+        if (isStream(value)) {
             const chunks = [];
-            for await (const chunk of value as NodeJS.ReadableStream) {
+            for await (const chunk of value) {
                 chunks.push(chunk);
             }
             value = Buffer.concat(chunks as Buffer[]);

--- a/packages/fs-storage/src/utils.ts
+++ b/packages/fs-storage/src/utils.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 
 import type * as storage from '@crawlee/types';
-import { s } from '@sapphire/shapeshift';
+import { isBuffer, isStream } from '@crawlee/utils';
 
 import { REQUEST_ID_LENGTH } from './consts.js';
 
@@ -31,23 +31,7 @@ export function uniqueKeyToRequestId(uniqueKey: string): string {
     return str.length > REQUEST_ID_LENGTH ? str.slice(0, REQUEST_ID_LENGTH) : str;
 }
 
-export function isBuffer(value: unknown): boolean {
-    try {
-        s.union([s.instance(Buffer), s.instance(ArrayBuffer), s.typedArray()]).parse(value);
-
-        return true;
-    } catch {
-        return false;
-    }
-}
-
-export function isStream(value: any): boolean {
-    return (
-        typeof value === 'object' &&
-        value &&
-        ['on', 'pipe'].every((key) => key in value && typeof value[key] === 'function')
-    );
-}
+export { isBuffer, isStream };
 
 export type BackgroundHandlerReceivedMessage = BackgroundHandlerUpdateMetadataMessage;
 

--- a/packages/fs-storage/src/utils.ts
+++ b/packages/fs-storage/src/utils.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 
 import type * as storage from '@crawlee/types';
-import { isBuffer, isStream } from '@crawlee/utils';
+import { isBuffer, isStream, toBuffer } from '@crawlee/utils';
 
 import { REQUEST_ID_LENGTH } from './consts.js';
 
@@ -31,7 +31,7 @@ export function uniqueKeyToRequestId(uniqueKey: string): string {
     return str.length > REQUEST_ID_LENGTH ? str.slice(0, REQUEST_ID_LENGTH) : str;
 }
 
-export { isBuffer, isStream };
+export { isBuffer, isStream, toBuffer };
 
 export type BackgroundHandlerReceivedMessage = BackgroundHandlerUpdateMetadataMessage;
 

--- a/packages/fs-storage/test/async-iteration.test.ts
+++ b/packages/fs-storage/test/async-iteration.test.ts
@@ -71,7 +71,12 @@ describe('Async iteration support', () => {
             kvStore = await storage.createKeyValueStoreClient({ name: 'async-iteration-kvs' });
 
             for (const key of keys) {
-                await kvStore.setValue({ key, value: { data: key } });
+                // The client is a byte-transport: pass serialized bytes + content type.
+                await kvStore.setValue({
+                    key,
+                    value: JSON.stringify({ data: key }),
+                    contentType: 'application/json; charset=utf-8',
+                });
             }
         });
 

--- a/packages/fs-storage/test/fs-fallback.test.ts
+++ b/packages/fs-storage/test/fs-fallback.test.ts
@@ -92,10 +92,11 @@ describe('fallback to fs for reading', () => {
     test('attempting to read "no-ext" key value store should load the missing extension file correctly', async () => {
         const noExtStore = await storage.createKeyValueStoreClient({ name: 'no-ext' });
 
+        // Byte transport: the no-extension fallback also returns raw bytes now, not a decoded string.
         const input = await noExtStore.getValue('INPUT');
         expect(input).toStrictEqual<KeyValueStoreRecord>({
             key: 'INPUT',
-            value: JSON.stringify({ foo: 'bar but from fs' }),
+            value: Buffer.from(JSON.stringify({ foo: 'bar but from fs' })),
             contentType: 'text/plain',
         });
     });

--- a/packages/fs-storage/test/fs-fallback.test.ts
+++ b/packages/fs-storage/test/fs-fallback.test.ts
@@ -61,10 +61,12 @@ describe('fallback to fs for reading', () => {
         expect(defaultStoreInfo.name).toEqual('default');
         expect(defaultStoreInfo.createdAt).toEqual(expectedFsDate);
 
+        // The client is a byte transport: it returns the raw on-disk bytes verbatim and leaves
+        // parsing to the KeyValueStore frontend codec. So we expect a Buffer, not a parsed object.
         const input = await defaultStore.getValue('INPUT');
         expect(input).toStrictEqual<KeyValueStoreRecord>({
             key: 'INPUT',
-            value: { foo: 'bar but from fs' },
+            value: Buffer.from(JSON.stringify({ foo: 'bar but from fs' })),
             contentType: 'application/json; charset=utf-8',
         });
     });
@@ -72,10 +74,11 @@ describe('fallback to fs for reading', () => {
     test('attempting to read "other" key value store with no "__metadata__" present should read from fs, even if accessed without generating id first', async () => {
         const otherStore = await storage.createKeyValueStoreClient({ name: 'other' });
 
+        // Byte transport: raw bytes out, parsing is the frontend's job.
         const input = await otherStore.getValue('INPUT');
         expect(input).toStrictEqual<KeyValueStoreRecord>({
             key: 'INPUT',
-            value: { foo: 'bar but from fs' },
+            value: Buffer.from(JSON.stringify({ foo: 'bar but from fs' })),
             contentType: 'application/json; charset=utf-8',
         });
     });

--- a/packages/fs-storage/test/write-metadata.test.ts
+++ b/packages/fs-storage/test/write-metadata.test.ts
@@ -30,7 +30,8 @@ describe('writeMetadata option', () => {
 
         test('creating a key-value pair in a key-value store should not write __metadata__.json file for the value', async () => {
             const keyValueStore = await storage.createKeyValueStoreClient();
-            await keyValueStore.setValue({ key: 'foo', value: 'test' });
+            // The client is a byte-transport: pass the content type so the on-disk extension is `txt`.
+            await keyValueStore.setValue({ key: 'foo', value: 'test', contentType: 'text/plain; charset=utf-8' });
 
             const keyValueStoreInfo = await keyValueStore.getMetadata();
             const expectedFilePath = resolve(storage.keyValueStoresDirectory, `${keyValueStoreInfo.id}/foo.txt`);
@@ -62,7 +63,8 @@ describe('writeMetadata option', () => {
 
         test('creating a key-value pair in a key-value store should write __metadata__.json file for the value', async () => {
             const keyValueStore = await storage.createKeyValueStoreClient();
-            await keyValueStore.setValue({ key: 'foo', value: 'test' });
+            // The client is a byte-transport: pass the content type so the on-disk extension is `txt`.
+            await keyValueStore.setValue({ key: 'foo', value: 'test', contentType: 'text/plain; charset=utf-8' });
 
             const keyValueStoreInfo = await keyValueStore.getMetadata();
             const expectedFilePath = resolve(storage.keyValueStoresDirectory, `${keyValueStoreInfo.id}/foo.txt`);

--- a/packages/memory-storage/package.json
+++ b/packages/memory-storage/package.json
@@ -43,6 +43,7 @@
     },
     "dependencies": {
         "@crawlee/types": "workspace:*",
+        "@crawlee/utils": "workspace:*",
         "@sapphire/async-queue": "^1.5.5",
         "@sapphire/shapeshift": "^4.0.0",
         "content-type": "^1.0.5",

--- a/packages/memory-storage/src/resource-clients/key-value-store.ts
+++ b/packages/memory-storage/src/resource-clients/key-value-store.ts
@@ -172,7 +172,9 @@ export class KeyValueStoreClient extends BaseClient implements storage.KeyValueS
         const record: storage.KeyValueStoreRecord = {
             key: entry.key,
             value: entry.value,
-            contentType: entry.contentType ?? (mime.contentType(entry.extension) as string),
+            // mime.contentType returns `false` for unknown extensions; fall back to undefined so the
+            // frontend treats it as "no content type" rather than a bogus value.
+            contentType: entry.contentType ?? (mime.contentType(entry.extension) || undefined),
         };
 
         this.updateTimestamps(false);

--- a/packages/memory-storage/src/resource-clients/key-value-store.ts
+++ b/packages/memory-storage/src/resource-clients/key-value-store.ts
@@ -3,9 +3,8 @@ import { randomUUID } from 'node:crypto';
 import type * as storage from '@crawlee/types';
 import { s } from '@sapphire/shapeshift';
 
-import { maybeParseBody } from '../body-parser.js';
 import type { MemoryStorageClient } from '../index.js';
-import { isBuffer, isStream } from '../utils.js';
+import { isStream } from '../utils.js';
 import { BaseClient } from './common/base-client.js';
 import mime from 'mime-types';
 
@@ -168,14 +167,13 @@ export class KeyValueStoreClient extends BaseClient implements storage.KeyValueS
             return undefined;
         }
 
+        // Return raw bytes + verbatim content type. Parsing is the frontend's job (see the
+        // KeyValueStore codec). The mime fallback reconstructs the content type for on-disk records.
         const record: storage.KeyValueStoreRecord = {
             key: entry.key,
             value: entry.value,
             contentType: entry.contentType ?? (mime.contentType(entry.extension) as string),
         };
-
-        // Auto-parse the body (JSON → object, text → string, etc.)
-        record.value = maybeParseBody(record.value, record.contentType!);
 
         this.updateTimestamps(false);
 
@@ -199,32 +197,15 @@ export class KeyValueStoreClient extends BaseClient implements storage.KeyValueS
         }).parse(record);
 
         const { key } = record;
-        let { value, contentType } = record;
-
-        const valueIsStream = isStream(value);
-
-        const isValueStreamOrBuffer = valueIsStream || isBuffer(value);
-        // To allow saving Objects to JSON without providing content type
-        if (!contentType) {
-            if (isValueStreamOrBuffer) contentType = 'application/octet-stream';
-            else if (typeof value === 'string') contentType = 'text/plain; charset=utf-8';
-            else contentType = 'application/json; charset=utf-8';
-        }
+        let { value } = record;
+        // The frontend (KeyValueStore codec) serializes the value and resolves its content type
+        // before it reaches the client. We only need it here for on-disk extension bookkeeping.
+        const contentType = record.contentType ?? 'application/octet-stream';
 
         const extension = mime.extension(contentType) || DEFAULT_LOCAL_FILE_EXTENSION;
 
-        const isContentTypeJson = extension === 'json';
-
-        if (isContentTypeJson && !isValueStreamOrBuffer && typeof value !== 'string') {
-            try {
-                value = JSON.stringify(value, null, 2);
-            } catch (err: any) {
-                const msg = `The record value cannot be stringified to JSON. Please provide other content type.\nCause: ${err.message}`;
-                throw new Error(msg);
-            }
-        }
-
-        if (valueIsStream) {
+        // Draining a stream into a Buffer for storage is the client's responsibility.
+        if (isStream(value)) {
             const chunks = [];
             for await (const chunk of value) {
                 chunks.push(chunk);

--- a/packages/memory-storage/src/resource-clients/key-value-store.ts
+++ b/packages/memory-storage/src/resource-clients/key-value-store.ts
@@ -4,7 +4,7 @@ import type * as storage from '@crawlee/types';
 import { s } from '@sapphire/shapeshift';
 
 import type { MemoryStorageClient } from '../index.js';
-import { isStream } from '../utils.js';
+import { isStream, toBuffer } from '../utils.js';
 import { BaseClient } from './common/base-client.js';
 import mime from 'mime-types';
 
@@ -213,10 +213,15 @@ export class KeyValueStoreClient extends BaseClient implements storage.KeyValueS
             value = Buffer.concat(chunks);
         }
 
+        // The store holds raw bytes (or a string). Streams were drained above, so any remaining
+        // non-string value is byte-like; normalize ArrayBuffer / typed-array views to Buffer.
+        const normalizedValue: Buffer | string =
+            typeof value === 'string' ? value : toBuffer(value as Buffer | ArrayBuffer | ArrayBufferView);
+
         const _record = {
             extension,
             key,
-            value,
+            value: normalizedValue,
             contentType,
         } satisfies InternalKeyRecord;
 

--- a/packages/memory-storage/src/resource-clients/key-value-store.ts
+++ b/packages/memory-storage/src/resource-clients/key-value-store.ts
@@ -30,7 +30,7 @@ export interface KeyValueStoreClientOptions {
 
 export interface InternalKeyRecord {
     key: string;
-    value: Buffer | string;
+    value: Buffer;
     contentType?: string;
     extension: string;
 }
@@ -180,7 +180,7 @@ export class KeyValueStoreClient extends BaseClient implements storage.KeyValueS
         return record;
     }
 
-    async setValue(record: storage.KeyValueStoreRecord): Promise<void> {
+    async setValue(record: storage.KeyValueStoreInputRecord): Promise<void> {
         s.object({
             key: s.string().lengthGreaterThan(0),
             value: s.union([
@@ -213,10 +213,13 @@ export class KeyValueStoreClient extends BaseClient implements storage.KeyValueS
             value = Buffer.concat(chunks);
         }
 
-        // The store holds raw bytes (or a string). Streams were drained above, so any remaining
-        // non-string value is byte-like; normalize ArrayBuffer / typed-array views to Buffer.
-        const normalizedValue: Buffer | string =
-            typeof value === 'string' ? value : toBuffer(value as Buffer | ArrayBuffer | ArrayBufferView);
+        // This client is a byte transport: it stores and returns raw bytes regardless of the input
+        // shape. Streams were drained above; encode strings to UTF-8 bytes and normalize
+        // ArrayBuffer / typed-array views to a Buffer over the same memory.
+        const normalizedValue: Buffer =
+            typeof value === 'string'
+                ? Buffer.from(value, 'utf-8')
+                : toBuffer(value as Buffer | ArrayBuffer | ArrayBufferView);
 
         const _record = {
             extension,

--- a/packages/memory-storage/src/utils.ts
+++ b/packages/memory-storage/src/utils.ts
@@ -1,6 +1,5 @@
 import { createHash } from 'node:crypto';
 
-import { s } from '@sapphire/shapeshift';
 import { isBuffer, isStream } from '@crawlee/utils';
 
 import { REQUEST_ID_LENGTH } from './consts.js';

--- a/packages/memory-storage/src/utils.ts
+++ b/packages/memory-storage/src/utils.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 
-import { isBuffer, isStream } from '@crawlee/utils';
+import { isBuffer, isStream, toBuffer } from '@crawlee/utils';
 
 import { REQUEST_ID_LENGTH } from './consts.js';
 
@@ -30,4 +30,4 @@ export function uniqueKeyToRequestId(uniqueKey: string): string {
     return str.length > REQUEST_ID_LENGTH ? str.slice(0, REQUEST_ID_LENGTH) : str;
 }
 
-export { isBuffer, isStream };
+export { isBuffer, isStream, toBuffer };

--- a/packages/memory-storage/src/utils.ts
+++ b/packages/memory-storage/src/utils.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 
 import { s } from '@sapphire/shapeshift';
+import { isBuffer, isStream } from '@crawlee/utils';
 
 import { REQUEST_ID_LENGTH } from './consts.js';
 
@@ -30,20 +31,4 @@ export function uniqueKeyToRequestId(uniqueKey: string): string {
     return str.length > REQUEST_ID_LENGTH ? str.slice(0, REQUEST_ID_LENGTH) : str;
 }
 
-export function isBuffer(value: unknown): boolean {
-    try {
-        s.union([s.instance(Buffer), s.instance(ArrayBuffer), s.typedArray()]).parse(value);
-
-        return true;
-    } catch {
-        return false;
-    }
-}
-
-export function isStream(value: any): boolean {
-    return (
-        typeof value === 'object' &&
-        value &&
-        ['on', 'pipe'].every((key) => key in value && typeof value[key] === 'function')
-    );
-}
+export { isBuffer, isStream };

--- a/packages/memory-storage/test/async-iteration.test.ts
+++ b/packages/memory-storage/test/async-iteration.test.ts
@@ -61,7 +61,12 @@ describe('Async iteration support', () => {
             kvStore = await storage.createKeyValueStoreClient({ name: 'async-iteration-kvs' });
 
             for (const key of keys) {
-                await kvStore.setValue({ key, value: { data: key } });
+                // The client is a byte-transport: pass serialized bytes + content type.
+                await kvStore.setValue({
+                    key,
+                    value: JSON.stringify({ data: key }),
+                    contentType: 'application/json; charset=utf-8',
+                });
             }
         });
 

--- a/packages/memory-storage/test/key-value-store/purge.test.ts
+++ b/packages/memory-storage/test/key-value-store/purge.test.ts
@@ -6,14 +6,22 @@ describe('MemoryStorageClient.purge preserves the default key-value store input'
         const storage = new MemoryStorageClient();
         const store: KeyValueStoreClient = await storage.createKeyValueStoreClient({ name: 'default' });
 
-        await store.setValue({ key: 'INPUT', value: { hello: 'world' } });
-        await store.setValue({ key: 'some-other-key', value: { foo: 'bar' } });
+        await store.setValue({
+            key: 'INPUT',
+            value: JSON.stringify({ hello: 'world' }),
+            contentType: 'application/json; charset=utf-8',
+        });
+        await store.setValue({
+            key: 'some-other-key',
+            value: JSON.stringify({ foo: 'bar' }),
+            contentType: 'application/json; charset=utf-8',
+        });
 
         await storage.purge();
 
         // INPUT must survive the purge (parity with FileSystemStorageClient)...
         const input = await store.getValue('INPUT');
-        expect(input?.value).toEqual({ hello: 'world' });
+        expect(input?.value.toString()).toBe(JSON.stringify({ hello: 'world' }));
 
         // ...while every other record is removed.
         expect(await store.getValue('some-other-key')).toBeUndefined();
@@ -25,11 +33,15 @@ describe('MemoryStorageClient.purge preserves the default key-value store input'
         const storage = new MemoryStorageClient();
         const store: KeyValueStoreClient = await storage.createKeyValueStoreClient({ name: 'not-default' });
 
-        await store.setValue({ key: 'INPUT', value: { hello: 'world' } });
+        await store.setValue({
+            key: 'INPUT',
+            value: JSON.stringify({ hello: 'world' }),
+            contentType: 'application/json; charset=utf-8',
+        });
 
         // `purge` on the storage client only touches default storages, so a named store keeps its data.
         await storage.purge();
-        expect((await store.getValue('INPUT'))?.value).toEqual({ hello: 'world' });
+        expect((await store.getValue('INPUT'))?.value.toString()).toBe(JSON.stringify({ hello: 'world' }));
 
         // Purging the store directly clears everything, including INPUT.
         await store.purge();

--- a/packages/types/src/storages.ts
+++ b/packages/types/src/storages.ts
@@ -98,7 +98,17 @@ export interface KeyValueStoreInfo {
 
 export interface KeyValueStoreRecord {
     key: string;
-    value: any;
+    /**
+     * The record body as raw bytes (or a stream / pre-serialized string on the write path).
+     *
+     * Storage clients are byte transports: they persist and return bytes verbatim and never
+     * serialize or parse. The `KeyValueStore` frontend owns that — it serializes on the way in
+     * (see its codec, `serializeValue`) and parses on the way out (`parseValue`). Consequently:
+     * - on `getValue`, this is the raw `Buffer | ArrayBuffer` read from the backend;
+     * - on `setValue`, the frontend has already serialized, so this is a `string`, `Buffer`,
+     *   `ArrayBuffer`, typed array, or a stream to be drained.
+     */
+    value: Buffer | ArrayBuffer | ArrayBufferView | string | NodeJS.ReadableStream | ReadableStream;
     contentType?: string;
 }
 
@@ -135,7 +145,12 @@ export interface KeyValueStoreClient {
     /** Remove all records from the store but keep the store itself. */
     purge(): Promise<void>;
 
-    /** Get a record value by key. Returns the parsed value or `undefined` if not found. */
+    /**
+     * Get a record by key. Returns the raw bytes plus content type, or `undefined` if not found.
+     *
+     * Clients are byte transports and must not parse the body — the `KeyValueStore` frontend
+     * interprets it according to the content type.
+     */
     getValue(key: string): Promise<KeyValueStoreRecord | undefined>;
 
     /** Set a record value. */

--- a/packages/types/src/storages.ts
+++ b/packages/types/src/storages.ts
@@ -96,19 +96,41 @@ export interface KeyValueStoreInfo {
     stats?: KeyValueStoreStats;
 }
 
+/**
+ * The value a serialized record carries on the way *into* a storage client (`setValue`).
+ *
+ * The `KeyValueStore` frontend has already serialized by this point, so it is a pre-serialized
+ * string, raw bytes (`Buffer` / `ArrayBuffer` / typed array), or a stream the client drains.
+ */
+export type KeyValueStoreRecordInputValue =
+    | Buffer
+    | ArrayBuffer
+    | ArrayBufferView
+    | string
+    | NodeJS.ReadableStream
+    | ReadableStream;
+
+/**
+ * A record as returned by a storage client (`getValue`).
+ *
+ * Storage clients are byte transports: they persist and return bytes verbatim and never serialize
+ * or parse. Interpretation is the `KeyValueStore` frontend's job (it parses according to the content
+ * type via `parseValue`). The value is therefore always raw bytes — a `Buffer` (Node) or an
+ * `ArrayBuffer` (browser backends).
+ */
 export interface KeyValueStoreRecord {
     key: string;
-    /**
-     * The record body as raw bytes (or a stream / pre-serialized string on the write path).
-     *
-     * Storage clients are byte transports: they persist and return bytes verbatim and never
-     * serialize or parse. The `KeyValueStore` frontend owns that — it serializes on the way in
-     * (see its codec, `serializeValue`) and parses on the way out (`parseValue`). Consequently:
-     * - on `getValue`, this is the raw `Buffer | ArrayBuffer` read from the backend;
-     * - on `setValue`, the frontend has already serialized, so this is a `string`, `Buffer`,
-     *   `ArrayBuffer`, typed array, or a stream to be drained.
-     */
-    value: Buffer | ArrayBuffer | ArrayBufferView | string | NodeJS.ReadableStream | ReadableStream;
+    value: Buffer | ArrayBuffer;
+    contentType?: string;
+}
+
+/**
+ * A record passed to a storage client for writing (`setValue`). Like {@link KeyValueStoreRecord} but
+ * with the lenient, pre-serialized {@link KeyValueStoreRecordInputValue} for the value.
+ */
+export interface KeyValueStoreInputRecord {
+    key: string;
+    value: KeyValueStoreRecordInputValue;
     contentType?: string;
 }
 
@@ -154,7 +176,7 @@ export interface KeyValueStoreClient {
     getValue(key: string): Promise<KeyValueStoreRecord | undefined>;
 
     /** Set a record value. */
-    setValue(record: KeyValueStoreRecord): Promise<void>;
+    setValue(record: KeyValueStoreInputRecord): Promise<void>;
 
     /** Delete a record by key. */
     deleteValue(key: string): Promise<void>;

--- a/packages/utils/src/internals/general.ts
+++ b/packages/utils/src/internals/general.ts
@@ -220,3 +220,21 @@ export function isBuffer(value: unknown): value is Buffer | ArrayBuffer | ArrayB
             (value as any).constructor?.name === 'Buffer')
     );
 }
+
+/**
+ * Converts a byte-like value (Buffer, ArrayBuffer, or any typed-array / DataView) into a Buffer over
+ * the exact same bytes, honoring `byteOffset` / `byteLength` for views. Existing Buffers are returned
+ * as-is. Used by storage clients, which persist raw bytes regardless of the input's concrete shape.
+ * @ignore
+ */
+export function toBuffer(value: Buffer | ArrayBuffer | ArrayBufferView): Buffer {
+    if (Buffer.isBuffer(value)) {
+        return value;
+    }
+
+    if (value instanceof ArrayBuffer) {
+        return Buffer.from(value);
+    }
+
+    return Buffer.from(value.buffer, value.byteOffset, value.byteLength);
+}

--- a/packages/utils/src/internals/general.ts
+++ b/packages/utils/src/internals/general.ts
@@ -199,11 +199,18 @@ export function expandShadowRoots(document: Document): string {
  * @ignore
  */
 export function isStream(value: unknown): value is NodeJS.ReadableStream | ReadableStream {
-    return (
-        typeof value === 'object' &&
-        value !== null &&
-        (typeof (value as any).pipe === 'function' || typeof (value as any).pipeTo === 'function')
-    );
+    if (typeof value !== 'object' || value === null) {
+        return false;
+    }
+
+    // A Node.js Readable is both pipeable and async-iterable; a Web ReadableStream exposes pipeTo.
+    // Requiring async-iterability for the `pipe` branch rejects plain `{ pipe }` ducks that would
+    // otherwise blow up later in the storage clients' drain loop with a cryptic TypeError.
+    const isNodeStream =
+        typeof (value as any).pipe === 'function' && typeof (value as any)[Symbol.asyncIterator] === 'function';
+    const isWebStream = typeof (value as any).pipeTo === 'function';
+
+    return isNodeStream || isWebStream;
 }
 
 /**

--- a/packages/utils/src/internals/general.ts
+++ b/packages/utils/src/internals/general.ts
@@ -193,3 +193,30 @@ export function expandShadowRoots(document: Document): string {
 
     return document.documentElement.outerHTML;
 }
+
+/**
+ * Checks if the given value is a Node.js Stream or a Web API ReadableStream.
+ * @ignore
+ */
+export function isStream(value: unknown): value is NodeJS.ReadableStream | ReadableStream {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        (typeof (value as any).pipe === 'function' || typeof (value as any).pipeTo === 'function')
+    );
+}
+
+/**
+ * Checks if the given value is a Node.js Buffer, ArrayBuffer, or TypedArray.
+ * @ignore
+ */
+export function isBuffer(value: unknown): value is Buffer | ArrayBuffer | ArrayBufferView {
+    return (
+        value != null &&
+        typeof value === 'object' &&
+        (Buffer.isBuffer(value) ||
+            value instanceof ArrayBuffer ||
+            ArrayBuffer.isView(value) ||
+            (value as any).constructor?.name === 'Buffer')
+    );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -445,6 +445,9 @@ importers:
       '@vladfrangu/async_event_emitter':
         specifier: ^2.4.6
         version: 2.4.7
+      content-type:
+        specifier: ^1.0.5
+        version: 1.0.5
       csv-stringify:
         specifier: ^6.5.2
         version: 6.7.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -544,6 +544,9 @@ importers:
       '@crawlee/types':
         specifier: workspace:*
         version: link:../types
+      '@crawlee/utils':
+        specifier: workspace:*
+        version: link:../utils
       '@sapphire/async-queue':
         specifier: ^1.5.5
         version: 1.5.5
@@ -721,6 +724,9 @@ importers:
       '@crawlee/types':
         specifier: workspace:*
         version: link:../types
+      '@crawlee/utils':
+        specifier: workspace:*
+        version: link:../utils
       '@sapphire/async-queue':
         specifier: ^1.5.5
         version: 1.5.5

--- a/test/core/crawlers/adaptive_playwright_crawler.test.ts
+++ b/test/core/crawlers/adaptive_playwright_crawler.test.ts
@@ -460,9 +460,9 @@ describe('AdaptivePlaywrightCrawler', () => {
 
         const store = await KeyValueStore.open();
 
-        expect(store.getValue('1')).resolves.toEqual({ content: 42 });
-        expect(store.getValue('2')).resolves.toEqual({ content: 42 });
-        expect(store.getValue('3')).resolves.toEqual({ content: 42 });
+        await expect(store.getValue('1')).resolves.toEqual({ content: 42 });
+        await expect(store.getValue('2')).resolves.toEqual({ content: 42 });
+        await expect(store.getValue('3')).resolves.toEqual({ content: 42 });
     });
 
     test('should not allow direct key-value store manipulation', async () => {

--- a/test/core/crawlers/adaptive_playwright_crawler.test.ts
+++ b/test/core/crawlers/adaptive_playwright_crawler.test.ts
@@ -1,7 +1,7 @@
 import type { Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
 
-import { type Dictionary, EventType, KeyValueStore, parseValue, serviceLocator } from '@crawlee/core';
+import { type Dictionary, EventType, KeyValueStore, serviceLocator } from '@crawlee/core';
 import type {
     AdaptivePlaywrightCrawlerContext,
     AdaptivePlaywrightCrawlerOptions,
@@ -384,9 +384,8 @@ describe('AdaptivePlaywrightCrawler', () => {
         );
 
         await crawler.run();
-        // The client returns raw bytes now; parse them as the frontend would.
-        const state = await localStorageEmulator.getState();
-        expect(parseValue(state!.value, state!.contentType!)).toEqual({ count: 3 });
+        // getState reads through the frontend, so the value is already parsed.
+        expect(await localStorageEmulator.getState()).toEqual({ count: 3 });
     });
 
     test('should return deeply equal but not identical state objects across handler runs', async () => {

--- a/test/core/crawlers/adaptive_playwright_crawler.test.ts
+++ b/test/core/crawlers/adaptive_playwright_crawler.test.ts
@@ -1,7 +1,7 @@
 import type { Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
 
-import { Configuration, type Dictionary, EventType, KeyValueStore, serviceLocator } from '@crawlee/core';
+import { type Dictionary, EventType, KeyValueStore, parseValue, serviceLocator } from '@crawlee/core';
 import type {
     AdaptivePlaywrightCrawlerContext,
     AdaptivePlaywrightCrawlerOptions,
@@ -384,8 +384,9 @@ describe('AdaptivePlaywrightCrawler', () => {
         );
 
         await crawler.run();
+        // The client returns raw bytes now; parse them as the frontend would.
         const state = await localStorageEmulator.getState();
-        expect(state!.value).toEqual({ count: 3 });
+        expect(parseValue(state!.value, state!.contentType!)).toEqual({ count: 3 });
     });
 
     test('should return deeply equal but not identical state objects across handler runs', async () => {
@@ -456,11 +457,12 @@ describe('AdaptivePlaywrightCrawler', () => {
         );
 
         await crawler.run();
-        const store = await localStorageEmulator.getKeyValueStore();
 
-        expect((await store.getValue('1'))!.value).toEqual({ content: 42 });
-        expect((await store.getValue('2'))!.value).toEqual({ content: 42 });
-        expect((await store.getValue('3'))!.value).toEqual({ content: 42 });
+        const store = await KeyValueStore.open();
+
+        expect(store.getValue('1')).resolves.toEqual({ content: 42 });
+        expect(store.getValue('2')).resolves.toEqual({ content: 42 });
+        expect(store.getValue('3')).resolves.toEqual({ content: 42 });
     });
 
     test('should not allow direct key-value store manipulation', async () => {

--- a/test/core/crawlers/rendering_type_predictor.test.ts
+++ b/test/core/crawlers/rendering_type_predictor.test.ts
@@ -1,4 +1,4 @@
-import { Request } from '@crawlee/core';
+import { KeyValueStore, Request } from '@crawlee/core';
 import { RenderingTypePredictor } from '@crawlee/playwright';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
@@ -34,16 +34,15 @@ describe('RenderingTypePredictor', () => {
             predictor.storeResult(clientRequest, 'clientOnly');
 
             // Persist the state
-            const store = await localStorageEmulator.getKeyValueStore();
+            const store = await KeyValueStore.open();
             // eslint-disable-next-line dot-notation
             await predictor['state'].persistState(); // Access private state for persistence
 
-            // Verify state was persisted
-            const persistedRecord = await store.getValue(persistStateKey);
-            expect(persistedRecord).not.toBeNull();
-            expect(persistedRecord?.value).toBeDefined();
-
-            const parsedState = JSON.parse(persistedRecord!.value as string);
+            // RecoverableState persists with a `text/plain` content type on purpose (it owns
+            // (de)serialization), so the frontend hands back the raw serialized string here.
+            const serializedState = await store.getValue<string>(persistStateKey);
+            expect(serializedState).not.toBeNull();
+            const parsedState = JSON.parse(serializedState!);
             expect(parsedState).toHaveProperty('logreg');
             expect(parsedState).toHaveProperty('detectionResults');
 

--- a/test/core/recoverable_state.test.ts
+++ b/test/core/recoverable_state.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
+import { KeyValueStore } from '../../packages/core/src/index.js';
 import { RecoverableState } from '../../packages/core/src/recoverable_state.js';
 import { MemoryStorageEmulator } from '../shared/MemoryStorageEmulator.js';
 
@@ -179,10 +180,10 @@ describe('RecoverableState', () => {
         recoverableState.currentValue.data.value = 'updated';
         await recoverableState.persistState();
 
-        const persistedState = JSON.parse(
-            (await (await localStorageEmulator.getKeyValueStore()).getValue('test-key'))?.value,
-        );
-        expect(persistedState).toMatchObject({
+        // RecoverableState persists with a `text/plain` content type on purpose (it owns
+        // (de)serialization), so the frontend hands back the raw serialized string here.
+        const persistedState = await (await KeyValueStore.open()).getValue<string>('test-key');
+        expect(JSON.parse(persistedState!)).toMatchObject({
             data: { value: 'updated' },
         });
 

--- a/test/core/storages/key_value_store.test.ts
+++ b/test/core/storages/key_value_store.test.ts
@@ -355,6 +355,30 @@ describe('KeyValueStore', () => {
         });
     });
 
+    describe('round-trips through the real storage client (no content type)', () => {
+        test('object: setValue → getValue returns the same object', async () => {
+            const store = await KeyValueStore.open();
+            const original = { foo: 'bar', n: 1 };
+            await store.setValue('obj', original);
+            await expect(store.getValue('obj')).resolves.toEqual(original);
+        });
+
+        test('string: setValue → getValue returns the same string (not JSON-wrapped)', async () => {
+            const store = await KeyValueStore.open();
+            await store.setValue('str', 'hello world');
+            await expect(store.getValue('str')).resolves.toBe('hello world');
+        });
+
+        test('Buffer: setValue → getValue returns the same Buffer (not JSON-mangled)', async () => {
+            const store = await KeyValueStore.open();
+            const original = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
+            await store.setValue('buf', original);
+            const got = await store.getValue('buf');
+            expect(Buffer.isBuffer(got)).toBe(true);
+            expect((got as Buffer).equals(original)).toBe(true);
+        });
+    });
+
     // TODO move to actor sdk tests before splitting the repos
     // describe('getPublicUrl', () => {
     //     test('should return the url of a file in apify cloud', async () => {

--- a/test/core/storages/key_value_store.test.ts
+++ b/test/core/storages/key_value_store.test.ts
@@ -379,6 +379,75 @@ describe('KeyValueStore', () => {
         });
     });
 
+    describe('pre-serialized JSON via setValue (caller owns the bytes)', () => {
+        test('Buffer containing JSON + explicit application/json CT round-trips as a parsed object', async () => {
+            const store = await KeyValueStore.open();
+            const original = { foo: 'bar', n: 1 };
+            const preSerialized = Buffer.from(JSON.stringify(original));
+
+            await store.setValue('k', preSerialized, { contentType: 'application/json; charset=utf-8' });
+
+            // getValue parses the bytes back into the original object.
+            expect(await store.getValue('k')).toEqual(original);
+        });
+
+        test('string containing JSON + explicit application/json CT round-trips as a parsed object', async () => {
+            const store = await KeyValueStore.open();
+            const original = [1, 2, 3];
+
+            await store.setValue('k', JSON.stringify(original), {
+                contentType: 'application/json; charset=utf-8',
+            });
+
+            expect(await store.getValue('k')).toEqual(original);
+        });
+    });
+
+    describe('getRecord', () => {
+        test('returns null for a missing key', async () => {
+            const store = await KeyValueStore.open();
+            expect(await store.getRecord('missing')).toBeNull();
+        });
+
+        test('returns raw bytes + content type without parsing JSON', async () => {
+            const store = await KeyValueStore.open();
+            const original = { foo: 'bar', n: 1 };
+            await store.setValue('obj', original);
+
+            const record = await store.getRecord('obj');
+            expect(record).not.toBeNull();
+            expect(record!.contentType).toMatch(/^application\/json/);
+            // Bytes are the serialized JSON, not the parsed object — the caller does the parsing.
+            const asText = Buffer.isBuffer(record!.value) ? record!.value.toString() : (record!.value as string);
+            expect(JSON.parse(asText)).toEqual(original);
+        });
+
+        test('returns the exact bytes a caller wrote with an explicit content type', async () => {
+            const store = await KeyValueStore.open();
+            const preSerialized = Buffer.from(JSON.stringify({ a: 1 }));
+
+            await store.setValue('k', preSerialized, { contentType: 'application/json; charset=utf-8' });
+
+            const record = await store.getRecord('k');
+            expect(record).not.toBeNull();
+            expect(record!.contentType).toBe('application/json; charset=utf-8');
+            const asText = Buffer.isBuffer(record!.value) ? record!.value.toString() : (record!.value as string);
+            expect(asText).toBe(preSerialized.toString());
+        });
+
+        test('returns a Buffer for octet-stream records', async () => {
+            const store = await KeyValueStore.open();
+            const original = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
+            await store.setValue('buf', original);
+
+            const record = await store.getRecord('buf');
+            expect(record).not.toBeNull();
+            expect(record!.contentType).toBe('application/octet-stream');
+            expect(Buffer.isBuffer(record!.value)).toBe(true);
+            expect((record!.value as Buffer).equals(original)).toBe(true);
+        });
+    });
+
     // TODO move to actor sdk tests before splitting the repos
     // describe('getPublicUrl', () => {
     //     test('should return the url of a file in apify cloud', async () => {

--- a/test/core/storages/key_value_store.test.ts
+++ b/test/core/storages/key_value_store.test.ts
@@ -1,6 +1,6 @@
 import { PassThrough } from 'node:stream';
 
-import { KeyValueStore, maybeStringify, serviceLocator } from '@crawlee/core';
+import { KeyValueStore, serviceLocator } from '@crawlee/core';
 import type { Dictionary } from '@crawlee/utils';
 import { MemoryStorageEmulator } from '../../shared/MemoryStorageEmulator.js';
 
@@ -52,7 +52,8 @@ describe('KeyValueStore', () => {
             .spyOn(store.client, 'getValue')
             .mockResolvedValueOnce({
                 key: 'key-1',
-                value: record,
+                // The client now returns raw bytes; the frontend parses them.
+                value: Buffer.from(recordStr),
                 contentType: 'application/json; charset=utf-8',
             });
 
@@ -370,22 +371,6 @@ describe('KeyValueStore', () => {
     //         delete process.env[ENV_VARS.TOKEN];
     //     });
     // });
-
-    describe('maybeStringify()', () => {
-        test('should work', () => {
-            expect(maybeStringify({ foo: 'bar' }, { contentType: null as any })).toBe('{\n  "foo": "bar"\n}');
-            expect(maybeStringify({ foo: 'bar' }, { contentType: undefined })).toBe('{\n  "foo": "bar"\n}');
-
-            expect(maybeStringify('xxx', { contentType: undefined })).toBe('"xxx"');
-            expect(maybeStringify('xxx', { contentType: 'something' })).toBe('xxx');
-
-            const obj = {} as Dictionary;
-            obj.self = obj;
-            expect(() => maybeStringify(obj, { contentType: null as any })).toThrow(
-                'The "value" parameter cannot be stringified to JSON: Converting circular structure to JSON',
-            );
-        });
-    });
 
     describe('getFileNameRegexp()', () => {
         const getFileNameRegexp = (key: string) => {

--- a/test/core/storages/key_value_store.test.ts
+++ b/test/core/storages/key_value_store.test.ts
@@ -356,26 +356,39 @@ describe('KeyValueStore', () => {
     });
 
     describe('round-trips through the real storage client (no content type)', () => {
-        test('object: setValue → getValue returns the same object', async () => {
+        test('object: setValue → getValue returns the same object, stored as application/json', async () => {
             const store = await KeyValueStore.open();
             const original = { foo: 'bar', n: 1 };
             await store.setValue('obj', original);
+
             await expect(store.getValue('obj')).resolves.toEqual(original);
+            const record = await store.getRecord('obj');
+            expect(record!.contentType).toBe('application/json; charset=utf-8');
         });
 
-        test('string: setValue → getValue returns the same string (not JSON-wrapped)', async () => {
+        test('string: setValue → getValue returns the same string, stored as text/plain (not JSON-wrapped)', async () => {
             const store = await KeyValueStore.open();
             await store.setValue('str', 'hello world');
+
             await expect(store.getValue('str')).resolves.toBe('hello world');
+            const record = await store.getRecord('str');
+            expect(record!.contentType).toBe('text/plain; charset=utf-8');
+            // Bytes are the raw string, not the JSON-wrapped `'"hello world"'` the old code produced.
+            expect(record!.value.toString()).toBe('hello world');
         });
 
-        test('Buffer: setValue → getValue returns the same Buffer (not JSON-mangled)', async () => {
+        test('Buffer: setValue → getValue returns the same Buffer, stored as octet-stream (not JSON-mangled)', async () => {
             const store = await KeyValueStore.open();
             const original = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
             await store.setValue('buf', original);
-            const got = await store.getValue('buf');
-            expect(Buffer.isBuffer(got)).toBe(true);
-            expect((got as Buffer).equals(original)).toBe(true);
+
+            const value = await store.getValue('buf');
+            expect(Buffer.isBuffer(value)).toBe(true);
+            expect((value as Buffer).equals(original)).toBe(true);
+
+            const record = await store.getRecord('buf');
+            expect(record!.contentType).toBe('application/octet-stream');
+            expect(record!.value.equals(original)).toBe(true);
         });
     });
 

--- a/test/core/storages/key_value_store.test.ts
+++ b/test/core/storages/key_value_store.test.ts
@@ -2,6 +2,7 @@ import { PassThrough } from 'node:stream';
 
 import { KeyValueStore, serviceLocator } from '@crawlee/core';
 import type { Dictionary } from '@crawlee/utils';
+import { toBuffer } from '@crawlee/utils';
 import { MemoryStorageEmulator } from '../../shared/MemoryStorageEmulator.js';
 
 const localStorageEmulator = new MemoryStorageEmulator();
@@ -388,7 +389,7 @@ describe('KeyValueStore', () => {
 
             const record = await store.getRecord('buf');
             expect(record!.contentType).toBe('application/octet-stream');
-            expect(record!.value.equals(original)).toBe(true);
+            expect(toBuffer(record!.value).equals(original)).toBe(true);
         });
     });
 
@@ -431,7 +432,7 @@ describe('KeyValueStore', () => {
             expect(record).not.toBeNull();
             expect(record!.contentType).toMatch(/^application\/json/);
             // Bytes are the serialized JSON, not the parsed object — the caller does the parsing.
-            const asText = Buffer.isBuffer(record!.value) ? record!.value.toString() : (record!.value as string);
+            const asText = toBuffer(record!.value).toString('utf-8');
             expect(JSON.parse(asText)).toEqual(original);
         });
 
@@ -444,7 +445,7 @@ describe('KeyValueStore', () => {
             const record = await store.getRecord('k');
             expect(record).not.toBeNull();
             expect(record!.contentType).toBe('application/json; charset=utf-8');
-            const asText = Buffer.isBuffer(record!.value) ? record!.value.toString() : (record!.value as string);
+            const asText = toBuffer(record!.value).toString('utf-8');
             expect(asText).toBe(preSerialized.toString());
         });
 

--- a/test/core/storages/key_value_store.test.ts
+++ b/test/core/storages/key_value_store.test.ts
@@ -183,7 +183,7 @@ describe('KeyValueStore', () => {
             );
 
             const valueErrMsg =
-                'The "value" parameter must be a String, Buffer or Stream when "options.contentType" is specified';
+                'The "value" parameter must be a String, Buffer, ArrayBuffer, TypedArray, or Stream when "options.contentType" is specified';
             await expect(store.setValue('key', {}, { contentType: 'image/png' })).rejects.toThrow(valueErrMsg);
             await expect(store.setValue('key', 12345, { contentType: 'image/png' })).rejects.toThrow(valueErrMsg);
             await expect(store.setValue('key', () => {}, { contentType: 'image/png' })).rejects.toThrow(valueErrMsg);
@@ -215,12 +215,12 @@ describe('KeyValueStore', () => {
 
             const contTypeRedundantErrMsg = 'Expected property string `contentType` to not be empty in object';
             await expect(store.setValue('key', null, { contentType: 'image/png' })).rejects.toThrow(
-                'The "value" parameter must be a String, Buffer or Stream when "options.contentType" is specified.',
+                'The "value" parameter must be a String, Buffer, ArrayBuffer, TypedArray, or Stream when "options.contentType" is specified.',
             );
             await expect(store.setValue('key', null, { contentType: '' })).rejects.toThrow(contTypeRedundantErrMsg);
             // @ts-expect-error Type '{}' is not assignable to type 'string'.
             await expect(store.setValue('key', null, { contentType: {} })).rejects.toThrow(
-                'The "value" parameter must be a String, Buffer or Stream when "options.contentType" is specified.',
+                'The "value" parameter must be a String, Buffer, ArrayBuffer, TypedArray, or Stream when "options.contentType" is specified.',
             );
 
             // @ts-expect-error Type 'number' is not assignable to type 'string'.

--- a/test/core/storages/key_value_store_codec.test.ts
+++ b/test/core/storages/key_value_store_codec.test.ts
@@ -78,11 +78,6 @@ describe('key_value_store_codec', () => {
             expect(parseValue(body, 'application/json; charset=utf-8')).toEqual({ foo: 'bar' });
         });
 
-        test('JSON5 features (trailing commas, comments)', () => {
-            const body = Buffer.from('{ foo: "bar", /* comment */ baz: 1, }');
-            expect(parseValue(body, 'application/json')).toEqual({ foo: 'bar', baz: 1 });
-        });
-
         test('text/* → string', () => {
             const body = Buffer.from('plain text');
             expect(parseValue(body, 'text/plain; charset=utf-8')).toBe('plain text');

--- a/test/core/storages/key_value_store_codec.test.ts
+++ b/test/core/storages/key_value_store_codec.test.ts
@@ -98,9 +98,14 @@ describe('key_value_store_codec', () => {
             expect(parseValue(body, 'text/plain; charset=not-a-real-charset')).toBe(body);
         });
 
+        test('null content type → raw buffer', () => {
+            const body = Buffer.from('text');
+            expect(parseValue(body, null)).toBe(body);
+        });
+
         test('unparseable content type header → raw buffer', () => {
             const body = Buffer.from('text');
-            expect(parseValue(body, '')).toBe(body);
+            expect(parseValue(body, 'this is not a valid header')).toBe(body);
         });
 
         test('ArrayBuffer input is decoded as UTF-8', () => {

--- a/test/core/storages/key_value_store_codec.test.ts
+++ b/test/core/storages/key_value_store_codec.test.ts
@@ -1,3 +1,5 @@
+import { Readable } from 'node:stream';
+
 import { parseValue, serializeValue } from '@crawlee/core';
 
 describe('key_value_store_codec', () => {
@@ -29,9 +31,9 @@ describe('key_value_store_codec', () => {
         });
 
         test('no content type + stream → octet-stream passthrough', () => {
-            const fakeStream = { pipe: () => {} };
-            const { value, contentType } = serializeValue(fakeStream);
-            expect(value).toBe(fakeStream);
+            const stream = Readable.from(Buffer.from('data'));
+            const { value, contentType } = serializeValue(stream);
+            expect(value).toBe(stream);
             expect(contentType).toBe('application/octet-stream');
         });
 

--- a/test/core/storages/key_value_store_codec.test.ts
+++ b/test/core/storages/key_value_store_codec.test.ts
@@ -1,0 +1,116 @@
+import { parseValue, serializeValue } from '@crawlee/core';
+
+describe('key_value_store_codec', () => {
+    describe('serializeValue()', () => {
+        test('no content type → JSON-serializes object and infers json content type', () => {
+            const { value, contentType } = serializeValue({ foo: 'bar' });
+            expect(value).toBe('{\n  "foo": "bar"\n}');
+            expect(contentType).toBe('application/json; charset=utf-8');
+        });
+
+        test('no content type → JSON-wraps strings (legacy behavior)', () => {
+            const { value, contentType } = serializeValue('xxx');
+            expect(value).toBe('"xxx"');
+            expect(contentType).toBe('application/json; charset=utf-8');
+        });
+
+        test('explicit content type → value passes through unchanged', () => {
+            const { value, contentType } = serializeValue('xxx', 'text/plain; charset=utf-8');
+            expect(value).toBe('xxx');
+            expect(contentType).toBe('text/plain; charset=utf-8');
+
+            const buf = Buffer.from('bytes');
+            const buffered = serializeValue(buf, 'image/jpeg');
+            expect(buffered.value).toBe(buf);
+            expect(buffered.contentType).toBe('image/jpeg');
+        });
+
+        test('"Object is too large" remap', () => {
+            const tooLong = {
+                toJSON() {
+                    throw new Error('Invalid string length');
+                },
+            };
+            expect(() => serializeValue(tooLong)).toThrow(
+                'The "value" parameter cannot be stringified to JSON: Object is too large',
+            );
+        });
+
+        test('circular structure error is surfaced', () => {
+            const obj: Record<string, unknown> = {};
+            obj.self = obj;
+            expect(() => serializeValue(obj)).toThrow(
+                'The "value" parameter cannot be stringified to JSON: Converting circular structure to JSON',
+            );
+        });
+
+        test('undefined-after-stringify guard', () => {
+            expect(() => serializeValue(undefined)).toThrow(
+                'The "value" parameter was stringified to JSON and returned undefined.',
+            );
+        });
+    });
+
+    describe('parseValue()', () => {
+        test('json content type → parsed object', () => {
+            const body = Buffer.from('{"foo":"bar"}');
+            expect(parseValue(body, 'application/json; charset=utf-8')).toEqual({ foo: 'bar' });
+        });
+
+        test('JSON5 features (trailing commas, comments)', () => {
+            const body = Buffer.from('{ foo: "bar", /* comment */ baz: 1, }');
+            expect(parseValue(body, 'application/json')).toEqual({ foo: 'bar', baz: 1 });
+        });
+
+        test('text/* → string', () => {
+            const body = Buffer.from('plain text');
+            expect(parseValue(body, 'text/plain; charset=utf-8')).toBe('plain text');
+        });
+
+        test('application/*xml → string', () => {
+            const body = Buffer.from('<root/>');
+            expect(parseValue(body, 'application/xml')).toBe('<root/>');
+        });
+
+        test('unknown content type → raw buffer', () => {
+            const body = Buffer.from([0, 1, 2, 3]);
+            expect(parseValue(body, 'application/octet-stream')).toBe(body);
+        });
+
+        test('unknown charset → raw buffer', () => {
+            const body = Buffer.from('text');
+            expect(parseValue(body, 'text/plain; charset=not-a-real-charset')).toBe(body);
+        });
+
+        test('unparseable content type header → raw buffer', () => {
+            const body = Buffer.from('text');
+            expect(parseValue(body, '')).toBe(body);
+        });
+
+        test('ArrayBuffer input is decoded as UTF-8', () => {
+            const source = Buffer.from('{"a":1}');
+            const arrayBuffer = source.buffer.slice(source.byteOffset, source.byteOffset + source.byteLength);
+            expect(parseValue(arrayBuffer, 'application/json')).toEqual({ a: 1 });
+        });
+    });
+
+    describe('round-trips', () => {
+        test('object → json → object', () => {
+            const original = { foo: 'bar', nested: { n: 1 } };
+            const { value, contentType } = serializeValue(original);
+            expect(parseValue(Buffer.from(value as string), contentType)).toEqual(original);
+        });
+
+        test('string → text → string', () => {
+            const original = 'hello world';
+            const { value, contentType } = serializeValue(original, 'text/plain; charset=utf-8');
+            expect(parseValue(Buffer.from(value as string), contentType)).toBe(original);
+        });
+
+        test('Buffer → octet-stream → Buffer', () => {
+            const original = Buffer.from([1, 2, 3, 4]);
+            const { value, contentType } = serializeValue(original, 'application/octet-stream');
+            expect(parseValue(value as Buffer, contentType)).toBe(original);
+        });
+    });
+});

--- a/test/core/storages/key_value_store_codec.test.ts
+++ b/test/core/storages/key_value_store_codec.test.ts
@@ -8,10 +8,31 @@ describe('key_value_store_codec', () => {
             expect(contentType).toBe('application/json; charset=utf-8');
         });
 
-        test('no content type → JSON-wraps strings (legacy behavior)', () => {
+        test('no content type + string → text/plain passthrough', () => {
             const { value, contentType } = serializeValue('xxx');
-            expect(value).toBe('"xxx"');
-            expect(contentType).toBe('application/json; charset=utf-8');
+            expect(value).toBe('xxx');
+            expect(contentType).toBe('text/plain; charset=utf-8');
+        });
+
+        test('no content type + Buffer → octet-stream passthrough', () => {
+            const buf = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
+            const { value, contentType } = serializeValue(buf);
+            expect(value).toBe(buf);
+            expect(contentType).toBe('application/octet-stream');
+        });
+
+        test('no content type + typed array → octet-stream passthrough', () => {
+            const u8 = new Uint8Array([1, 2, 3]);
+            const { value, contentType } = serializeValue(u8);
+            expect(value).toBe(u8);
+            expect(contentType).toBe('application/octet-stream');
+        });
+
+        test('no content type + stream → octet-stream passthrough', () => {
+            const fakeStream = { pipe: () => {} };
+            const { value, contentType } = serializeValue(fakeStream);
+            expect(value).toBe(fakeStream);
+            expect(contentType).toBe('application/octet-stream');
         });
 
         test('explicit content type → value passes through unchanged', () => {
@@ -111,6 +132,20 @@ describe('key_value_store_codec', () => {
             const original = Buffer.from([1, 2, 3, 4]);
             const { value, contentType } = serializeValue(original, 'application/octet-stream');
             expect(parseValue(value as Buffer, contentType)).toBe(original);
+        });
+
+        test('no content type: string round-trips as a string', () => {
+            const original = 'hello world';
+            const { value, contentType } = serializeValue(original);
+            expect(parseValue(Buffer.from(value as string), contentType)).toBe(original);
+        });
+
+        test('no content type: Buffer round-trips as a Buffer (not JSON-mangled)', () => {
+            const original = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
+            const { value, contentType } = serializeValue(original);
+            const parsed = parseValue(value as Buffer, contentType);
+            expect(Buffer.isBuffer(parsed)).toBe(true);
+            expect((parsed as Buffer).equals(original)).toBe(true);
         });
     });
 });

--- a/test/core/storages/key_value_store_fs_roundtrip.test.ts
+++ b/test/core/storages/key_value_store_fs_roundtrip.test.ts
@@ -52,6 +52,24 @@ describe('KeyValueStore frontend over FileSystemStorageClient (byte-transport co
         await expect(store.getValue('BYTES')).resolves.toStrictEqual(bytes);
     });
 
+    test('round-trips a typed array (with byteOffset) as the correct bytes', async () => {
+        const store = await KeyValueStore.open();
+        // A view into a larger buffer, so byteOffset / byteLength matter.
+        const backing = new Uint8Array([0x00, 0x11, 0x22, 0x33, 0x44]).buffer;
+        const view = new Uint8Array(backing, 1, 3); // -> [0x11, 0x22, 0x33]
+        await store.setValue('VIEW', view, { contentType: 'application/octet-stream' });
+
+        await expect(store.getValue('VIEW')).resolves.toStrictEqual(Buffer.from([0x11, 0x22, 0x33]));
+    });
+
+    test('round-trips an ArrayBuffer as the correct bytes', async () => {
+        const store = await KeyValueStore.open();
+        const buf = new Uint8Array([0x01, 0x02, 0x03]).buffer;
+        await store.setValue('AB', buf, { contentType: 'application/octet-stream' });
+
+        await expect(store.getValue('AB')).resolves.toStrictEqual(Buffer.from([0x01, 0x02, 0x03]));
+    });
+
     test('getRecord returns the raw bytes, not a parsed object', async () => {
         const store = await KeyValueStore.open();
         await store.setValue('OUTPUT', { foo: 'bar' });

--- a/test/core/storages/key_value_store_fs_roundtrip.test.ts
+++ b/test/core/storages/key_value_store_fs_roundtrip.test.ts
@@ -1,0 +1,78 @@
+import { resolve } from 'node:path';
+
+import { KeyValueStore, serviceLocator } from '@crawlee/core';
+import { FileSystemStorageClient } from '@crawlee/fs-storage';
+import { ensureDir, rm } from 'fs-extra';
+
+import { cryptoRandomObjectId } from '@apify/utilities';
+
+/**
+ * Regression guard for the "centralize KVS value semantics" refactor.
+ *
+ * The core unit tests run against {@link MemoryStorageEmulator}, so they never exercise the
+ * default {@link FileSystemStorageClient} backend. After moving serialize/parse into the
+ * `KeyValueStore` frontend, the backend must be a pure byte transport — if a backend still parses
+ * the body itself, the frontend would double-parse (`JSON5.parse("[object Object]")`) and throw.
+ *
+ * These tests wire the real frontend to the real fs-storage backend and assert a clean round-trip.
+ */
+describe('KeyValueStore frontend over FileSystemStorageClient (byte-transport contract)', () => {
+    const localStorageDir = resolve(import.meta.dirname, '..', 'tmp', 'fs-kvs-roundtrip', cryptoRandomObjectId(10));
+
+    beforeEach(async () => {
+        serviceLocator.reset();
+        await ensureDir(localStorageDir);
+        serviceLocator.setStorageClient(new FileSystemStorageClient({ localDataDirectory: localStorageDir }));
+    });
+
+    afterAll(async () => {
+        await rm(localStorageDir, { force: true, recursive: true });
+        serviceLocator.getStorageInstanceManager().clearCache();
+    });
+
+    test('round-trips a JSON object without double-parsing', async () => {
+        const store = await KeyValueStore.open();
+        await store.setValue('OUTPUT', { foo: 'bar', nested: { count: 42 } });
+
+        await expect(store.getValue('OUTPUT')).resolves.toEqual({ foo: 'bar', nested: { count: 42 } });
+    });
+
+    test('round-trips a string with an explicit content type', async () => {
+        const store = await KeyValueStore.open();
+        await store.setValue('TEXT', 'hello world', { contentType: 'text/plain; charset=utf-8' });
+
+        await expect(store.getValue('TEXT')).resolves.toBe('hello world');
+    });
+
+    test('round-trips a Buffer verbatim', async () => {
+        const store = await KeyValueStore.open();
+        const bytes = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
+        await store.setValue('BYTES', bytes, { contentType: 'application/octet-stream' });
+
+        await expect(store.getValue('BYTES')).resolves.toStrictEqual(bytes);
+    });
+
+    test('getRecord returns the raw bytes, not a parsed object', async () => {
+        const store = await KeyValueStore.open();
+        await store.setValue('OUTPUT', { foo: 'bar' });
+
+        const record = await store.getRecord('OUTPUT');
+        expect(record).not.toBeNull();
+        expect(Buffer.isBuffer(record!.value) || record!.value instanceof ArrayBuffer).toBe(true);
+        expect(JSON.parse(Buffer.from(record!.value as Buffer).toString('utf-8'))).toEqual({ foo: 'bar' });
+        expect(record!.contentType).toMatch(/application\/json/);
+    });
+
+    test('iterates JSON records via forEachKey without double-parsing', async () => {
+        const store = await KeyValueStore.open();
+        await store.setValue('a', { idx: 1 });
+        await store.setValue('b', { idx: 2 });
+
+        const seen: Record<string, unknown> = {};
+        await store.forEachKey(async (key) => {
+            seen[key] = await store.getValue(key);
+        });
+
+        expect(seen).toEqual({ a: { idx: 1 }, b: { idx: 2 } });
+    });
+});

--- a/test/shared/MemoryStorageEmulator.ts
+++ b/test/shared/MemoryStorageEmulator.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'node:path';
 
 import { MemoryStorageClient } from '@crawlee/memory-storage';
-import { Configuration, serviceLocator } from 'crawlee';
+import { Configuration, KeyValueStore, serviceLocator } from 'crawlee';
 import { ensureDir } from 'fs-extra';
 
 import log from '@apify/log';
@@ -77,8 +77,12 @@ export class MemoryStorageEmulator extends StorageEmulator {
         return this.storage.createKeyValueStoreClient(id ? { id } : { alias: '__default__' });
     }
 
-    async getState() {
-        return await (await this.getKeyValueStore()).getValue('CRAWLEE_STATE');
+    /**
+     * Reads the crawler state through the `KeyValueStore` frontend, so the JSON value is parsed for
+     * you (the raw client returns bytes — parsing is the frontend's job).
+     */
+    async getState<T = unknown>() {
+        return (await KeyValueStore.open()).getValue<T>('CRAWLEE_STATE');
     }
 }
 


### PR DESCRIPTION
`KeyValueStore` now owns serialize/parse; the storage clients (backends) are pure byte transports.

- New `key_value_store_codec.ts` (`serializeValue` + `parseValue`); removed `maybeStringify`.
- Frontend `getValue`/iterator parse, `setValue` serializes.
- Memory client no longer serializes/parses; deleted `body-parser.ts`.

Behavior-preserving. Read contract changes atomically across core + memory. fs-storage/apify clients deferred to #3762. Tests green.

- related to #3075
