### PR TITLE
test(e2e): use plain ApifyClient for platform result reads

### DIFF
--- a/test/e2e/tools.mjs
+++ b/test/e2e/tools.mjs
@@ -6,7 +6,7 @@ import { dirname, join } from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 import { fileURLToPath } from 'node:url';
 
-import { Actor } from 'apify';
+import { Actor, ApifyClient } from 'apify';
 import fs from 'fs-extra';
 import { got } from 'got';
 
@@ -166,7 +166,9 @@ export async function runActor(dirName, memory = 4096) {
     const contentType = input ? 'application/json' : undefined;
 
     if (process.env.STORAGE_IMPLEMENTATION === 'PLATFORM') {
-        const client = Actor.newClient();
+        // Plain client, not Actor.newClient(): the latter's charging-aware `.dataset()`
+        // throws unless Actor.init() ran, which it never does in this harness process.
+        const client = new ApifyClient({ token: process.env.APIFY_TOKEN });
         const id = await pushActor(client, dirName);
         const runId = await startActorOnPlatform(client, id, input, contentType, memory);
 


### PR DESCRIPTION
## What & why

The scheduled PLATFORM E2E run started failing on every dataset-reading test with `Error: ChargingManager is not initialized` ([example run](https://github.com/apify/crawlee/actions/runs/27999256469/job/82867849412)).

Root cause is an `apify` SDK change (3.7.2): `Actor.newClient()` now returns a charging-aware client whose `.dataset()` getter unconditionally calls `Actor.getChargingManager().getPricingInfo()`, which throws when the Actor was never initialized. The PLATFORM harness runs the Actor on the platform and never calls `Actor.init()` in the local process, so `client.dataset(...).listItems()` blew up.

The one PLATFORM test that doesn't read a dataset (`request-queue-with-concurrency`) kept passing, confirming the cause.

## Fix

Use a plain `ApifyClient` (re-exported by `apify`) for the read-only result-gathering path, bypassing the charging patch. `request-queue-with-concurrency` keeps using `Actor.newClient()` since it never touches a dataset.