### PR TITLE
fix(utils): use article:* selectors for article Open Graph properties

### DIFF
--- a/packages/utils/src/internals/open_graph_parser.ts
+++ b/packages/utils/src/internals/open_graph_parser.ts
@@ -268,32 +268,32 @@ const OPEN_GRAPH_PROPERTIES: OpenGraphProperty[] = [
         outputName: 'articleInfo',
         children: [
             {
-                name: 'music:published_time',
+                name: 'article:published_time',
                 outputName: 'publishedTime',
                 children: [],
             },
             {
-                name: 'music:modified_time',
+                name: 'article:modified_time',
                 outputName: 'modifiedTime',
                 children: [],
             },
             {
-                name: 'music:expiration_time',
+                name: 'article:expiration_time',
                 outputName: 'expirationTime',
                 children: [],
             },
             {
-                name: 'music:author',
+                name: 'article:author',
                 outputName: 'author',
                 children: [],
             },
             {
-                name: 'music:section',
+                name: 'article:section',
                 outputName: 'section',
                 children: [],
             },
             {
-                name: 'music:tag',
+                name: 'article:tag',
                 outputName: 'tag',
                 children: [],
             },

--- a/test/utils/open_graph_parser.test.ts
+++ b/test/utils/open_graph_parser.test.ts
@@ -21,6 +21,14 @@ describe('parseOpenGraph', () => {
     const case6 = `<meta property="og:title" content="My Website"/>
     <meta property="og:type" content="website"/>`;
 
+    const case7 = load(`<meta property="og:type" content="article"/>
+    <meta property="article:published_time" content="2024-01-01T00:00:00Z"/>
+    <meta property="article:modified_time" content="2024-01-02T00:00:00Z"/>
+    <meta property="article:expiration_time" content="2024-01-03T00:00:00Z"/>
+    <meta property="article:author" content="Jane Doe"/>
+    <meta property="article:section" content="Tech"/>
+    <meta property="article:tag" content="ai"/>`);
+
     it('Should scrape properties', () => {
         expect(parseOpenGraph(case1)).toEqual({
             title: 'Under Pressure',
@@ -75,6 +83,20 @@ describe('parseOpenGraph', () => {
         expect(parseOpenGraph(case6)).toEqual({
             title: 'My Website',
             type: 'website',
+        });
+    });
+
+    it('Should parse article properties into articleInfo', () => {
+        expect(parseOpenGraph(case7)).toEqual({
+            type: 'article',
+            articleInfo: {
+                publishedTime: '2024-01-01T00:00:00Z',
+                modifiedTime: '2024-01-02T00:00:00Z',
+                expirationTime: '2024-01-03T00:00:00Z',
+                author: 'Jane Doe',
+                section: 'Tech',
+                tag: 'ai',
+            },
         });
     });
 });


### PR DESCRIPTION
## What & why

In `parseOpenGraph()` (`@crawlee/utils`), the `article` Open Graph object (`outputName: 'articleInfo'`) declares all six of its child selectors with the `music:*` prefix instead of `article:*`. It looks like a copy-paste from the adjacent `music` block:

```ts
// packages/utils/src/internals/open_graph_parser.ts
{
    name: 'article',
    outputName: 'articleInfo',
    children: [
        { name: 'music:published_time',  outputName: 'publishedTime',  children: [] },
        { name: 'music:modified_time',   outputName: 'modifiedTime',   children: [] },
        { name: 'music:expiration_time', outputName: 'expirationTime', children: [] },
        { name: 'music:author',          outputName: 'author',         children: [] },
        { name: 'music:section',         outputName: 'section',        children: [] },
        { name: 'music:tag',             outputName: 'tag',            children: [] },
    ],
},
```

Two consequences:

1. Valid article metadata is silently dropped. A page with `<meta property="article:author">`, `article:published_time`, etc. produces **no** `articleInfo` at all.
2. Stray `music:author` / `music:section` tags get mis-attributed to `articleInfo` (and these aren't even valid Open Graph properties).

Per the [Open Graph protocol](https://ogp.me/), the `article` namespace (`https://ogp.me/ns/article#`) defines exactly `article:published_time`, `article:modified_time`, `article:expiration_time`, `article:author`, `article:section`, `article:tag`.

The `music` block itself is unaffected (it only declares `music:duration|album|musician|song|release_date|creator` and never these six names), so the fix is isolated and does not change music parsing.

## Fix

Change the six `article`-block child selectors from `music:*` to `article:*`, and add a test asserting an article page parses into `articleInfo` with all six fields. With the fix:

```ts
parseOpenGraph(`
  <meta property="og:type" content="article"/>
  <meta property="article:published_time" content="2024-01-01T00:00:00Z"/>
  <meta property="article:author" content="Jane Doe"/>
  <meta property="article:section" content="Tech"/>
  <meta property="article:tag" content="ai"/>
`)
// => { type: 'article', articleInfo: { publishedTime: '2024-01-01T00:00:00Z',
//        author: 'Jane Doe', section: 'Tech', tag: 'ai' } }
```
