### PR TITLE
test(e2e): de-flake puppeteer-ignore-ssl-errors

### DIFF
--- a/test/e2e/puppeteer-ignore-ssl-errors/actor/main.js
+++ b/test/e2e/puppeteer-ignore-ssl-errors/actor/main.js
@@ -11,6 +11,9 @@ const mainOptions = {
 
 await Actor.main(async () => {
     const crawler = new PuppeteerCrawler({
+        // Keep concurrency low so the burst of requests to badssl.com doesn't trip its
+        // rate limiting, which surfaces as ERR_CONNECTION_RESET and makes the test flaky.
+        maxConcurrency: 2,
         launchContext: { launchOptions: { acceptInsecureCerts: true } },
         preNavigationHooks: [
             (_ctx, goToOptions) => {

--- a/test/e2e/puppeteer-ignore-ssl-errors/test.mjs
+++ b/test/e2e/puppeteer-ignore-ssl-errors/test.mjs
@@ -5,6 +5,9 @@ await initialize(testActorDirname);
 
 const { stats, datasetItems } = await runActor(testActorDirname, 16384);
 
-await expect(stats.requestsFinished > 20, 'All requests finished');
-await expect(datasetItems.length > 20, 'Minimum number of dataset items');
+// Of badssl.com's ~31 "bad" links, ~10 use ciphers/protocols modern Chrome removed
+// (3des, rc4, dh*, null, …) and can never load regardless of acceptInsecureCerts, so the
+// ceiling is ~20. Assert a comfortable floor that still proves cert errors are bypassed.
+await expect(stats.requestsFinished > 10, 'All requests finished');
+await expect(datasetItems.length > 10, 'Minimum number of dataset items');
 await expect(validateDataset(datasetItems, ['url', 'title']), 'Dataset items validation');


### PR DESCRIPTION
## What & why

`puppeteer-ignore-ssl-errors` fails intermittently (it does *not* reproduce deterministically — the same commit passes on re-run; it's been flaking on master's scheduled E2E too).

Root cause is a too-tight assertion. The test crawls badssl.com's ~31 `.group a.bad` links and asserts `> 20` load. But ~10 of those use ciphers/protocols **modern Chrome removed entirely** (`3des`, `rc4`, `rc4-md5`, `null`, `dh480/512/1024`, `dh-composite`, `dh-small-subgroup`) and fail with `ERR_SSL_VERSION_OR_CIPHER_MISMATCH` regardless of `acceptInsecureCerts`. That caps the loadable set at ~20–22, so `> 20` has near-zero margin — any runner→badssl `ERR_CONNECTION_RESET` (rate limiting under load) tips it red.

## Changes

- **Cap `maxConcurrency: 2`** so the request burst doesn't trip badssl.com's rate limiting (the `ERR_CONNECTION_RESET` source).
- **Lower the thresholds to `> 10`** — a comfortable floor that still proves cert errors are bypassed. For reference, the `puppeteer-throw-on-ssl-errors` sibling shows only 5–9 of these links load under strict SSL, so `> 10` clearly demonstrates the `acceptInsecureCerts` path while leaving margin for transient resets.

The `cheerio-ignore-ssl-errors` test has the same `> 20` shape but runs over Node's TLS stack (different cipher support) and wasn't observed failing; left as-is to keep this scoped.