### PR TITLE
fix(utils): prevent sitemap metadata leak across url without loc

### DIFF
--- a/packages/utils/src/internals/sitemap.ts
+++ b/packages/utils/src/internals/sitemap.ts
@@ -136,8 +136,10 @@ class SitemapXmlParser extends Transform {
             this.currentTag = undefined;
         }
 
-        if (name === 'url' && this.url.loc !== undefined) {
-            this.push({ type: 'url', ...this.url, loc: this.url.loc } satisfies SitemapItem);
+        if (name === 'url') {
+            if (this.url.loc !== undefined) {
+                this.push({ type: 'url', ...this.url, loc: this.url.loc } satisfies SitemapItem);
+            }
             this.url = {};
         }
     }
@@ -157,7 +159,10 @@ class SitemapXmlParser extends Transform {
         text = text.trim();
 
         if (this.currentTag === 'lastmod') {
-            this.url.lastmod = new Date(text);
+            const lastmod = new Date(text);
+            if (!Number.isNaN(lastmod.getTime())) {
+                this.url.lastmod = lastmod;
+            }
         }
 
         if (this.currentTag === 'priority') {

--- a/packages/utils/test/sitemap.test.ts
+++ b/packages/utils/test/sitemap.test.ts
@@ -423,6 +423,39 @@ describe('Sitemap', () => {
         );
     });
 
+    it('does not leak metadata from a url without loc and drops invalid lastmod', async () => {
+        const items: SitemapUrl[] = [];
+
+        for await (const item of parseSitemap([
+            {
+                type: 'raw',
+                content: [
+                    '<?xml version="1.0" encoding="UTF-8"?>',
+                    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+                    '<url>',
+                    '<loc>http://not-exists.com/a</loc>',
+                    '<lastmod>not-a-date</lastmod>',
+                    '</url>',
+                    '<url>',
+                    '<lastmod>2020-01-01</lastmod>',
+                    '<priority>0.5</priority>',
+                    '</url>',
+                    '<url>',
+                    '<loc>http://not-exists.com/c</loc>',
+                    '</url>',
+                    '</urlset>',
+                ].join('\n'),
+            },
+        ])) {
+            items.push(item);
+        }
+
+        expect(items.map((item) => item.loc)).toEqual(['http://not-exists.com/a', 'http://not-exists.com/c']);
+        expect(items[0].lastmod).toBeUndefined();
+        expect(items[1].lastmod).toBeUndefined();
+        expect(items[1].priority).toBeUndefined();
+    });
+
     it('loads sitemaps that reference other sitemaps from string', async () => {
         const sitemap = await Sitemap.fromXmlString(
             [


### PR DESCRIPTION
### What

`SitemapXmlParser` in `packages/utils/src/internals/sitemap.ts` could leak per-url metadata from a malformed `<url>` block into the next one, and emitted `Invalid Date` for unparseable `<lastmod>` values. This fixes both.

### Why

1. **Metadata leak.** A `<url>` with no `<loc>` is correctly dropped, but `onCloseTag` only reset the `this.url` buffer when `loc` was present. So a loc-less `<url>` that carried `lastmod` / `priority` / `changefreq` left those values in the buffer, and they bled onto the next emitted url:

   ```diff
   - if (name === 'url' && this.url.loc !== undefined) {
   -     this.push({ type: 'url', ...this.url, loc: this.url.loc } satisfies SitemapItem);
   + if (name === 'url') {
   +     if (this.url.loc !== undefined) {
   +         this.push({ type: 'url', ...this.url, loc: this.url.loc } satisfies SitemapItem);
   +     }
         this.url = {};
     }
   ```

2. **Invalid lastmod.** `this.url.lastmod = new Date(text)` was set unconditionally, so junk like `<lastmod>not-a-date</lastmod>` produced an `Invalid Date` (its `.getTime()` is `NaN` and consumers calling `.toISOString()` throw). Now `lastmod` is only set when the parsed date is valid, mirroring how `changefreq` is already enum-guarded.

   ```diff
   - this.url.lastmod = new Date(text);
   + const lastmod = new Date(text);
   + if (!Number.isNaN(lastmod.getTime())) {
   +     this.url.lastmod = lastmod;
   + }
   ```

Well-formed sitemaps are unaffected; the buffer was already cleared for valid urls.

### Testing

Added one offline regression test to `packages/utils/test/sitemap.test.ts` using a `{ type: 'raw' }` urlset (no network): a url with an invalid `lastmod`, a loc-less url carrying `lastmod`/`priority`, then a bare url. It asserts only the two loc'd urls are emitted, the invalid `lastmod` is dropped, and no `lastmod`/`priority` leaks onto the following url. Fails on `master`, passes with the fix. Full `sitemap` suite: 30/30. `yarn lint` and `tsc -p packages/utils --noEmit` clean.

### Note

This mirrors the same metadata-leak fix I opened against the sibling crawlee-python repo (apify/crawlee-python#1992); the TS parser additionally needed the `lastmod` validity guard. Happy to file a tracking issue if you'd prefer one.
