### PR TITLE
fix: filter sitemap-derived URLs by enqueue strategy

### DIFF
--- a/packages/core/src/enqueue_links/enqueue_links.ts
+++ b/packages/core/src/enqueue_links/enqueue_links.ts
@@ -1,5 +1,5 @@
 import type { BatchAddRequestsResult, Dictionary } from '@crawlee/types';
-import { type RobotsTxtFile } from '@crawlee/utils';
+import { EnqueueStrategy, type RobotsTxtFile } from '@crawlee/utils';
 import ow from 'ow';
 import { getDomain } from 'tldts';
 import type { SetRequired } from 'type-fest';
@@ -30,6 +30,8 @@ import {
     createRequests,
     filterRequestsByPatterns,
 } from './shared';
+
+export { EnqueueStrategy };
 
 export interface EnqueueLinksOptions extends RequestQueueOperationOptions {
     /** Limit the amount of actually enqueued URLs to this number. Useful for testing across the entire crawling scope. */
@@ -197,61 +199,6 @@ export interface EnqueueLinksOptions extends RequestQueueOperationOptions {
      * 3. or because the maxRequestsPerCrawl limit has been reached
      */
     onSkippedRequest?: SkippedRequestCallback;
-}
-
-/**
- * The different enqueueing strategies available.
- *
- * Depending on the strategy you select, we will only check certain parts of the URLs found. Here is a diagram of each URL part and their name:
- *
- * ```md
- * Protocol          Domain
- * ┌────┐          ┌─────────┐
- * https://example.crawlee.dev/...
- * │       └─────────────────┤
- * │             Hostname    │
- * │                         │
- * └─────────────────────────┘
- *          Origin
- *```
- *
- * - The `Protocol` is usually `http` or `https`
- * - The `Domain` represents the path without any possible subdomains to a website. For example, `crawlee.dev` is the domain of `https://example.crawlee.dev/`
- * - The `Hostname` is the full path to a website, including any subdomains. For example, `example.crawlee.dev` is the hostname of `https://example.crawlee.dev/`
- * - The `Origin` is the combination of the `Protocol` and `Hostname`. For example, `https://example.crawlee.dev` is the origin of `https://example.crawlee.dev/`
- */
-export enum EnqueueStrategy {
-    /**
-     * Matches any URLs found
-     */
-    All = 'all',
-
-    /**
-     * Matches any URLs that have the same hostname.
-     * For example, `https://wow.example.com/hello` will be matched for a base url of `https://wow.example.com/`, but
-     * `https://example.com/hello` will not be matched.
-     *
-     * > This strategy will match both `http` and `https` protocols regardless of the base URL protocol.
-     */
-    SameHostname = 'same-hostname',
-
-    /**
-     * Matches any URLs that have the same domain as the base URL.
-     * For example, `https://wow.an.example.com` and `https://example.com` will both be matched for a base url of
-     * `https://example.com`.
-     *
-     * > This strategy will match both `http` and `https` protocols regardless of the base URL protocol.
-     */
-    SameDomain = 'same-domain',
-
-    /**
-     * Matches any URLs that have the same hostname and protocol.
-     * For example, `https://wow.example.com/hello` will be matched for a base url of `https://wow.example.com/`, but
-     * `http://wow.example.com/hello` will not be matched.
-     *
-     * > This strategy will ensure the protocol of the base URL is the same as the protocol of the URL to be enqueued.
-     */
-    SameOrigin = 'same-origin',
 }
 
 /**

--- a/packages/core/src/storages/sitemap_request_list.ts
+++ b/packages/core/src/storages/sitemap_request_list.ts
@@ -97,8 +97,8 @@ export interface SitemapRequestListOptions extends UrlConstraints {
     maxBufferSize?: number;
     /**
      * Keep only sitemap-derived URLs matching this strategy relative to the parent sitemap URL; non-`http(s)`
-     * schemes are always dropped. The strategy is also stamped onto emitted `Request`s, so it stays enforced
-     * after navigation (e.g. across redirects). Pass `'all'` to disable host filtering.
+     * schemes are always dropped. The filtering stays enforced after navigation (e.g. across redirects).
+     * Pass `'all'` to disable host filtering.
      * @default EnqueueStrategy.SameHostname
      */
     enqueueStrategy?: EnqueueStrategy | `${EnqueueStrategy}`;

--- a/packages/core/src/storages/sitemap_request_list.ts
+++ b/packages/core/src/storages/sitemap_request_list.ts
@@ -101,7 +101,7 @@ export interface SitemapRequestListOptions extends UrlConstraints {
      * after navigation (e.g. across redirects). Pass `'all'` to disable host filtering.
      * @default EnqueueStrategy.SameHostname
      */
-    enqueueStrategy?: EnqueueStrategy | 'all' | 'same-domain' | 'same-hostname' | 'same-origin';
+    enqueueStrategy?: EnqueueStrategy | `${EnqueueStrategy}`;
     /**
      * Advanced options for the underlying `parseSitemap` call.
      */
@@ -202,7 +202,7 @@ export class SitemapRequestList implements IRequestList {
     /**
      * Enqueue strategy applied to sitemap-derived URLs and stamped onto the emitted `Request` objects.
      */
-    private enqueueStrategy: EnqueueStrategy | 'all' | 'same-domain' | 'same-hostname' | 'same-origin';
+    private enqueueStrategy: EnqueueStrategy | `${EnqueueStrategy}`;
 
     /**
      * Logger instance.

--- a/packages/core/src/storages/sitemap_request_list.ts
+++ b/packages/core/src/storages/sitemap_request_list.ts
@@ -96,14 +96,9 @@ export interface SitemapRequestListOptions extends UrlConstraints {
      */
     maxBufferSize?: number;
     /**
-     * Strategy used to decide which sitemap-derived URLs (both nested `<sitemap><loc>` entries and
-     * `<url><loc>` entries) are kept relative to the parent sitemap URL. Defaults to `'same-hostname'`,
-     * matching the sitemaps protocol's same-host expectation and the `enqueueLinks` default. Pass `'all'`
-     * to disable host filtering, or `'same-domain'` / `'same-origin'` for other scopes.
-     *
-     * The selected strategy is also stamped onto the emitted `Request` objects, so it keeps being enforced
-     * after navigation (e.g. across redirects). Regardless of the strategy, entries with non-`http(s)`
-     * schemes are always filtered out.
+     * Keep only sitemap-derived URLs matching this strategy relative to the parent sitemap URL; non-`http(s)`
+     * schemes are always dropped. The strategy is also stamped onto emitted `Request`s, so it stays enforced
+     * after navigation (e.g. across redirects). Pass `'all'` to disable host filtering.
      * @default EnqueueStrategy.SameHostname
      */
     enqueueStrategy?: EnqueueStrategy | 'all' | 'same-domain' | 'same-hostname' | 'same-origin';

--- a/packages/core/src/storages/sitemap_request_list.ts
+++ b/packages/core/src/storages/sitemap_request_list.ts
@@ -9,7 +9,7 @@ import defaultLog from '@apify/log';
 
 import { Configuration } from '../configuration';
 import type { GlobInput, RegExpInput, UrlPatternObject } from '../enqueue_links';
-import { constructGlobObjectsFromGlobs, constructRegExpObjectsFromRegExps } from '../enqueue_links';
+import { constructGlobObjectsFromGlobs, constructRegExpObjectsFromRegExps, EnqueueStrategy } from '../enqueue_links';
 import { type EventManager, EventType } from '../events/event_manager';
 import { Request } from '../request';
 import { KeyValueStore } from './key_value_store';
@@ -95,6 +95,18 @@ export interface SitemapRequestListOptions extends UrlConstraints {
      * @default 200
      */
     maxBufferSize?: number;
+    /**
+     * Strategy used to decide which sitemap-derived URLs (both nested `<sitemap><loc>` entries and
+     * `<url><loc>` entries) are kept relative to the parent sitemap URL. Defaults to `'same-hostname'`,
+     * matching the sitemaps protocol's same-host expectation and the `enqueueLinks` default. Pass `'all'`
+     * to disable host filtering, or `'same-domain'` / `'same-origin'` for other scopes.
+     *
+     * The selected strategy is also stamped onto the emitted `Request` objects, so it keeps being enforced
+     * after navigation (e.g. across redirects). Regardless of the strategy, entries with non-`http(s)`
+     * schemes are always filtered out.
+     * @default EnqueueStrategy.SameHostname
+     */
+    enqueueStrategy?: EnqueueStrategy | 'all' | 'same-domain' | 'same-hostname' | 'same-origin';
     /**
      * Advanced options for the underlying `parseSitemap` call.
      */
@@ -193,6 +205,11 @@ export class SitemapRequestList implements IRequestList {
     private proxyUrl: string | undefined;
 
     /**
+     * Enqueue strategy applied to sitemap-derived URLs and stamped onto the emitted `Request` objects.
+     */
+    private enqueueStrategy: EnqueueStrategy | 'all' | 'same-domain' | 'same-hostname' | 'same-origin';
+
+    /**
      * Logger instance.
      */
     private log = defaultLog.child({ prefix: 'SitemapRequestList' });
@@ -216,6 +233,7 @@ export class SitemapRequestList implements IRequestList {
                 signal: ow.optional.any(),
                 timeoutMillis: ow.optional.number,
                 maxBufferSize: ow.optional.number,
+                enqueueStrategy: ow.optional.string.oneOf(Object.values(EnqueueStrategy)),
                 parseSitemapOptions: ow.optional.object,
                 globs: ow.optional.array.ofType(ow.any(ow.string, ow.object.hasKeys('glob'))),
                 exclude: ow.optional.array.ofType(
@@ -251,6 +269,7 @@ export class SitemapRequestList implements IRequestList {
         this.persistenceOptions = { enable: true, ...options.persistenceOptions };
 
         this.proxyUrl = options.proxyUrl;
+        this.enqueueStrategy = options.enqueueStrategy ?? EnqueueStrategy.SameHostname;
 
         this.urlQueueStream = this.createNewStream(options.maxBufferSize ?? 200);
 
@@ -382,6 +401,7 @@ export class SitemapRequestList implements IRequestList {
                     ...parseSitemapOptions,
                     maxDepth: 0,
                     emitNestedSitemaps: true,
+                    enqueueStrategy: this.enqueueStrategy,
                 })) {
                     if (!item.originSitemapUrl) {
                         // This is a nested sitemap
@@ -561,7 +581,7 @@ export class SitemapRequestList implements IRequestList {
             if (!nextUrl) {
                 return null;
             }
-            this.requestData.set(nextUrl, new Request({ url: nextUrl }));
+            this.requestData.set(nextUrl, new Request({ url: nextUrl, enqueueStrategy: this.enqueueStrategy }));
         }
 
         this.inProgress.add(nextUrl);

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -57,6 +57,7 @@
         "ow": "^0.28.1",
         "robots-parser": "^3.0.1",
         "sax": "^1.4.1",
+        "tldts": "^7.0.0",
         "tslib": "^2.4.0",
         "whatwg-mimetype": "^4.0.0"
     },

--- a/packages/utils/src/internals/robots.ts
+++ b/packages/utils/src/internals/robots.ts
@@ -7,9 +7,18 @@ import log from '@apify/log';
 
 import { gotScraping } from './gotScraping';
 import { Sitemap } from './sitemap';
-import { type EnqueueStrategyValue, filterUrl } from './url';
+import { type EnqueueStrategy, filterUrl } from './url';
 
 let HTTPError: typeof HTTPErrorClass;
+
+export interface RobotsTxtFileSitemapsOptions {
+    /**
+     * Keep only sitemap URLs matching this strategy relative to the robots.txt host; non-`http(s)` schemes
+     * are always dropped. Pass `'all'` to disable host filtering.
+     * @default 'same-hostname'
+     */
+    enqueueStrategy?: EnqueueStrategy | `${EnqueueStrategy}`;
+}
 
 /**
  * Loads and queries information from a [robots.txt file](https://en.wikipedia.org/wiki/Robots.txt).
@@ -115,10 +124,12 @@ export class RobotsTxtFile {
     }
 
     /**
-     * Get URLs of sitemaps referenced in the robots file, filtered by `enqueueStrategy` relative to the
-     * robots.txt host (default `'same-hostname'`; pass `'all'` to disable). Non-`http(s)` schemes are always dropped.
+     * Get URLs of sitemaps referenced in the robots file, filtered by `options.enqueueStrategy` relative to
+     * the robots.txt host (default `'same-hostname'`; pass `'all'` to disable). Non-`http(s)` schemes are
+     * always dropped.
      */
-    getSitemaps(enqueueStrategy: EnqueueStrategyValue = 'same-hostname'): string[] {
+    getSitemaps(options: RobotsTxtFileSitemapsOptions = {}): string[] {
+        const { enqueueStrategy = 'same-hostname' } = options;
         const sitemaps: string[] = [];
 
         for (const sitemapUrl of this.robots.getSitemaps()) {
@@ -135,19 +146,19 @@ export class RobotsTxtFile {
     }
 
     /**
-     * Parse all the sitemaps referenced in the robots file. `enqueueStrategy` is forwarded to `getSitemaps`
+     * Parse all the sitemaps referenced in the robots file. `options` are forwarded to `getSitemaps`
      * and the sitemap parser.
      */
-    async parseSitemaps(enqueueStrategy: EnqueueStrategyValue = 'same-hostname'): Promise<Sitemap> {
-        return Sitemap.load(this.getSitemaps(enqueueStrategy), this.proxyUrl, { enqueueStrategy });
+    async parseSitemaps(options: RobotsTxtFileSitemapsOptions = {}): Promise<Sitemap> {
+        return Sitemap.load(this.getSitemaps(options), this.proxyUrl, options);
     }
 
     /**
      * Get all URLs from all the sitemaps referenced in the robots file. A shorthand for `(await robots.parseSitemaps()).urls`.
-     * `enqueueStrategy` is forwarded to `parseSitemaps`.
+     * `options` are forwarded to `parseSitemaps`.
      */
-    async parseUrlsFromSitemaps(enqueueStrategy: EnqueueStrategyValue = 'same-hostname'): Promise<string[]> {
-        return (await this.parseSitemaps(enqueueStrategy)).urls;
+    async parseUrlsFromSitemaps(options: RobotsTxtFileSitemapsOptions = {}): Promise<string[]> {
+        return (await this.parseSitemaps(options)).urls;
     }
 }
 

--- a/packages/utils/src/internals/robots.ts
+++ b/packages/utils/src/internals/robots.ts
@@ -122,7 +122,7 @@ export class RobotsTxtFile {
         const sitemaps: string[] = [];
 
         for (const sitemapUrl of this.robots.getSitemaps()) {
-            // Pass `this.url` as a string so `filterUrl` tolerates a bad origin instead of throwing.
+            // `filterUrl` tolerates an unparseable origin (returns not-allowed) rather than throwing.
             const { allowed, reason } = filterUrl(sitemapUrl, this.url, enqueueStrategy);
             if (!allowed) {
                 log.warning(`Skipping sitemap ${sitemapUrl} listed in robots.txt at ${this.url}: ${reason}.`);

--- a/packages/utils/src/internals/robots.ts
+++ b/packages/utils/src/internals/robots.ts
@@ -115,12 +115,8 @@ export class RobotsTxtFile {
     }
 
     /**
-     * Get URLs of sitemaps referenced in the robots file.
-     *
-     * @param enqueueStrategy Strategy used to filter sitemap entries relative to the robots.txt URL's host.
-     *   Defaults to `'same-hostname'`, matching the sitemaps protocol's same-host expectation; pass `'all'`
-     *   to disable host filtering. Regardless of the strategy, entries with non-`http(s)` schemes are always
-     *   filtered out.
+     * Get URLs of sitemaps referenced in the robots file, filtered by `enqueueStrategy` relative to the
+     * robots.txt host (default `'same-hostname'`; pass `'all'` to disable). Non-`http(s)` schemes are always dropped.
      */
     getSitemaps(enqueueStrategy: EnqueueStrategyValue = 'same-hostname'): string[] {
         const origin = new URL(this.url);
@@ -139,10 +135,8 @@ export class RobotsTxtFile {
     }
 
     /**
-     * Parse all the sitemaps referenced in the robots file.
-     *
-     * @param enqueueStrategy Forwarded to {@apilink RobotsTxtFile.getSitemaps|`getSitemaps`} and to the
-     *   sitemap parser; see `getSitemaps` for details.
+     * Parse all the sitemaps referenced in the robots file. `enqueueStrategy` is forwarded to `getSitemaps`
+     * and the sitemap parser.
      */
     async parseSitemaps(enqueueStrategy: EnqueueStrategyValue = 'same-hostname'): Promise<Sitemap> {
         return Sitemap.load(this.getSitemaps(enqueueStrategy), this.proxyUrl, { enqueueStrategy });
@@ -150,9 +144,7 @@ export class RobotsTxtFile {
 
     /**
      * Get all URLs from all the sitemaps referenced in the robots file. A shorthand for `(await robots.parseSitemaps()).urls`.
-     *
-     * @param enqueueStrategy Forwarded to {@apilink RobotsTxtFile.parseSitemaps|`parseSitemaps`}; see
-     *   {@apilink RobotsTxtFile.getSitemaps|`getSitemaps`} for details.
+     * `enqueueStrategy` is forwarded to `parseSitemaps`.
      */
     async parseUrlsFromSitemaps(enqueueStrategy: EnqueueStrategyValue = 'same-hostname'): Promise<string[]> {
         return (await this.parseSitemaps(enqueueStrategy)).urls;

--- a/packages/utils/src/internals/robots.ts
+++ b/packages/utils/src/internals/robots.ts
@@ -119,11 +119,11 @@ export class RobotsTxtFile {
      * robots.txt host (default `'same-hostname'`; pass `'all'` to disable). Non-`http(s)` schemes are always dropped.
      */
     getSitemaps(enqueueStrategy: EnqueueStrategyValue = 'same-hostname'): string[] {
-        const origin = new URL(this.url);
         const sitemaps: string[] = [];
 
         for (const sitemapUrl of this.robots.getSitemaps()) {
-            const { allowed, reason } = filterUrl(sitemapUrl, origin, enqueueStrategy);
+            // Pass `this.url` as a string so `filterUrl` tolerates a bad origin instead of throwing.
+            const { allowed, reason } = filterUrl(sitemapUrl, this.url, enqueueStrategy);
             if (!allowed) {
                 log.warning(`Skipping sitemap ${sitemapUrl} listed in robots.txt at ${this.url}: ${reason}.`);
                 continue;

--- a/packages/utils/src/internals/robots.ts
+++ b/packages/utils/src/internals/robots.ts
@@ -3,8 +3,11 @@ import type { HTTPError as HTTPErrorClass } from 'got-scraping';
 import type { Robot } from 'robots-parser';
 import robotsParser from 'robots-parser';
 
+import log from '@apify/log';
+
 import { gotScraping } from './gotScraping';
 import { Sitemap } from './sitemap';
+import { type EnqueueStrategyValue, filterUrl } from './url';
 
 let HTTPError: typeof HTTPErrorClass;
 
@@ -28,6 +31,7 @@ let HTTPError: typeof HTTPErrorClass;
  */
 export class RobotsTxtFile {
     private constructor(
+        private url: string,
         private robots: Pick<Robot, 'isAllowed' | 'getSitemaps'>,
         private proxyUrl?: string,
     ) {}
@@ -59,7 +63,7 @@ export class RobotsTxtFile {
      * @param [proxyUrl] a proxy to be used for fetching the robots.txt file
      */
     static from(url: string, content: string, proxyUrl?: string): RobotsTxtFile {
-        return new RobotsTxtFile(robotsParser(url, content), proxyUrl);
+        return new RobotsTxtFile(url, robotsParser(url, content), proxyUrl);
     }
 
     protected static async load(
@@ -81,10 +85,11 @@ export class RobotsTxtFile {
                 ...(options?.timeoutMillis ? { timeout: { request: options.timeoutMillis } } : {}),
             });
 
-            return new RobotsTxtFile(robotsParser(url.toString(), response.body), proxyUrl);
+            return new RobotsTxtFile(url, robotsParser(url.toString(), response.body), proxyUrl);
         } catch (e) {
             if (e instanceof HTTPError && e.response.statusCode === 404) {
                 return new RobotsTxtFile(
+                    url,
                     {
                         isAllowed() {
                             return true;
@@ -111,23 +116,46 @@ export class RobotsTxtFile {
 
     /**
      * Get URLs of sitemaps referenced in the robots file.
+     *
+     * @param enqueueStrategy Strategy used to filter sitemap entries relative to the robots.txt URL's host.
+     *   Defaults to `'same-hostname'`, matching the sitemaps protocol's same-host expectation; pass `'all'`
+     *   to disable host filtering. Regardless of the strategy, entries with non-`http(s)` schemes are always
+     *   filtered out.
      */
-    getSitemaps(): string[] {
-        return this.robots.getSitemaps();
+    getSitemaps(enqueueStrategy: EnqueueStrategyValue = 'same-hostname'): string[] {
+        const origin = new URL(this.url);
+        const sitemaps: string[] = [];
+
+        for (const sitemapUrl of this.robots.getSitemaps()) {
+            const { allowed, reason } = filterUrl(sitemapUrl, origin, enqueueStrategy);
+            if (!allowed) {
+                log.warning(`Skipping sitemap ${sitemapUrl} listed in robots.txt at ${this.url}: ${reason}.`);
+                continue;
+            }
+            sitemaps.push(sitemapUrl);
+        }
+
+        return sitemaps;
     }
 
     /**
      * Parse all the sitemaps referenced in the robots file.
+     *
+     * @param enqueueStrategy Forwarded to {@apilink RobotsTxtFile.getSitemaps|`getSitemaps`} and to the
+     *   sitemap parser; see `getSitemaps` for details.
      */
-    async parseSitemaps(): Promise<Sitemap> {
-        return Sitemap.load(this.robots.getSitemaps(), this.proxyUrl);
+    async parseSitemaps(enqueueStrategy: EnqueueStrategyValue = 'same-hostname'): Promise<Sitemap> {
+        return Sitemap.load(this.getSitemaps(enqueueStrategy), this.proxyUrl, { enqueueStrategy });
     }
 
     /**
      * Get all URLs from all the sitemaps referenced in the robots file. A shorthand for `(await robots.parseSitemaps()).urls`.
+     *
+     * @param enqueueStrategy Forwarded to {@apilink RobotsTxtFile.parseSitemaps|`parseSitemaps`}; see
+     *   {@apilink RobotsTxtFile.getSitemaps|`getSitemaps`} for details.
      */
-    async parseUrlsFromSitemaps(): Promise<string[]> {
-        return (await this.parseSitemaps()).urls;
+    async parseUrlsFromSitemaps(enqueueStrategy: EnqueueStrategyValue = 'same-hostname'): Promise<string[]> {
+        return (await this.parseSitemaps(enqueueStrategy)).urls;
     }
 }
 

--- a/packages/utils/src/internals/sitemap.ts
+++ b/packages/utils/src/internals/sitemap.ts
@@ -358,6 +358,10 @@ export async function* parseSitemap<T extends ParseSitemapOptions>(
             continue;
         }
 
+        // URL entries dropped by the enqueue strategy filter, reported in one warning per sitemap after
+        // the loop (per-entry warnings could flood the log; individual drops are logged at debug level).
+        let droppedUrlEntries = 0;
+
         for await (const item of items) {
             if (item.type === 'sitemapUrl' && !visitedSitemapUrls.has(item.url)) {
                 if (nestedSitemapFilter && !nestedSitemapFilter(item.url)) {
@@ -386,6 +390,7 @@ export async function* parseSitemap<T extends ParseSitemapOptions>(
                 if (source.type === 'url') {
                     const { allowed, reason } = filterUrl(item.loc, sitemapUrl!, enqueueStrategy);
                     if (!allowed) {
+                        droppedUrlEntries++;
                         log.debug(`Skipping sitemap URL ${item.loc} (parent ${source.url}): ${reason}.`);
                         continue;
                     }
@@ -399,6 +404,12 @@ export async function* parseSitemap<T extends ParseSitemapOptions>(
                             : `raw://${createHash('sha256').update(source.content).digest('base64')}`,
                 };
             }
+        }
+
+        if (droppedUrlEntries > 0 && source.type === 'url') {
+            log.warning(
+                `Skipped ${droppedUrlEntries} URL(s) from sitemap ${source.url} not matching enqueue strategy '${enqueueStrategy}' (or using a non-http(s) scheme). Enable debug logs to see each skipped URL.`,
+            );
         }
     }
 }

--- a/packages/utils/src/internals/sitemap.ts
+++ b/packages/utils/src/internals/sitemap.ts
@@ -263,8 +263,11 @@ export async function* parseSitemap<T extends ParseSitemapOptions>(
 
         let items: AsyncIterable<SitemapItem> | null = null;
 
+        // Parent URL, parsed once and reused as the origin for the strategy checks below.
+        let sitemapUrl: URL | undefined;
+
         if (source.type === 'url') {
-            const sitemapUrl = new URL(source.url);
+            sitemapUrl = new URL(source.url);
             visitedSitemapUrls.add(sitemapUrl.toString());
             let retriesLeft = sitemapRetries + 1;
 
@@ -365,7 +368,7 @@ export async function* parseSitemap<T extends ParseSitemapOptions>(
                 // Keep only nested sitemaps matching the strategy (and using http(s)) relative to the
                 // parent. Raw string sources have no parent URL, so the check is skipped.
                 if (source.type === 'url') {
-                    const { allowed, reason } = filterUrl(item.url, source.url, enqueueStrategy);
+                    const { allowed, reason } = filterUrl(item.url, sitemapUrl!, enqueueStrategy);
                     if (!allowed) {
                         log.warning(`Skipping nested sitemap ${item.url} (parent ${source.url}): ${reason}.`);
                         continue;
@@ -381,7 +384,7 @@ export async function* parseSitemap<T extends ParseSitemapOptions>(
             if (item.type === 'url') {
                 // Keep only URL entries that match the enqueue strategy relative to the parent (see above).
                 if (source.type === 'url') {
-                    const { allowed, reason } = filterUrl(item.loc, source.url, enqueueStrategy);
+                    const { allowed, reason } = filterUrl(item.loc, sitemapUrl!, enqueueStrategy);
                     if (!allowed) {
                         log.debug(`Skipping sitemap URL ${item.loc} (parent ${source.url}): ${reason}.`);
                         continue;
@@ -569,7 +572,8 @@ export async function* discoverValidSitemaps(
                 timeoutMillis: requestTimeoutMillis,
                 signal,
             });
-            for (const sitemapUrl of robotsFile.getSitemaps()) {
+            // Surface all referenced sitemaps, including cross-host; scoping happens at load time.
+            for (const sitemapUrl of robotsFile.getSitemaps('all')) {
                 if (addSitemapUrl(sitemapUrl)) {
                     yield sitemapUrl;
                 }

--- a/packages/utils/src/internals/sitemap.ts
+++ b/packages/utils/src/internals/sitemap.ts
@@ -13,7 +13,7 @@ import log from '@apify/log';
 
 import { mergeAsyncIterables } from './iterables';
 import { RobotsFile } from './robots';
-import { type EnqueueStrategyValue, filterUrl } from './url';
+import { type EnqueueStrategy, filterUrl } from './url';
 
 interface SitemapUrlData {
     loc: string;
@@ -208,7 +208,7 @@ export interface ParseSitemapOptions {
      * sources (no parent URL). Pass `'all'` to disable host filtering.
      * @default 'same-hostname'
      */
-    enqueueStrategy?: EnqueueStrategyValue;
+    enqueueStrategy?: EnqueueStrategy | `${EnqueueStrategy}`;
 }
 
 export async function* parseSitemap<T extends ParseSitemapOptions>(
@@ -584,7 +584,7 @@ export async function* discoverValidSitemaps(
                 signal,
             });
             // Surface all referenced sitemaps, including cross-host; scoping happens at load time.
-            for (const sitemapUrl of robotsFile.getSitemaps('all')) {
+            for (const sitemapUrl of robotsFile.getSitemaps({ enqueueStrategy: 'all' })) {
                 if (addSitemapUrl(sitemapUrl)) {
                     yield sitemapUrl;
                 }

--- a/packages/utils/src/internals/sitemap.ts
+++ b/packages/utils/src/internals/sitemap.ts
@@ -13,6 +13,7 @@ import log from '@apify/log';
 
 import { mergeAsyncIterables } from './iterables';
 import { RobotsFile } from './robots';
+import { type EnqueueStrategyValue, filterUrl } from './url';
 
 interface SitemapUrlData {
     loc: string;
@@ -201,6 +202,17 @@ export interface ParseSitemapOptions {
      * If not provided, all nested sitemaps are followed.
      */
     nestedSitemapFilter?: (sitemapUrl: string) => boolean;
+    /**
+     * Strategy used to decide which sitemap-derived URLs (both nested `<sitemap><loc>` entries and
+     * `<url><loc>` entries) are kept relative to the parent sitemap URL. Defaults to `'same-hostname'`,
+     * matching the sitemaps protocol's same-host expectation and the `enqueueLinks` default. Pass `'all'`
+     * to disable host filtering, or `'same-domain'` / `'same-origin'` for other scopes.
+     *
+     * Regardless of the strategy, entries with non-`http(s)` schemes are always filtered out. The filter
+     * only applies to URL sources (it is skipped for raw string content, which has no parent URL).
+     * @default 'same-hostname'
+     */
+    enqueueStrategy?: EnqueueStrategyValue;
 }
 
 export async function* parseSitemap<T extends ParseSitemapOptions>(
@@ -217,6 +229,7 @@ export async function* parseSitemap<T extends ParseSitemapOptions>(
         networkTimeouts,
         reportNetworkErrors = true,
         nestedSitemapFilter,
+        enqueueStrategy = 'same-hostname',
     } = options ?? {};
 
     const sources = [...initialSources];
@@ -353,6 +366,17 @@ export async function* parseSitemap<T extends ParseSitemapOptions>(
                     continue;
                 }
 
+                // Keep only nested sitemaps that match the enqueue strategy (and use an http(s) scheme)
+                // relative to the parent sitemap URL. Raw string sources have no parent URL, so the
+                // check is skipped for them.
+                if (source.type === 'url') {
+                    const { allowed, reason } = filterUrl(item.url, source.url, enqueueStrategy);
+                    if (!allowed) {
+                        log.warning(`Skipping nested sitemap ${item.url} (parent ${source.url}): ${reason}.`);
+                        continue;
+                    }
+                }
+
                 sources.push({ type: 'url', url: item.url, depth: (source.depth ?? 0) + 1 });
                 if (emitNestedSitemaps) {
                     yield { loc: item.url, originSitemapUrl: null } as any;
@@ -360,6 +384,15 @@ export async function* parseSitemap<T extends ParseSitemapOptions>(
             }
 
             if (item.type === 'url') {
+                // Keep only URL entries that match the enqueue strategy relative to the parent (see above).
+                if (source.type === 'url') {
+                    const { allowed, reason } = filterUrl(item.loc, source.url, enqueueStrategy);
+                    if (!allowed) {
+                        log.debug(`Skipping sitemap URL ${item.loc} (parent ${source.url}): ${reason}.`);
+                        continue;
+                    }
+                }
+
                 yield {
                     ...item,
                     originSitemapUrl:

--- a/packages/utils/src/internals/sitemap.ts
+++ b/packages/utils/src/internals/sitemap.ts
@@ -203,13 +203,9 @@ export interface ParseSitemapOptions {
      */
     nestedSitemapFilter?: (sitemapUrl: string) => boolean;
     /**
-     * Strategy used to decide which sitemap-derived URLs (both nested `<sitemap><loc>` entries and
-     * `<url><loc>` entries) are kept relative to the parent sitemap URL. Defaults to `'same-hostname'`,
-     * matching the sitemaps protocol's same-host expectation and the `enqueueLinks` default. Pass `'all'`
-     * to disable host filtering, or `'same-domain'` / `'same-origin'` for other scopes.
-     *
-     * Regardless of the strategy, entries with non-`http(s)` schemes are always filtered out. The filter
-     * only applies to URL sources (it is skipped for raw string content, which has no parent URL).
+     * Keep only sitemap-derived URLs (nested `<sitemap>` and `<url>` entries) matching this strategy
+     * relative to the parent sitemap URL; non-`http(s)` schemes are always dropped. Skipped for raw string
+     * sources (no parent URL). Pass `'all'` to disable host filtering.
      * @default 'same-hostname'
      */
     enqueueStrategy?: EnqueueStrategyValue;
@@ -366,9 +362,8 @@ export async function* parseSitemap<T extends ParseSitemapOptions>(
                     continue;
                 }
 
-                // Keep only nested sitemaps that match the enqueue strategy (and use an http(s) scheme)
-                // relative to the parent sitemap URL. Raw string sources have no parent URL, so the
-                // check is skipped for them.
+                // Keep only nested sitemaps matching the strategy (and using http(s)) relative to the
+                // parent. Raw string sources have no parent URL, so the check is skipped.
                 if (source.type === 'url') {
                     const { allowed, reason } = filterUrl(item.url, source.url, enqueueStrategy);
                     if (!allowed) {

--- a/packages/utils/src/internals/url.ts
+++ b/packages/utils/src/internals/url.ts
@@ -2,13 +2,7 @@ import { getDomain } from 'tldts';
 
 export type SearchParams = string | URLSearchParams | Record<string, string | number | boolean | null | undefined>;
 
-/**
- * The enqueue strategy values used to decide whether a target URL is eligible relative to an origin URL.
- *
- * These mirror the string values of the `EnqueueStrategy` enum from `@crawlee/core`. The strategy
- * matching lives here (in the lower-level `@crawlee/utils` package) so that the sitemap and `robots.txt`
- * helpers can apply it without depending on `@crawlee/core`.
- */
+/** Enqueue strategy values, mirroring the `EnqueueStrategy` enum from `@crawlee/core` (which `@crawlee/utils` can't import). */
 export type EnqueueStrategyValue = 'all' | 'same-hostname' | 'same-domain' | 'same-origin';
 
 /** Reusable suffix for log messages explaining why a non-`http(s)` URL was rejected. */
@@ -56,18 +50,8 @@ export function matchesEnqueueStrategy(strategy: EnqueueStrategyValue, target: U
 }
 
 /**
- * Check whether `target` is eligible to be enqueued under `strategy` relative to `origin`.
- *
- * Combines the two checks every enqueue site needs: the URL must use a supported scheme (`http` or
- * `https`), and it must match `strategy` relative to `origin`. Callers that need to distinguish a
- * scheme rejection from a strategy mismatch can compare the returned reason against
- * {@apilink UNSUPPORTED_SCHEME_MESSAGE}.
- *
- * @param target The URL being evaluated.
- * @param origin The reference URL the target is compared against.
- * @param strategy The enqueue strategy to apply.
- * @returns `{ allowed: true }` if `target` is eligible, otherwise `{ allowed: false, reason }` where
- *   `reason` is a human-readable rejection message suitable for log output.
+ * Check whether `target` may be enqueued under `strategy` relative to `origin`: it must use an `http(s)`
+ * scheme and match the strategy. On rejection, `reason` is a human-readable message for log output.
  */
 export function filterUrl(
     target: string | URL,

--- a/packages/utils/src/internals/url.ts
+++ b/packages/utils/src/internals/url.ts
@@ -30,6 +30,10 @@ function normalizeHostname(hostname: string): string {
 /**
  * Check whether `target` matches `origin` under the given enqueue `strategy`. The URL scheme is not
  * considered here (use {@apilink filterUrl} for the combined scheme + strategy check).
+ *
+ * Reimplements the `EnqueueStrategy` semantics of `@crawlee/core` (which matches via glob patterns in
+ * `packages/core/src/enqueue_links/enqueue_links.ts` and can't be imported from here) as a boolean
+ * predicate — keep the two in sync when changing either.
  */
 export function matchesEnqueueStrategy(strategy: EnqueueStrategyValue, target: URL, origin: URL): boolean {
     switch (strategy) {
@@ -76,7 +80,11 @@ export function filterUrl(
 
     const originUrl = toUrl(origin);
 
-    if (originUrl === null || !matchesEnqueueStrategy(strategy, targetUrl, originUrl)) {
+    if (originUrl === null) {
+        return { allowed: false, reason: 'invalid origin URL' };
+    }
+
+    if (!matchesEnqueueStrategy(strategy, targetUrl, originUrl)) {
         return { allowed: false, reason: `does not match enqueue strategy '${strategy}'` };
     }
 

--- a/packages/utils/src/internals/url.ts
+++ b/packages/utils/src/internals/url.ts
@@ -2,8 +2,60 @@ import { getDomain } from 'tldts';
 
 export type SearchParams = string | URLSearchParams | Record<string, string | number | boolean | null | undefined>;
 
-/** Enqueue strategy values, mirroring the `EnqueueStrategy` enum from `@crawlee/core` (which `@crawlee/utils` can't import). */
-export type EnqueueStrategyValue = 'all' | 'same-hostname' | 'same-domain' | 'same-origin';
+/**
+ * The different enqueueing strategies available.
+ *
+ * Depending on the strategy you select, we will only check certain parts of the URLs found. Here is a diagram of each URL part and their name:
+ *
+ * ```md
+ * Protocol          Domain
+ * ┌────┐          ┌─────────┐
+ * https://example.crawlee.dev/...
+ * │       └─────────────────┤
+ * │             Hostname    │
+ * │                         │
+ * └─────────────────────────┘
+ *          Origin
+ *```
+ *
+ * - The `Protocol` is usually `http` or `https`
+ * - The `Domain` represents the path without any possible subdomains to a website. For example, `crawlee.dev` is the domain of `https://example.crawlee.dev/`
+ * - The `Hostname` is the full path to a website, including any subdomains. For example, `example.crawlee.dev` is the hostname of `https://example.crawlee.dev/`
+ * - The `Origin` is the combination of the `Protocol` and `Hostname`. For example, `https://example.crawlee.dev` is the origin of `https://example.crawlee.dev/`
+ */
+export enum EnqueueStrategy {
+    /**
+     * Matches any URLs found
+     */
+    All = 'all',
+
+    /**
+     * Matches any URLs that have the same hostname.
+     * For example, `https://wow.example.com/hello` will be matched for a base url of `https://wow.example.com/`, but
+     * `https://example.com/hello` will not be matched.
+     *
+     * > This strategy will match both `http` and `https` protocols regardless of the base URL protocol.
+     */
+    SameHostname = 'same-hostname',
+
+    /**
+     * Matches any URLs that have the same domain as the base URL.
+     * For example, `https://wow.an.example.com` and `https://example.com` will both be matched for a base url of
+     * `https://example.com`.
+     *
+     * > This strategy will match both `http` and `https` protocols regardless of the base URL protocol.
+     */
+    SameDomain = 'same-domain',
+
+    /**
+     * Matches any URLs that have the same hostname and protocol.
+     * For example, `https://wow.example.com/hello` will be matched for a base url of `https://wow.example.com/`, but
+     * `http://wow.example.com/hello` will not be matched.
+     *
+     * > This strategy will ensure the protocol of the base URL is the same as the protocol of the URL to be enqueued.
+     */
+    SameOrigin = 'same-origin',
+}
 
 /** Reusable suffix for log messages explaining why a non-`http(s)` URL was rejected. */
 export const UNSUPPORTED_SCHEME_MESSAGE = 'unsupported URL scheme (only http and https are allowed)';
@@ -31,11 +83,14 @@ function normalizeHostname(hostname: string): string {
  * Check whether `target` matches `origin` under the given enqueue `strategy`. The URL scheme is not
  * considered here (use {@apilink filterUrl} for the combined scheme + strategy check).
  *
- * Reimplements the `EnqueueStrategy` semantics of `@crawlee/core` (which matches via glob patterns in
- * `packages/core/src/enqueue_links/enqueue_links.ts` and can't be imported from here) as a boolean
- * predicate — keep the two in sync when changing either.
+ * The `enqueueLinks` implementation in `@crawlee/core` matches the same strategies via glob patterns
+ * (see `packages/core/src/enqueue_links/enqueue_links.ts`) — keep the two in sync when changing either.
  */
-export function matchesEnqueueStrategy(strategy: EnqueueStrategyValue, target: URL, origin: URL): boolean {
+export function matchesEnqueueStrategy(
+    strategy: EnqueueStrategy | `${EnqueueStrategy}`,
+    target: URL,
+    origin: URL,
+): boolean {
     switch (strategy) {
         case 'all':
             return true;
@@ -70,7 +125,7 @@ export function matchesEnqueueStrategy(strategy: EnqueueStrategyValue, target: U
 export function filterUrl(
     target: string | URL,
     origin: string | URL,
-    strategy: EnqueueStrategyValue,
+    strategy: EnqueueStrategy | `${EnqueueStrategy}`,
 ): { allowed: boolean; reason?: string } {
     const targetUrl = toUrl(target);
 

--- a/packages/utils/src/internals/url.ts
+++ b/packages/utils/src/internals/url.ts
@@ -22,6 +22,11 @@ function toUrl(value: string | URL): URL | null {
     }
 }
 
+/** Strip a trailing dot so `example.com.` equals `example.com`. */
+function normalizeHostname(hostname: string): string {
+    return hostname.endsWith('.') ? hostname.slice(0, -1) : hostname;
+}
+
 /**
  * Check whether `target` matches `origin` under the given enqueue `strategy`. The URL scheme is not
  * considered here (use {@apilink filterUrl} for the combined scheme + strategy check).
@@ -31,7 +36,7 @@ export function matchesEnqueueStrategy(strategy: EnqueueStrategyValue, target: U
         case 'all':
             return true;
         case 'same-hostname':
-            return target.hostname === origin.hostname;
+            return normalizeHostname(target.hostname) === normalizeHostname(origin.hostname);
         case 'same-domain': {
             const originDomain = getDomain(origin.hostname, { mixedInputs: false });
 
@@ -43,9 +48,14 @@ export function matchesEnqueueStrategy(strategy: EnqueueStrategyValue, target: U
             return target.origin === origin.origin;
         }
         case 'same-origin':
-            return target.origin === origin.origin;
+            // Compare scheme/host/port directly so a trailing-dot host is normalized.
+            return (
+                target.protocol === origin.protocol &&
+                normalizeHostname(target.hostname) === normalizeHostname(origin.hostname) &&
+                target.port === origin.port
+            );
         default:
-            return false;
+            throw new Error(`Unknown enqueue strategy '${strategy satisfies never}'.`);
     }
 }
 

--- a/packages/utils/src/internals/url.ts
+++ b/packages/utils/src/internals/url.ts
@@ -1,4 +1,93 @@
+import { getDomain } from 'tldts';
+
 export type SearchParams = string | URLSearchParams | Record<string, string | number | boolean | null | undefined>;
+
+/**
+ * The enqueue strategy values used to decide whether a target URL is eligible relative to an origin URL.
+ *
+ * These mirror the string values of the `EnqueueStrategy` enum from `@crawlee/core`. The strategy
+ * matching lives here (in the lower-level `@crawlee/utils` package) so that the sitemap and `robots.txt`
+ * helpers can apply it without depending on `@crawlee/core`.
+ */
+export type EnqueueStrategyValue = 'all' | 'same-hostname' | 'same-domain' | 'same-origin';
+
+/** Reusable suffix for log messages explaining why a non-`http(s)` URL was rejected. */
+export const UNSUPPORTED_SCHEME_MESSAGE = 'unsupported URL scheme (only http and https are allowed)';
+
+const ALLOWED_SCHEMES = new Set(['http:', 'https:']);
+
+function toUrl(value: string | URL): URL | null {
+    if (value instanceof URL) {
+        return value;
+    }
+
+    try {
+        return new URL(value);
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Check whether `target` matches `origin` under the given enqueue `strategy`. The URL scheme is not
+ * considered here (use {@apilink filterUrl} for the combined scheme + strategy check).
+ */
+export function matchesEnqueueStrategy(strategy: EnqueueStrategyValue, target: URL, origin: URL): boolean {
+    switch (strategy) {
+        case 'all':
+            return true;
+        case 'same-hostname':
+            return target.hostname === origin.hostname;
+        case 'same-domain': {
+            const originDomain = getDomain(origin.hostname, { mixedInputs: false });
+
+            if (originDomain) {
+                return originDomain === getDomain(target.hostname, { mixedInputs: false });
+            }
+
+            // No registrable domain (e.g. an IP address), fall back to comparing origins.
+            return target.origin === origin.origin;
+        }
+        case 'same-origin':
+            return target.origin === origin.origin;
+        default:
+            return false;
+    }
+}
+
+/**
+ * Check whether `target` is eligible to be enqueued under `strategy` relative to `origin`.
+ *
+ * Combines the two checks every enqueue site needs: the URL must use a supported scheme (`http` or
+ * `https`), and it must match `strategy` relative to `origin`. Callers that need to distinguish a
+ * scheme rejection from a strategy mismatch can compare the returned reason against
+ * {@apilink UNSUPPORTED_SCHEME_MESSAGE}.
+ *
+ * @param target The URL being evaluated.
+ * @param origin The reference URL the target is compared against.
+ * @param strategy The enqueue strategy to apply.
+ * @returns `{ allowed: true }` if `target` is eligible, otherwise `{ allowed: false, reason }` where
+ *   `reason` is a human-readable rejection message suitable for log output.
+ */
+export function filterUrl(
+    target: string | URL,
+    origin: string | URL,
+    strategy: EnqueueStrategyValue,
+): { allowed: boolean; reason?: string } {
+    const targetUrl = toUrl(target);
+
+    if (targetUrl === null || !ALLOWED_SCHEMES.has(targetUrl.protocol)) {
+        return { allowed: false, reason: UNSUPPORTED_SCHEME_MESSAGE };
+    }
+
+    const originUrl = toUrl(origin);
+
+    if (originUrl === null || !matchesEnqueueStrategy(strategy, targetUrl, originUrl)) {
+        return { allowed: false, reason: `does not match enqueue strategy '${strategy}'` };
+    }
+
+    return { allowed: true };
+}
 
 /**
  * Appends search (query string) parameters to a URL, replacing the original value (if any).

--- a/packages/utils/test/robots.test.ts
+++ b/packages/utils/test/robots.test.ts
@@ -99,6 +99,32 @@ describe('RobotsTxtFile', () => {
         expect(end - start).toBeLessThanOrEqual(500);
     });
 
+    it('drops cross-host and non-http(s) sitemap directives under the default same-hostname strategy', () => {
+        const content = [
+            'User-agent: *',
+            'Sitemap: http://not-exists.com/legit.xml',
+            'Sitemap: http://other.test/cross.xml',
+            'Sitemap: mailto:foo@bar.com',
+            'Sitemap: ftp://not-exists.com/cross.xml',
+        ].join('\n');
+        const robots = RobotsTxtFile.from('http://not-exists.com/robots.txt', content);
+        expect(robots.getSitemaps()).toEqual(['http://not-exists.com/legit.xml']);
+    });
+
+    it('keeps cross-host http sitemaps but still drops non-http(s) ones with enqueueStrategy "all"', () => {
+        const content = [
+            'User-agent: *',
+            'Sitemap: http://not-exists.com/legit.xml',
+            'Sitemap: http://other.test/cross.xml',
+            'Sitemap: mailto:foo@bar.com',
+            'Sitemap: ftp://not-exists.com/cross.xml',
+        ].join('\n');
+        const robots = RobotsTxtFile.from('http://not-exists.com/robots.txt', content);
+        expect(new Set(robots.getSitemaps('all'))).toEqual(
+            new Set(['http://not-exists.com/legit.xml', 'http://other.test/cross.xml']),
+        );
+    });
+
     it('parses allow/deny directives from explicitly provided robots.txt contents', async () => {
         const contents = `User-agent: *',
 Disallow: *deny_all/

--- a/packages/utils/test/robots.test.ts
+++ b/packages/utils/test/robots.test.ts
@@ -125,6 +125,12 @@ describe('RobotsTxtFile', () => {
         );
     });
 
+    it('getSitemaps does not throw when the robots.txt url is not absolute', () => {
+        // A non-absolute url must not crash getSitemaps().
+        const robots = RobotsTxtFile.from('not-exists.com/robots.txt', 'Sitemap: http://not-exists.com/legit.xml');
+        expect(() => robots.getSitemaps()).not.toThrow();
+    });
+
     it('parses allow/deny directives from explicitly provided robots.txt contents', async () => {
         const contents = `User-agent: *',
 Disallow: *deny_all/

--- a/packages/utils/test/robots.test.ts
+++ b/packages/utils/test/robots.test.ts
@@ -120,7 +120,7 @@ describe('RobotsTxtFile', () => {
             'Sitemap: ftp://not-exists.com/cross.xml',
         ].join('\n');
         const robots = RobotsTxtFile.from('http://not-exists.com/robots.txt', content);
-        expect(new Set(robots.getSitemaps('all'))).toEqual(
+        expect(new Set(robots.getSitemaps({ enqueueStrategy: 'all' }))).toEqual(
             new Set(['http://not-exists.com/legit.xml', 'http://other.test/cross.xml']),
         );
     });

--- a/packages/utils/test/sitemap.test.ts
+++ b/packages/utils/test/sitemap.test.ts
@@ -217,6 +217,60 @@ describe('Sitemap', () => {
                     'http://not-exists.com/catalog?item=79&desc=vacation_somalia',
                 ].join('\n'),
             )
+            // urlset mixing a same-host and a cross-host URL entry (for enqueue-strategy filtering)
+            .get('/cross_host_urls.xml')
+            .reply(
+                200,
+                [
+                    '<?xml version="1.0" encoding="UTF-8"?>',
+                    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+                    '<url><loc>http://not-exists.com/local-page</loc></url>',
+                    '<url><loc>http://other.test/cross-page</loc></url>',
+                    '</urlset>',
+                ].join('\n'),
+            )
+            // sitemap index pointing at a cross-host nested sitemap
+            .get('/cross_host_index.xml')
+            .reply(
+                200,
+                [
+                    '<?xml version="1.0" encoding="UTF-8"?>',
+                    '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+                    '<sitemap><loc>http://other.test/child.xml</loc></sitemap>',
+                    '</sitemapindex>',
+                ].join('\n'),
+            )
+            // urlset mixing a valid http URL with non-http(s) schemes
+            .get('/bad_schemes.xml')
+            .reply(
+                200,
+                [
+                    '<?xml version="1.0" encoding="UTF-8"?>',
+                    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+                    '<url><loc>http://not-exists.com/ok</loc></url>',
+                    '<url><loc>mailto:foo@bar.com</loc></url>',
+                    '<url><loc>javascript:alert(1)</loc></url>',
+                    '<url><loc>ftp://example.com/file.txt</loc></url>',
+                    '</urlset>',
+                ].join('\n'),
+            )
+            .get('*')
+            .reply(404);
+
+        // A cross-host server. Its child sitemap is served so that a *followed* nested reference would
+        // surface `child-page`; under the default `same-hostname` strategy it must never be fetched.
+        nock('http://other.test')
+            .persist()
+            .get('/child.xml')
+            .reply(
+                200,
+                [
+                    '<?xml version="1.0" encoding="UTF-8"?>',
+                    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+                    '<url><loc>http://other.test/child-page</loc></url>',
+                    '</urlset>',
+                ].join('\n'),
+            )
             .get('*')
             .reply(404);
 
@@ -474,6 +528,40 @@ describe('Sitemap', () => {
                 'http://not-exists.com/catalog?item=83&desc=vacation_usa',
             ]),
         );
+    });
+
+    it('drops cross-host URL entries under the default same-hostname strategy', async () => {
+        const sitemap = await Sitemap.load('http://not-exists.com/cross_host_urls.xml');
+        expect(sitemap.urls).toEqual(['http://not-exists.com/local-page']);
+    });
+
+    it('keeps cross-host URL entries when enqueueStrategy is "all"', async () => {
+        const sitemap = await Sitemap.load('http://not-exists.com/cross_host_urls.xml', undefined, {
+            enqueueStrategy: 'all',
+        });
+        expect(new Set(sitemap.urls)).toEqual(
+            new Set(['http://not-exists.com/local-page', 'http://other.test/cross-page']),
+        );
+    });
+
+    it('does not fetch cross-host nested sitemaps under the default same-hostname strategy', async () => {
+        const sitemap = await Sitemap.load('http://not-exists.com/cross_host_index.xml');
+        // If the cross-host nested sitemap were fetched, `child-page` would appear in the result.
+        expect(sitemap.urls).toEqual([]);
+    });
+
+    it('follows cross-host nested sitemaps when enqueueStrategy is "all"', async () => {
+        const sitemap = await Sitemap.load('http://not-exists.com/cross_host_index.xml', undefined, {
+            enqueueStrategy: 'all',
+        });
+        expect(sitemap.urls).toEqual(['http://other.test/child-page']);
+    });
+
+    it('drops non-http(s) scheme entries even when enqueueStrategy is "all"', async () => {
+        const sitemap = await Sitemap.load('http://not-exists.com/bad_schemes.xml', undefined, {
+            enqueueStrategy: 'all',
+        });
+        expect(sitemap.urls).toEqual(['http://not-exists.com/ok']);
     });
 });
 

--- a/packages/utils/test/sitemap.test.ts
+++ b/packages/utils/test/sitemap.test.ts
@@ -257,8 +257,8 @@ describe('Sitemap', () => {
             .get('*')
             .reply(404);
 
-        // A cross-host server. Its child sitemap is served so that a *followed* nested reference would
-        // surface `child-page`; under the default `same-hostname` strategy it must never be fetched.
+        // A cross-host server whose child sitemap is served, so a *followed* nested reference would surface
+        // `child-page`. Under the default `same-hostname` strategy it must never be fetched.
         nock('http://other.test')
             .persist()
             .get('/child.xml')

--- a/packages/utils/test/sitemap.test.ts
+++ b/packages/utils/test/sitemap.test.ts
@@ -596,6 +596,26 @@ describe('discoverValidSitemaps', () => {
         expect(urls).toEqual(['http://sitemap-discovery.com/some-sitemap.xml']);
     });
 
+    it('discovers cross-host sitemaps referenced in robots.txt', async () => {
+        nock('http://sitemap-discovery.com')
+            .get('/robots.txt')
+            .reply(200, 'Sitemap: http://cdn.other-host.com/some-sitemap.xml')
+            .head('/sitemap.xml')
+            .reply(404, '')
+            .head('/sitemap.txt')
+            .reply(404, '')
+            .head('/sitemap_index.xml')
+            .reply(404, '');
+
+        const urls = [];
+        for await (const url of discoverValidSitemaps(['http://sitemap-discovery.com'])) {
+            urls.push(url);
+        }
+
+        // Cross-host sitemap is surfaced; host scoping is applied at load time.
+        expect(urls).toEqual(['http://cdn.other-host.com/some-sitemap.xml']);
+    });
+
     it('extracts sitemap from well-known paths if robots.txt is missing', async () => {
         nock('http://sitemap-discovery.com')
             .get('/robots.txt')

--- a/packages/utils/test/sitemap.test.ts
+++ b/packages/utils/test/sitemap.test.ts
@@ -535,6 +535,17 @@ describe('Sitemap', () => {
         expect(sitemap.urls).toEqual(['http://not-exists.com/local-page']);
     });
 
+    it('logs one aggregated warning per sitemap for dropped URL entries', async () => {
+        const spy = vi.spyOn(log, 'warning');
+
+        await Sitemap.load('http://not-exists.com/cross_host_urls.xml');
+
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith(
+            expect.stringContaining('Skipped 1 URL(s) from sitemap http://not-exists.com/cross_host_urls.xml'),
+        );
+    });
+
     it('keeps cross-host URL entries when enqueueStrategy is "all"', async () => {
         const sitemap = await Sitemap.load('http://not-exists.com/cross_host_urls.xml', undefined, {
             enqueueStrategy: 'all',

--- a/packages/utils/test/url.test.ts
+++ b/packages/utils/test/url.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { filterUrl, matchesEnqueueStrategy } from '../src/internals/url';
+
+describe('matchesEnqueueStrategy', () => {
+    const match = (strategy: Parameters<typeof matchesEnqueueStrategy>[0], target: string, origin: string) =>
+        matchesEnqueueStrategy(strategy, new URL(target), new URL(origin));
+
+    it('all matches regardless of host, domain, or scheme', () => {
+        expect(match('all', 'https://other.test/page', 'http://example.com/sitemap.xml')).toBe(true);
+    });
+
+    it('same-hostname matches only the exact host', () => {
+        expect(match('same-hostname', 'http://example.com/a', 'http://example.com/sitemap.xml')).toBe(true);
+        expect(match('same-hostname', 'http://www.example.com/a', 'http://example.com/sitemap.xml')).toBe(false);
+    });
+
+    it('same-domain matches across subdomains but not across registrable domains', () => {
+        expect(match('same-domain', 'http://www.example.com/a', 'http://example.com/sitemap.xml')).toBe(true);
+        expect(match('same-domain', 'http://example.org/a', 'http://example.com/sitemap.xml')).toBe(false);
+    });
+
+    it('same-origin requires matching scheme, host, and port', () => {
+        expect(match('same-origin', 'http://example.com/a', 'http://example.com/sitemap.xml')).toBe(true);
+        expect(match('same-origin', 'https://example.com/a', 'http://example.com/sitemap.xml')).toBe(false);
+    });
+
+    it('treats a trailing-dot FQDN host as equal to the bare host across strategies', () => {
+        for (const strategy of ['same-hostname', 'same-domain', 'same-origin'] as const) {
+            expect(match(strategy, 'http://example.com./page', 'http://example.com/sitemap.xml')).toBe(true);
+        }
+    });
+});
+
+describe('filterUrl', () => {
+    it('drops non-http(s) schemes regardless of strategy', () => {
+        for (const target of ['mailto:foo@bar.com', 'ftp://example.com/f.txt']) {
+            expect(filterUrl(target, 'http://example.com/sitemap.xml', 'all').allowed).toBe(false);
+        }
+    });
+
+    it('drops gracefully (no throw) when the origin is not parseable', () => {
+        expect(() => filterUrl('http://example.com/a', 'not-a-url', 'same-hostname')).not.toThrow();
+        expect(filterUrl('http://example.com/a', 'not-a-url', 'same-hostname').allowed).toBe(false);
+    });
+});

--- a/packages/utils/test/url.test.ts
+++ b/packages/utils/test/url.test.ts
@@ -41,6 +41,9 @@ describe('filterUrl', () => {
 
     it('drops gracefully (no throw) when the origin is not parseable', () => {
         expect(() => filterUrl('http://example.com/a', 'not-a-url', 'same-hostname')).not.toThrow();
-        expect(filterUrl('http://example.com/a', 'not-a-url', 'same-hostname').allowed).toBe(false);
+        expect(filterUrl('http://example.com/a', 'not-a-url', 'same-hostname')).toEqual({
+            allowed: false,
+            reason: 'invalid origin URL',
+        });
     });
 });

--- a/test/core/sitemap_request_list.test.ts
+++ b/test/core/sitemap_request_list.test.ts
@@ -195,9 +195,8 @@ beforeAll(async () => {
     });
 
     // --- Fixtures for the enqueue-strategy filtering tests ---
-    // The server is reachable both as `localhost` and `127.0.0.1`, which are distinct hostnames. We use
-    // the `127.0.0.1` variant as a reachable "cross-host" target, so the tests can tell a dropped entry
-    // (never fetched) apart from one that was fetched but failed.
+    // The server answers on both `localhost` and `127.0.0.1` (distinct hostnames), so the `127.0.0.1`
+    // variant is a reachable "cross-host" target — a dropped entry is distinguishable from a failed fetch.
 
     // urlset mixing a same-host and a cross-host URL entry
     app.get('/cross-host-content.xml', async (req, res) => {
@@ -337,7 +336,10 @@ describe('SitemapRequestList', () => {
     });
 
     test('teardown works', async () => {
-        const list = await SitemapRequestList.open({ sitemapUrls: [`${url}/sitemap-index.xml`], enqueueStrategy: 'all' });
+        const list = await SitemapRequestList.open({
+            sitemapUrls: [`${url}/sitemap-index.xml`],
+            enqueueStrategy: 'all',
+        });
 
         for await (const request of list) {
             await list.markRequestHandled(request);
@@ -395,7 +397,10 @@ describe('SitemapRequestList', () => {
     });
 
     test('draining the request list between sitemaps', async () => {
-        const list = await SitemapRequestList.open({ sitemapUrls: [`${url}/sitemap-index.xml`], enqueueStrategy: 'all' });
+        const list = await SitemapRequestList.open({
+            sitemapUrls: [`${url}/sitemap-index.xml`],
+            enqueueStrategy: 'all',
+        });
 
         while (await list.isEmpty()) {
             await sleep(20);
@@ -430,7 +435,10 @@ describe('SitemapRequestList', () => {
     });
 
     test('for..await syntax works with SitemapRequestList', async () => {
-        const list = await SitemapRequestList.open({ sitemapUrls: [`${url}/sitemap-index.xml`], enqueueStrategy: 'all' });
+        const list = await SitemapRequestList.open({
+            sitemapUrls: [`${url}/sitemap-index.xml`],
+            enqueueStrategy: 'all',
+        });
 
         for await (const request of list) {
             await list.markRequestHandled(request);
@@ -622,8 +630,7 @@ describe('SitemapRequestList', () => {
         const restoredRequest = await newList.fetchNextRequest();
 
         expect(restoredRequest!.url).toEqual(firstLoadedUrl);
-        // `toMatchObject` (not `toEqual`): the request also carries internal `__crawlee` bookkeeping
-        // (the stamped enqueue strategy), so we assert the user payload round-trips rather than exact equality.
+        // `toMatchObject` (not `toEqual`): the request also carries internal `__crawlee` bookkeeping (the stamped strategy).
         expect(restoredRequest!.userData).toMatchObject(userDataPayload);
     });
 

--- a/test/core/sitemap_request_list.test.ts
+++ b/test/core/sitemap_request_list.test.ts
@@ -193,6 +193,70 @@ beforeAll(async () => {
 
         res.end();
     });
+
+    // --- Fixtures for the enqueue-strategy filtering tests ---
+    // The server is reachable both as `localhost` and `127.0.0.1`, which are distinct hostnames. We use
+    // the `127.0.0.1` variant as a reachable "cross-host" target, so the tests can tell a dropped entry
+    // (never fetched) apart from one that was fetched but failed.
+
+    // urlset mixing a same-host and a cross-host URL entry
+    app.get('/cross-host-content.xml', async (req, res) => {
+        const cross = url.replace('localhost', '127.0.0.1');
+        res.setHeader('content-type', 'text/xml');
+        res.end(
+            [
+                '<?xml version="1.0" encoding="UTF-8"?>',
+                '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+                `<url><loc>${url}/same-host-page</loc></url>`,
+                `<url><loc>${cross}/cross-host-page</loc></url>`,
+                '</urlset>',
+            ].join('\n'),
+        );
+    });
+
+    // sitemap index pointing at a cross-host nested sitemap
+    app.get('/cross-host-index.xml', async (req, res) => {
+        const cross = url.replace('localhost', '127.0.0.1');
+        res.setHeader('content-type', 'text/xml');
+        res.end(
+            [
+                '<?xml version="1.0" encoding="UTF-8"?>',
+                '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+                `<sitemap><loc>${cross}/cross-host-child.xml</loc></sitemap>`,
+                '</sitemapindex>',
+            ].join('\n'),
+        );
+    });
+
+    // nested sitemap referenced by the cross-host index; its URL appears only if the index is followed
+    app.get('/cross-host-child.xml', async (req, res) => {
+        const cross = url.replace('localhost', '127.0.0.1');
+        res.setHeader('content-type', 'text/xml');
+        res.end(
+            [
+                '<?xml version="1.0" encoding="UTF-8"?>',
+                '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+                `<url><loc>${cross}/child-page</loc></url>`,
+                '</urlset>',
+            ].join('\n'),
+        );
+    });
+
+    // urlset mixing a valid http URL with non-http(s) schemes
+    app.get('/mixed-scheme.xml', async (req, res) => {
+        res.setHeader('content-type', 'text/xml');
+        res.end(
+            [
+                '<?xml version="1.0" encoding="UTF-8"?>',
+                '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+                `<url><loc>${url}/ok</loc></url>`,
+                '<url><loc>mailto:foo@bar.com</loc></url>',
+                '<url><loc>javascript:alert(1)</loc></url>',
+                '<url><loc>ftp://example.com/file.txt</loc></url>',
+                '</urlset>',
+            ].join('\n'),
+        );
+    });
 });
 
 afterAll(async () => {
@@ -212,7 +276,10 @@ afterAll(async () => {
 
 describe('SitemapRequestList', () => {
     test('requests are available before the sitemap is fully loaded', async () => {
-        const list = await SitemapRequestList.open({ sitemapUrls: [`${url}/sitemap-stream.xml`] });
+        const list = await SitemapRequestList.open({
+            sitemapUrls: [`${url}/sitemap-stream.xml`],
+            enqueueStrategy: 'all',
+        });
 
         while (await list.isEmpty()) {
             await sleep(20);
@@ -232,7 +299,10 @@ describe('SitemapRequestList', () => {
     });
 
     test('retry sitemap load on error', async () => {
-        const list = await SitemapRequestList.open({ sitemapUrls: [`${url}/sitemap-unreliable.xml`] });
+        const list = await SitemapRequestList.open({
+            sitemapUrls: [`${url}/sitemap-unreliable.xml`],
+            enqueueStrategy: 'all',
+        });
 
         for await (const request of list) {
             await list.markRequestHandled(request);
@@ -242,7 +312,10 @@ describe('SitemapRequestList', () => {
     });
 
     test('broken off sitemap load resurrects correctly and does not duplicate / lose requests', async () => {
-        const list = await SitemapRequestList.open({ sitemapUrls: [`${url}/sitemap-unreliable-break-off.xml`] });
+        const list = await SitemapRequestList.open({
+            sitemapUrls: [`${url}/sitemap-unreliable-break-off.xml`],
+            enqueueStrategy: 'all',
+        });
 
         const urls = new Set<string>();
 
@@ -264,7 +337,7 @@ describe('SitemapRequestList', () => {
     });
 
     test('teardown works', async () => {
-        const list = await SitemapRequestList.open({ sitemapUrls: [`${url}/sitemap-index.xml`] });
+        const list = await SitemapRequestList.open({ sitemapUrls: [`${url}/sitemap-index.xml`], enqueueStrategy: 'all' });
 
         for await (const request of list) {
             await list.markRequestHandled(request);
@@ -283,6 +356,7 @@ describe('SitemapRequestList', () => {
         const list = await SitemapRequestList.open({
             sitemapUrls: [`${url}/sitemap.xml`],
             globs: ['http://not-exists.com/catalog**'],
+            enqueueStrategy: 'all',
         });
 
         for await (const request of list) {
@@ -296,6 +370,7 @@ describe('SitemapRequestList', () => {
         const list = await SitemapRequestList.open({
             sitemapUrls: [`${url}/sitemap.xml`],
             regexps: [/desc=vacation_new.+/],
+            enqueueStrategy: 'all',
         });
 
         for await (const request of list) {
@@ -309,6 +384,7 @@ describe('SitemapRequestList', () => {
         const list = await SitemapRequestList.open({
             sitemapUrls: [`${url}/sitemap.xml`],
             exclude: [/desc=vacation_new/],
+            enqueueStrategy: 'all',
         });
 
         for await (const request of list) {
@@ -319,7 +395,7 @@ describe('SitemapRequestList', () => {
     });
 
     test('draining the request list between sitemaps', async () => {
-        const list = await SitemapRequestList.open({ sitemapUrls: [`${url}/sitemap-index.xml`] });
+        const list = await SitemapRequestList.open({ sitemapUrls: [`${url}/sitemap-index.xml`], enqueueStrategy: 'all' });
 
         while (await list.isEmpty()) {
             await sleep(20);
@@ -354,7 +430,7 @@ describe('SitemapRequestList', () => {
     });
 
     test('for..await syntax works with SitemapRequestList', async () => {
-        const list = await SitemapRequestList.open({ sitemapUrls: [`${url}/sitemap-index.xml`] });
+        const list = await SitemapRequestList.open({ sitemapUrls: [`${url}/sitemap-index.xml`], enqueueStrategy: 'all' });
 
         for await (const request of list) {
             await list.markRequestHandled(request);
@@ -370,6 +446,7 @@ describe('SitemapRequestList', () => {
         const list = await SitemapRequestList.open({
             sitemapUrls: [`${url}/sitemap-index.xml`],
             signal: controller.signal,
+            enqueueStrategy: 'all',
         });
 
         await sleep(50); // Loads the first sub-sitemap, but not the second
@@ -388,6 +465,7 @@ describe('SitemapRequestList', () => {
         const list = await SitemapRequestList.open({
             sitemapUrls: [`${url}/sitemap-index.xml`],
             timeoutMillis: 50, // Loads the first sub-sitemap, but not the second
+            enqueueStrategy: 'all',
         });
 
         for await (const request of list) {
@@ -404,6 +482,7 @@ describe('SitemapRequestList', () => {
             sitemapUrls: [`${url}/sitemap-index.xml`],
             persistStateKey: 'resurrection-abort',
             timeoutMillis: 50,
+            enqueueStrategy: 'all' as const,
         };
 
         {
@@ -424,7 +503,7 @@ describe('SitemapRequestList', () => {
     });
 
     test('processing the whole list', async () => {
-        const list = await SitemapRequestList.open({ sitemapUrls: [`${url}/sitemap.xml`] });
+        const list = await SitemapRequestList.open({ sitemapUrls: [`${url}/sitemap.xml`], enqueueStrategy: 'all' });
         const requests: Request[] = [];
 
         await expect(list.isFinished()).resolves.toBe(false);
@@ -448,7 +527,7 @@ describe('SitemapRequestList', () => {
     });
 
     test('processing the whole list with reclaiming', async () => {
-        const list = await SitemapRequestList.open({ sitemapUrls: [`${url}/sitemap.xml`] });
+        const list = await SitemapRequestList.open({ sitemapUrls: [`${url}/sitemap.xml`], enqueueStrategy: 'all' });
         const requests: Request[] = [];
 
         await expect(list.isFinished()).resolves.toBe(false);
@@ -482,7 +561,11 @@ describe('SitemapRequestList', () => {
     });
 
     test('persists state', async () => {
-        const options = { sitemapUrls: [`${url}/sitemap-stream.xml`], persistStateKey: 'some-key' };
+        const options = {
+            sitemapUrls: [`${url}/sitemap-stream.xml`],
+            persistStateKey: 'some-key',
+            enqueueStrategy: 'all' as const,
+        };
         const list = await SitemapRequestList.open(options);
 
         const firstRequest = await list.fetchNextRequest();
@@ -503,7 +586,7 @@ describe('SitemapRequestList', () => {
     });
 
     test("calling `persistState` doesn't throw", async () => {
-        const list = await SitemapRequestList.open({ sitemapUrls: [`${url}/sitemap.xml`] });
+        const list = await SitemapRequestList.open({ sitemapUrls: [`${url}/sitemap.xml`], enqueueStrategy: 'all' });
 
         for await (const request of list) {
             await list.markRequestHandled(request);
@@ -518,6 +601,7 @@ describe('SitemapRequestList', () => {
         const options = {
             sitemapUrls: [`${url}/sitemap-stream.xml`],
             persistStateKey: 'persist-user-changes',
+            enqueueStrategy: 'all' as const,
         };
 
         const userDataPayload = { some: 'data' };
@@ -538,6 +622,65 @@ describe('SitemapRequestList', () => {
         const restoredRequest = await newList.fetchNextRequest();
 
         expect(restoredRequest!.url).toEqual(firstLoadedUrl);
-        expect(restoredRequest!.userData).toEqual(userDataPayload);
+        // `toMatchObject` (not `toEqual`): the request also carries internal `__crawlee` bookkeeping
+        // (the stamped enqueue strategy), so we assert the user payload round-trips rather than exact equality.
+        expect(restoredRequest!.userData).toMatchObject(userDataPayload);
+    });
+
+    async function collectUrls(list: SitemapRequestList): Promise<string[]> {
+        const urls: string[] = [];
+        for await (const request of list) {
+            urls.push(request.url);
+            await list.markRequestHandled(request);
+        }
+        return urls;
+    }
+
+    test('default `same-hostname` strategy drops cross-host URL entries', async () => {
+        const list = await SitemapRequestList.open({ sitemapUrls: [`${url}/cross-host-content.xml`] });
+        expect(await collectUrls(list)).toEqual([`${url}/same-host-page`]);
+    });
+
+    test('`enqueueStrategy: all` keeps cross-host URL entries', async () => {
+        const cross = url.replace('localhost', '127.0.0.1');
+        const list = await SitemapRequestList.open({
+            sitemapUrls: [`${url}/cross-host-content.xml`],
+            enqueueStrategy: 'all',
+        });
+        expect(new Set(await collectUrls(list))).toEqual(
+            new Set([`${url}/same-host-page`, `${cross}/cross-host-page`]),
+        );
+    });
+
+    test('default `same-hostname` strategy drops cross-host nested sitemaps before fetching them', async () => {
+        const list = await SitemapRequestList.open({ sitemapUrls: [`${url}/cross-host-index.xml`] });
+        // The cross-host nested sitemap is never fetched, so its `child-page` URL is absent.
+        expect(await collectUrls(list)).toEqual([]);
+    });
+
+    test('`enqueueStrategy: all` follows cross-host nested sitemaps', async () => {
+        const cross = url.replace('localhost', '127.0.0.1');
+        const list = await SitemapRequestList.open({
+            sitemapUrls: [`${url}/cross-host-index.xml`],
+            enqueueStrategy: 'all',
+        });
+        expect(await collectUrls(list)).toEqual([`${cross}/child-page`]);
+    });
+
+    test('non-http(s) schemes are dropped even with `enqueueStrategy: all`', async () => {
+        const list = await SitemapRequestList.open({
+            sitemapUrls: [`${url}/mixed-scheme.xml`],
+            enqueueStrategy: 'all',
+        });
+        expect(await collectUrls(list)).toEqual([`${url}/ok`]);
+    });
+
+    test('the selected enqueue strategy is stamped onto emitted requests', async () => {
+        const list = await SitemapRequestList.open({ sitemapUrls: [`${url}/cross-host-content.xml`] });
+        const request = await list.fetchNextRequest();
+
+        expect(request).not.toBe(null);
+        // The strategy is persisted on the request so it keeps being enforced after navigation.
+        expect((request as any).enqueueStrategy).toBe('same-hostname');
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1204,6 +1204,7 @@ __metadata:
     ow: "npm:^0.28.1"
     robots-parser: "npm:^3.0.1"
     sax: "npm:^1.4.1"
+    tldts: "npm:^7.0.0"
     tslib: "npm:^2.4.0"
     whatwg-mimetype: "npm:^4.0.0"
   languageName: unknown


### PR DESCRIPTION
`SitemapRequestList`, `Sitemap.load` / `parseSitemap`, and `RobotsTxtFile.getSitemaps()` now apply an enqueue strategy to the URLs they extract. They keep only entries that match the strategy (default `same-hostname`) relative to their parent sitemap, and always drop non-`http(s)` schemes. This brings sitemap loading in line with `enqueueLinks`, which already scopes discovered links to the same hostname by default.

The selected strategy is also stamped onto the emitted `Request` objects, so it keeps being enforced after navigation (e.g. across redirects).

This changes the default behavior: cross-host sitemap entries are no longer enqueued unless you opt in with `enqueueStrategy: 'all'` (or `'same-domain'` / `'same-origin'`).