### PR TITLE
fix: `RequestManagerTandem` returns correct total count

### DIFF
--- a/packages/core/src/storages/request_manager_tandem.ts
+++ b/packages/core/src/storages/request_manager_tandem.ts
@@ -153,7 +153,8 @@ export class RequestManagerTandem implements IRequestManager {
         const requestManager = await this.getRequestManager();
         const [managerTotal, loaderTotal] = await Promise.all([
             requestManager.getTotalCount(),
-            this.requestLoader.getTotalCount(),
+            // count only pending to avoid double counting, requests marked as "handled" have been moved to requestManager
+            this.requestLoader.getPendingCount(),
         ]);
         return managerTotal + loaderTotal;
     }

--- a/test/core/request_manager_tandem.test.ts
+++ b/test/core/request_manager_tandem.test.ts
@@ -115,6 +115,29 @@ describe('RequestManagerTandem', () => {
         await expect(tandem.getHandledCount()).resolves.toBe(2);
     });
 
+    test('getTotalCount returns correct count', async () => {
+        const requestList = await RequestList.open(null, [
+            { url: 'https://example.com/1' },
+            { url: 'https://example.com/2' },
+        ]);
+        const requestQueue = await RequestQueue.open();
+        const tandem = new RequestManagerTandem(requestList, requestQueue);
+
+        await expect(tandem.getTotalCount()).resolves.toBe(2);
+
+        const req = await tandem.fetchNextRequest();
+
+        await expect(tandem.getTotalCount()).resolves.toBe(2);
+
+        await tandem.reclaimRequest(req!);
+
+        await expect(tandem.getTotalCount()).resolves.toBe(2);
+
+        await tandem.addRequest({ url: 'https://example.com/3' });
+
+        await expect(tandem.getTotalCount()).resolves.toBe(3);
+    });
+
     test('isFinished returns true only when both list and queue are finished', async () => {
         const requestList = await RequestList.open(null, [{ url: 'https://example.com/1' }]);
         const requestQueue = await RequestQueue.open();


### PR DESCRIPTION
Avoid double-counting requests in `RequestManagerTandem`. 

Closes https://github.com/apify/crawlee/issues/3787
