### PR TITLE
fix: read properties directly from `GotScrapingHttpClient` response

### DIFF
--- a/packages/core/src/http_clients/got-scraping-http-client.ts
+++ b/packages/core/src/http_clients/got-scraping-http-client.ts
@@ -34,6 +34,14 @@ export class GotScrapingHttpClient implements BaseHttpClient {
 
         return {
             ...gotResult,
+            complete: gotResult.complete,
+            headers: gotResult.headers,
+            ip: gotResult.ip,
+            redirectUrls: gotResult.redirectUrls,
+            statusCode: gotResult.statusCode,
+            statusMessage: gotResult.statusMessage,
+            trailers: gotResult.trailers,
+            url: gotResult.url,
             body: gotResult.body as ResponseTypes[TResponseType],
             request: { url: request.url, ...gotResult.request },
         };


### PR DESCRIPTION
Reads properties off `got-scraping`'s Response directly instead of relying on spread (see the [original bug report](https://github.com/sindresorhus/got/issues/2389)).

Closes https://github.com/apify/crawlee/issues/3793
