### PR TITLE
fix(basic-crawler): declare `@apify/datastructures` as a dependency

### DIFF
--- a/packages/basic-crawler/package.json
+++ b/packages/basic-crawler/package.json
@@ -45,6 +45,7 @@
         "access": "public"
     },
     "dependencies": {
+        "@apify/datastructures": "^2.0.0",
         "@apify/log": "^2.4.0",
         "@apify/timeout": "^0.3.0",
         "@apify/utilities": "^2.7.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -806,6 +806,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@crawlee/basic@workspace:packages/basic-crawler"
   dependencies:
+    "@apify/datastructures": "npm:^2.0.0"
     "@apify/log": "npm:^2.4.0"
     "@apify/timeout": "npm:^0.3.0"
     "@apify/utilities": "npm:^2.7.10"


### PR DESCRIPTION
`packages/basic-crawler/src/internals/basic-crawler.ts` imports `LruCache` from `@apify/datastructures` (line 65, used at line 704 for `robotsTxtFileCache`), but `@crawlee/basic`'s `package.json` does not declare `@apify/datastructures` as a dependency. It is currently only present transitively, via `@crawlee/core`'s own `@apify/datastructures: ^2.0.0` dependency.

This is an undeclared (phantom) dependency. It resolves fine under npm's default flat `node_modules` and pnpm's hoisted mode, where the transitive copy ends up reachable from `@crawlee/basic`. It breaks under any strict/isolated `node_modules` layout (e.g. pnpm with `node-linker=isolated`), where a package can only resolve what it declares — `@crawlee/basic` cannot see `@apify/datastructures` and `require`/`import` fails.

## Fix

Declare the dependency explicitly, matching the range `@crawlee/core` already uses:

```
"@apify/datastructures": "^2.0.0",
```

One line added to `packages/basic-crawler/package.json`. No changeset directory is present in the repo, so none is added.
