### PR TITLE
fix: declare missing dependencies

### DIFF
--- a/packages/crawlee/package.json
+++ b/packages/crawlee/package.json
@@ -63,6 +63,7 @@
         "@crawlee/http": "3.17.0",
         "@crawlee/jsdom": "3.17.0",
         "@crawlee/linkedom": "3.17.0",
+        "@crawlee/memory-storage": "3.17.0",
         "@crawlee/playwright": "3.17.0",
         "@crawlee/puppeteer": "3.17.0",
         "@crawlee/utils": "3.17.0",

--- a/packages/http-crawler/package.json
+++ b/packages/http-crawler/package.json
@@ -56,6 +56,7 @@
         "@apify/timeout": "^0.3.0",
         "@apify/utilities": "^2.7.10",
         "@crawlee/basic": "3.17.0",
+        "@crawlee/core": "3.17.0",
         "@crawlee/types": "3.17.0",
         "@crawlee/utils": "3.17.0",
         "@types/content-type": "^1.1.5",

--- a/packages/linkedom-crawler/package.json
+++ b/packages/linkedom-crawler/package.json
@@ -57,6 +57,8 @@
         "@apify/utilities": "^2.7.10",
         "@crawlee/http": "3.17.0",
         "@crawlee/types": "3.17.0",
+        "@crawlee/utils": "3.17.0",
+        "cheerio": "1.0.0-rc.12",
         "linkedom": "^0.18.0",
         "ow": "^0.28.2",
         "tslib": "^2.4.0"

--- a/packages/playwright-crawler/package.json
+++ b/packages/playwright-crawler/package.json
@@ -68,7 +68,8 @@
         "ml-matrix": "^6.11.0",
         "ow": "^0.28.1",
         "string-comparison": "^1.3.0",
-        "tslib": "^2.4.0"
+        "tslib": "^2.4.0",
+        "type-fest": "^4.0.0"
     },
     "peerDependencies": {
         "idcac-playwright": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -940,6 +940,7 @@ __metadata:
     "@apify/timeout": "npm:^0.3.0"
     "@apify/utilities": "npm:^2.7.10"
     "@crawlee/basic": "npm:3.17.0"
+    "@crawlee/core": "npm:3.17.0"
     "@crawlee/types": "npm:3.17.0"
     "@crawlee/utils": "npm:3.17.0"
     "@types/content-type": "npm:^1.1.5"
@@ -992,6 +993,8 @@ __metadata:
     "@apify/utilities": "npm:^2.7.10"
     "@crawlee/http": "npm:3.17.0"
     "@crawlee/types": "npm:3.17.0"
+    "@crawlee/utils": "npm:3.17.0"
+    cheerio: "npm:1.0.0-rc.12"
     linkedom: "npm:^0.18.0"
     ow: "npm:^0.28.2"
     tslib: "npm:^2.4.0"
@@ -1036,6 +1039,7 @@ __metadata:
     ow: "npm:^0.28.1"
     string-comparison: "npm:^1.3.0"
     tslib: "npm:^2.4.0"
+    type-fest: "npm:^4.0.0"
   peerDependencies:
     idcac-playwright: ^0.2.0
     playwright: "*"
@@ -5525,6 +5529,7 @@ __metadata:
     "@crawlee/http": "npm:3.17.0"
     "@crawlee/jsdom": "npm:3.17.0"
     "@crawlee/linkedom": "npm:3.17.0"
+    "@crawlee/memory-storage": "npm:3.17.0"
     "@crawlee/playwright": "npm:3.17.0"
     "@crawlee/puppeteer": "npm:3.17.0"
     "@crawlee/utils": "npm:3.17.0"


### PR DESCRIPTION
Install unlisted dependencies according to `npx knip --include unlisted`.

This is the only exception, a false positive due to an ambiguous comment detected as a dependency:

```
something  scripts/typescript_fixes.mjs:28:13
```

Notice that ESLint's `import/no-extraneous-dependencies` rule also detects missing dev dependencies from sub-packages, such as `@apify/log` in `packages/browser-crawler/test/migration.test.ts`.
As discussed, I ignored that and left the rule disabled, since ESLint is going to be replaced by Oxlint, which may have a different rule set and/or behavior.
~~Instead, I added implicit dev dependencies to the root's `package.json`.~~