### PR TITLE
fix(utils): advance the CPU tick baseline in systemInfoV2 getCurrentCpuTicks

### DIFF
--- a/packages/utils/src/internals/systemInfoV2/cpu-info.ts
+++ b/packages/utils/src/internals/systemInfoV2/cpu-info.ts
@@ -48,8 +48,9 @@ export function getCurrentCpuTicks() {
         },
         { idle: 0, total: 0 },
     );
-    const idleTicksDelta = ticks.idle - previousTicks!.idle;
-    const totalTicksDelta = ticks.total - previousTicks!.total;
+    const idleTicksDelta = ticks.idle - previousTicks.idle;
+    const totalTicksDelta = ticks.total - previousTicks.total;
+    Object.assign(previousTicks, ticks);
     return totalTicksDelta ? 1 - idleTicksDelta / totalTicksDelta : 0;
 }
 

--- a/test/core/autoscaling/snapshotter.test.ts
+++ b/test/core/autoscaling/snapshotter.test.ts
@@ -144,6 +144,10 @@ describe('Snapshotter', () => {
         // do not initialize the event intervals as we will fire them manually
         const spy = vitest.spyOn(LocalEventManager.prototype, 'init').mockImplementation(async () => {});
         const events = config.getEventManager() as LocalEventManager;
+
+        // Establish a baseline before the Snapshotter starts listening for events.
+        await events.emitSystemInfoEvent(noop);
+        cpusMock.mockClear();
         await snapshotter.start();
 
         await events.emitSystemInfoEvent(noop);

--- a/test/utils/cpu-infoV2.test.ts
+++ b/test/utils/cpu-infoV2.test.ts
@@ -32,6 +32,20 @@ vitest.mock('node:fs/promises', async (importActual) => {
 const getCgroupsVersionSpy = vitest.mocked(getCgroupsVersion);
 const readFileSpy = vitest.mocked(readFile);
 
+// `getCurrentCpuTicks` keeps a module-level baseline of the previous tick sample.
+// Zero it before each test so the singleton state cannot leak between tests.
+function resetCpuTicksBaseline() {
+    const cpusMock = vitest
+        .spyOn(os, 'cpus')
+        .mockReturnValue([{ times: { user: 0, nice: 0, sys: 0, idle: 0, irq: 0 } }] as os.CpuInfo[]);
+    getCurrentCpuTicks();
+    cpusMock.mockRestore();
+}
+
+beforeEach(() => {
+    resetCpuTicksBaseline();
+});
+
 describe('getCurrentCpuTicks()', () => {
     test('calculates cpu load based on os.cpus', () => {
         // For two CPUs, we simulate:
@@ -47,6 +61,29 @@ describe('getCurrentCpuTicks()', () => {
         const load = getCurrentCpuTicks();
         expect(load).toBeCloseTo(0.75);
         cpusMock.mockRestore();
+    });
+
+    test('measures load between samples, not cumulatively since boot', () => {
+        // First sample establishes the baseline: total = 400, idle = 200.
+        const firstMock = vitest
+            .spyOn(os, 'cpus')
+            .mockReturnValue([{ times: { user: 100, nice: 0, sys: 100, idle: 200, irq: 0 } }] as os.CpuInfo[]);
+        getCurrentCpuTicks();
+        firstMock.mockRestore();
+
+        // Second sample adds 150 busy ticks and 50 idle ticks: total = 600, idle = 250.
+        // Chosen so the inter-sample delta and the cumulative-since-boot ratio differ.
+        const secondMock = vitest
+            .spyOn(os, 'cpus')
+            .mockReturnValue([{ times: { user: 175, nice: 0, sys: 175, idle: 250, irq: 0 } }] as os.CpuInfo[]);
+        const load = getCurrentCpuTicks();
+        secondMock.mockRestore();
+
+        // Delta since the previous sample: idleDelta = 50, totalDelta = 200 -> 1 - 50/200 = 0.75.
+        // The cumulative-since-boot ratio would be 1 - 250/600 ≈ 0.583, which the buggy
+        // (baseline-never-advanced) implementation returned instead.
+        expect(load).toBeCloseTo(0.75);
+        expect(load).not.toBeCloseTo(1 - 250 / 600);
     });
 });
 


### PR DESCRIPTION

### What

`getCurrentCpuTicks()` in `packages/utils/src/internals/systemInfoV2/cpu-info.ts`
computes CPU load as the delta between the current `os.cpus()` tick counts and a
module-level `previousTicks` baseline, but it never wrote the new sample back to
`previousTicks`. The baseline therefore stayed at `{ idle: 0, total: 0 }` for the
whole process, so every call returned the average CPU load **since boot** instead
of the load since the previous sample.

```ts
const previousTicks = { idle: 0, total: 0 };

export function getCurrentCpuTicks() {
    const cpusCores = os.cpus();
    const ticks = cpusCores.reduce(/* sum idle + total across cores */);
    const idleTicksDelta = ticks.idle - previousTicks.idle;
    const totalTicksDelta = ticks.total - previousTicks.total;
    // <- previousTicks was never updated here, so the delta is always measured from boot
    return totalTicksDelta ? 1 - idleTicksDelta / totalTicksDelta : 0;
}
```

### Why it matters

`systemInfoV2` is enabled by default, and `getCurrentCpuTicks()` is the CPU
fallback used in uncontainerized environments, cgroup-less containers and AWS
Lambda (the other branches use cgroup stats). Its result feeds
`cpuCurrentUsage` / `isCpuOverloaded`, which drive the `AutoscaledPool`. With a
frozen boot-average signal the CPU value barely moves for the rest of a run, so
CPU-based autoscaling never reacts to real load.

The intended contract is already established twice in the codebase:

- the V1 path `LocalEventManager.createCpuInfo`
  (`packages/core/src/events/local_event_manager.ts`) does the identical delta
  math and then `Object.assign(this.previousTicks, ticks)`;
- the containerized branch in this same file advances its baseline with
  `previousSample = sample`.

`getCurrentCpuTicks()` was simply missing the equivalent write-back.

### The fix

Write the sample back after computing the delta, mirroring both siblings:

```ts
const idleTicksDelta = ticks.idle - previousTicks.idle;
const totalTicksDelta = ticks.total - previousTicks.total;
Object.assign(previousTicks, ticks);
return totalTicksDelta ? 1 - idleTicksDelta / totalTicksDelta : 0;
```

The now-redundant non-null assertions (`previousTicks!`) on the non-null const are
dropped.

### Test

Adds a regression test to `test/utils/cpu-infoV2.test.ts` that takes two samples
and asserts the second reflects the inter-sample delta (`0.75`) rather than the
cumulative-since-boot ratio (`~0.583`, which the buggy version returned). A
`beforeEach` resets the shared module baseline so the singleton state cannot leak
between tests.

Red -> green: against the unpatched source the new test fails
(`expected 0.5833333333333333 to be close to 0.75`); with the fix the file passes
18/18. `test/core/autoscaling/` (snapshotter + system status + autoscaled pool)
also stays green at 39/39.
