### PR TITLE
fix(memory-storage): don't increment `handledRequestCount` when updating a handled request

### DIFF
--- a/packages/memory-storage/src/resource-clients/request-queue.ts
+++ b/packages/memory-storage/src/resource-clients/request-queue.ts
@@ -551,7 +551,7 @@ export class RequestQueueClient extends BaseClient implements storage.RequestQue
             existingQueueById.pendingRequestCount += requestWasHandledBeforeUpdate ? 1 : -1;
         }
 
-        if (requestIsHandledAfterUpdate) {
+        if (isRequestHandledStateChanging && requestIsHandledAfterUpdate) {
             existingQueueById.handledRequestCount += 1;
         }
 

--- a/packages/memory-storage/test/request-queue/handledRequestCount-should-update.test.ts
+++ b/packages/memory-storage/test/request-queue/handledRequestCount-should-update.test.ts
@@ -50,4 +50,24 @@ describe('RequestQueue handledRequestCount should update', () => {
         const updatedStatistics = await requestQueue.get();
         expect(updatedStatistics?.handledRequestCount).toEqual(2);
     });
+
+    test('updating an already handled request should not increment the handledRequestCount again', async () => {
+        const { requestId } = await requestQueue.addRequest({
+            url: 'http://example.com/4',
+            uniqueKey: '4',
+            handledAt: new Date().toISOString(),
+        });
+
+        const { handledRequestCount } = (await requestQueue.get())!;
+
+        await requestQueue.updateRequest({
+            url: 'http://example.com/4',
+            uniqueKey: '4',
+            id: requestId,
+            handledAt: new Date().toISOString(),
+        });
+
+        const updatedStatistics = await requestQueue.get();
+        expect(updatedStatistics?.handledRequestCount).toEqual(handledRequestCount);
+    });
 });


### PR DESCRIPTION

`RequestQueueClient.updateRequest()` in `@crawlee/memory-storage` keeps two sibling counters on the queue in sync: `pendingRequestCount` and `handledRequestCount`. It derives three booleans from the request's `orderNo` (`null` when handled, a number when pending):

- `isRequestHandledStateChanging = typeof existingRequest.orderNo !== typeof requestModel.orderNo` — true only when the request actually crosses the pending/handled boundary.
- `requestWasHandledBeforeUpdate = existingRequest.orderNo === null`
- `requestIsHandledAfterUpdate = requestModel.orderNo === null`

`pendingRequestCount` is adjusted only inside `if (isRequestHandledStateChanging)`, so it is correct. `handledRequestCount`, however, was incremented under `if (requestIsHandledAfterUpdate)` alone:

```ts
if (requestIsHandledAfterUpdate) {
    existingQueueById.handledRequestCount += 1;
}
```

Because that branch is not gated on the state actually changing, updating a request that was **already** handled (handled -> handled, no transition) counts it a second time and permanently inflates the value reported by `getInfo()` / `toRequestQueueInfo()`.

This is reachable in normal use, not just in theory: `RequestProvider.markRequestHandled()` calls `client.updateRequest({ ...request, handledAt })` unconditionally, and the higher-level provider only guards its own `assumedHandledCount` with `if (!queueOperationInfo.wasAlreadyHandled)` — it never guards the memory-storage counter. So a second `markRequestHandled()` (or any re-`updateRequest()`) on an already-handled request double-counts.

### Fix

Guard the increment with `isRequestHandledStateChanging` as well, so it fires only on the pending -> handled transition, mirroring the `pendingRequestCount` block directly above:

```ts
if (isRequestHandledStateChanging && requestIsHandledAfterUpdate) {
    existingQueueById.handledRequestCount += 1;
}
```

One line changed. The legitimate paths are untouched: the pending -> handled transition still increments, and `deleteRequest()`'s `handledRequestCount -= 1` (on a handled request) is unchanged.

### Test

Extends the existing suite `packages/memory-storage/test/request-queue/handledRequestCount-should-update.test.ts` with a case that adds an already-handled request, records `handledRequestCount`, updates that request again, and asserts the count is unchanged. It fails without the fix (`expected 4 to deeply equal 3`) and passes with it. The assertion captures the count *after* the add, so it is self-contained and does not depend on the running total from the earlier tests in the file.
