### PR TITLE
docs: fix default values of `maxClientErrors` and `snapshotHistorySecs`

### DIFF
--- a/packages/core/src/autoscaling/snapshotter.ts
+++ b/packages/core/src/autoscaling/snapshotter.ts
@@ -48,14 +48,14 @@ export interface SnapshotterOptions {
     /**
      * Defines the maximum number of new rate limit errors within
      * the given interval.
-     * @default 1
+     * @default 3
      */
     maxClientErrors?: number;
 
     /**
      * Sets the interval in seconds for which a history of resource snapshots
      * will be kept. Increasing this to very high numbers will affect performance.
-     * @default 60
+     * @default 30
      */
     snapshotHistorySecs?: number;
 


### PR DESCRIPTION

The JSDoc `@default` tags for two `SnapshotterOptions` fields do not match the
effective defaults in the `Snapshotter` constructor, so the generated API
reference on crawlee.dev publishes the wrong values.

In `packages/core/src/autoscaling/snapshotter.ts`:

- `maxClientErrors` is documented `@default 1` but the constructor destructures
  it as `maxClientErrors = 3`. `createClientLoadSignal` also falls back to
  `options.maxClientErrors ?? 3` (`client_load_signal.ts`), so `3` is the
  effective value.
- `snapshotHistorySecs` is documented `@default 60` but the constructor
  destructures it as `snapshotHistorySecs = 30`, which is the sole value feeding
  the snapshot-history window (`snapshotHistoryMillis = snapshotHistorySecs * 1000`).

`git blame` shows the wrong JSDoc and the code defaults have coexisted since the
initial commit, so this is a longstanding docs mismatch rather than a regression.
This follows the same fix as commit `bab3b71` (`docs: fix default value of
\`maxUsedMemoryRatio\``), which corrected the identical issue for another field in
this same interface.

Docs-only change; no behavior changes. Following the precedent, no test is added
(the corrected values are only observable through the private load-signal
internals).
