### PR TITLE
chore(ci): Update renovate schedules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,10 +5,9 @@
 	"dependencyDashboard": false,
 	"semanticCommits": "enabled",
 	"lockFileMaintenance": {
-        "enabled": true,
-        "automerge": true,
-        "automergeType": "pr",
-        "schedule": ["* 0-5 * * 1"]
+		"enabled": true,
+		"automerge": true,
+		"schedule": ["* 0-5 * * 1"]
 	},
 	"constraints": {
 		"npm": "^8.0.0"
@@ -35,12 +34,12 @@
 			"matchPackageNames": ["playwright"],
 			"enabled": false
 		},
-        {
-            "matchUpdateTypes": ["lockFileMaintenance"],
-            "minimumReleaseAgeBehaviour": "timestamp-optional"
-        }
+		{
+			"matchUpdateTypes": ["lockFileMaintenance"],
+			"minimumReleaseAgeBehaviour": "timestamp-optional"
+		}
 	],
-    "schedule": ["* 0-5 * * 2-5"],
+	"schedule": ["* 0-5 * * 2-5"],
 	"minimumReleaseAge": "1 day",
 	"internalChecksFilter": "strict",
 	"ignoreDeps": ["crawlee", "cheerio", "yarn", "@browserbasehq/stagehand"]

--- a/renovate.json
+++ b/renovate.json
@@ -5,10 +5,10 @@
 	"dependencyDashboard": false,
 	"semanticCommits": "enabled",
 	"lockFileMaintenance": {
-		"enabled": true,
-		"schedule": ["before 2am"],
-		"automerge": true,
-		"automergeType": "branch"
+        "enabled": true,
+        "automerge": true,
+        "automergeType": "pr",
+        "schedule": ["* 0-5 * * 1"]
 	},
 	"constraints": {
 		"npm": "^8.0.0"
@@ -34,9 +34,13 @@
 			],
 			"matchPackageNames": ["playwright"],
 			"enabled": false
-		}
+		},
+        {
+            "matchUpdateTypes": ["lockFileMaintenance"],
+            "minimumReleaseAgeBehaviour": "timestamp-optional"
+        }
 	],
-	"schedule": ["every weekday"],
+    "schedule": ["* 0-5 * * 2-5"],
 	"minimumReleaseAge": "1 day",
 	"internalChecksFilter": "strict",
 	"ignoreDeps": ["crawlee", "cheerio", "yarn", "@browserbasehq/stagehand"]


### PR DESCRIPTION
- Replace deprecated `breejslater` syntax with `cron` syntax
https://docs.renovatebot.com/key-concepts/scheduling/#deprecated-breejslater-syntax
- Use these triggers, limit the window to avoid spam:
  - Every **Tuesday - Friday** between **0:00 and 6:00** to update **dependencies**
  - Every **Monday** between **0:00 and 6:00** to update **lockfiles** 
- Do not run both jobs on the same day.