### PR TITLE
fix(memory-storage): store JSON snapshots in DatasetClient.pushData()

### DIFF
--- a/packages/core/src/memory-storage/resource-clients/dataset.ts
+++ b/packages/core/src/memory-storage/resource-clients/dataset.ts
@@ -124,7 +124,7 @@ export class DatasetClient<Data extends Dictionary = Dictionary>
     async pushData(items: Data[]): Promise<void> {
         for (const entry of items) {
             const idx = this.generateLocalEntryName(++this.itemCount);
-            this.datasetEntries.set(idx, entry);
+            this.datasetEntries.set(idx, JSON.parse(JSON.stringify(entry)) as Data);
         }
 
         this.updateTimestamps(true);

--- a/test/core/storages/dataset.test.ts
+++ b/test/core/storages/dataset.test.ts
@@ -368,6 +368,30 @@ describe('dataset', () => {
             const jsonErrMsg = 'Converting circular structure to JSON';
             await expect(dataset.pushData(circularObj)).rejects.toThrow(jsonErrMsg);
         });
+
+        test('stores independent snapshots, not object references', async () => {
+            const dataset = await Dataset.open({ name: `test-snapshots-${Date.now()}` });
+            const mutableData = { rand: 0, counter: 0 };
+
+            await dataset.pushData(mutableData);
+            mutableData.rand = Math.random();
+            mutableData.counter = 1;
+            await dataset.pushData(mutableData);
+            mutableData.rand = Math.random();
+            mutableData.counter = 2;
+            await dataset.pushData(mutableData);
+
+            const { items } = await dataset.getData();
+
+            expect(items).toHaveLength(3);
+            expect(items[0]).toEqual({ rand: 0, counter: 0 });
+            expect(items[1].counter).toBe(1);
+            expect(items[2].counter).toBe(2);
+
+            // Each push must store an independent snapshot — items should not be the same reference
+            expect(items[0]).not.toBe(items[1]);
+            expect(items[1]).not.toBe(items[2]);
+        });
     });
 
     describe('utils', () => {


### PR DESCRIPTION
## PR Description

### What was the issue

`MemoryStorageClient`'s `DatasetClient.pushData()` stored the raw object reference into its internal `Map` rather than taking an independent deep copy. Later mutations to the original object were reflected in every stored entry — pushing the same mutable object multiple times (mutating between pushes) resulted in all items holding the same final value. This was inconsistent with `FileSystemStorageClient`, which serializes to disk on each push and therefore stores independent snapshots.

### Where was the issue

`packages/core/src/memory-storage/resource-clients/dataset.ts:127`

```ts
this.datasetEntries.set(idx, entry);
```

This line stored the direct reference — no copy, no serialization.

### How was it fixed

Store `JSON.parse(JSON.stringify(entry))` instead of the raw object reference so that each push produces an independent deep copy. This makes `MemoryStorageClient` consistent with `FileSystemStorageClient`, which already stores independent snapshots.

```ts
this.datasetEntries.set(idx, JSON.parse(JSON.stringify(entry)) as Data);
```

### Why this method over alternatives

- `JSON.parse(JSON.stringify())` is the canonical JavaScript deep-clone for JSON-serializable data — no dependencies, no overhead
- The `Dataset` frontend already enforces JSON serializability via `assertJsonSerializable` before data reaches the client, so this clone is guaranteed to succeed for every valid item
- `structuredClone()` handles types (`Date`, `Map`, `ArrayBuffer`, etc.) that dataset items can never contain (the validation gate rejects them), making it unnecessary overhead
- No external clone library needed — zero new dependencies

### How to test locally

```sh
pnpm test -- test/core/storages/dataset.test.ts
```

The added regression test `"stores independent snapshots, not object references"` pushes a mutable object three times with mutations between pushes, then asserts items have distinct values and are not the same reference.

Reproduction from the issue:

```ts
let data = { rand: 0 };
const refresh = () => { data.rand = Math.random(); };

const client = new MemoryStorageClient();
const dataset = await Dataset.open(null, { storageClient: client });
refresh(); await dataset.pushData(data);
refresh(); await dataset.pushData(data);
refresh(); await dataset.pushData(data);

const { items } = await dataset.getData();
// All three should now have different `rand` values — independent snapshots
console.log(items.map(i => i.rand));
```

Fixes #3812