### PR TITLE
perf: make the `proxy-chain` import dynamic in `@crawlee/browser-pool`

### DIFF
--- a/packages/browser-pool/src/anonymize-proxy.ts
+++ b/packages/browser-pool/src/anonymize-proxy.ts
@@ -1,5 +1,3 @@
-import { anonymizeProxy, closeAnonymizedProxy } from 'proxy-chain';
-
 type PromiseVoid = () => Promise<void>;
 
 export interface AnonymizeProxySugarOptions {
@@ -24,6 +22,7 @@ export const anonymizeProxySugar = async (
         if (url.username || url.password || options?.ignoreProxyCertificate) {
             // trim off trailing slash if it's present
             const proxyUrlString = url.href.endsWith('/') ? url.href.slice(0, -1) : url.href;
+            const { anonymizeProxy, closeAnonymizedProxy } = await import('proxy-chain');
             const anonymized = await anonymizeProxy({
                 url: proxyUrlString,
                 port: 0,

--- a/packages/jsdom-crawler/src/internals/jsdom-crawler.ts
+++ b/packages/jsdom-crawler/src/internals/jsdom-crawler.ts
@@ -21,7 +21,6 @@ import {
 } from '@crawlee/http';
 import type { Dictionary } from '@crawlee/types';
 import { type CheerioRoot, type RobotsTxtFile, sleep } from '@crawlee/utils';
-import * as cheerio from 'cheerio';
 import type { DOMWindow } from 'jsdom';
 import { JSDOM, ResourceLoader, VirtualConsole } from 'jsdom';
 import ow from 'ow';
@@ -362,6 +361,7 @@ export class JSDOMCrawler<
                 });
             },
             async waitForSelector(selector: string, timeoutMs = 5_000) {
+                const cheerio = await import('cheerio');
                 const $ = cheerio.load(crawlingContext.body);
 
                 if ($(selector).get().length === 0) {
@@ -375,6 +375,7 @@ export class JSDOMCrawler<
                 }
             },
             async parseWithCheerio(selector?: string, _timeoutMs = 5_000) {
+                const cheerio = await import('cheerio');
                 const $ = cheerio.load(crawlingContext.body);
 
                 if (selector && $(selector).get().length === 0) {

--- a/test/browser-pool/anonymize-proxy-sugar.test.ts
+++ b/test/browser-pool/anonymize-proxy-sugar.test.ts
@@ -8,6 +8,7 @@ describe('anonymizeProxySugar', () => {
     beforeEach(() => {
         vi.mock('proxy-chain', () => ({
             anonymizeProxy: vi.fn((opts) => Promise.resolve(`anonymized-${opts.url}`)),
+            closeAnonymizedProxy: vi.fn(() => Promise.resolve()),
         }));
     });
 


### PR DESCRIPTION
Lazy-loads `proxy-chain`, as it's only used when a proxy with credentials is used.

Shaves off `~60ms` on `browser-pool` import on average.

Related to #3549 
