### PR TITLE
feat: opt-in process-relative CPU usage signal

### DIFF
--- a/packages/core/src/autoscaling/cpu_load_signal.ts
+++ b/packages/core/src/autoscaling/cpu_load_signal.ts
@@ -1,3 +1,5 @@
+import { getCurrentProcessCpuTicks } from '@crawlee/utils';
+
 import type { Configuration } from '../configuration';
 import { EventType } from '../events/event_manager';
 import type { LoadSnapshot } from './load_signal';
@@ -13,13 +15,64 @@ export interface CpuLoadSignalOptions {
     overloadedRatio?: number;
     snapshotHistoryMillis?: number;
     config: Configuration;
+
+    /**
+     * Measures this process's own CPU usage (normalized to a single core) instead of
+     * the whole machine's aggregate CPU usage read from the shared `Configuration`.
+     *
+     * Useful when running multiple independent crawler instances (each with its own
+     * `AutoscaledPool`) concurrently in the same Node.js process, since the machine-wide
+     * aggregate metric gets diluted by the number of cores and can fail to detect that
+     * the combined load of all instances is overloading Node's single JS thread.
+     *
+     * Not recommended for browser-based crawlers, since their CPU-heavy work (rendering)
+     * happens in separate browser processes this doesn't measure.
+     * @default false
+     */
+    useProcessCpuUsage?: boolean;
+
+    /**
+     * Sampling interval for `useProcessCpuUsage`, in seconds.
+     * @default 0.5
+     */
+    processCpuSnapshotIntervalSecs?: number;
 }
 
 /**
- * Tracks CPU usage via `SYSTEM_INFO` events and reports overload when
- * the platform or local OS metrics indicate the CPU is overloaded.
+ * Tracks CPU usage and reports overload when the CPU exceeds `maxUsedCpuRatio`.
+ *
+ * By default, this listens to `SYSTEM_INFO` events from the shared `Configuration`
+ * (machine-wide aggregate, or platform-provided container metrics). With
+ * `useProcessCpuUsage`, it instead samples this process's own CPU usage on its own
+ * interval, independent of `Configuration`.
  */
 export function createCpuLoadSignal(options: CpuLoadSignalOptions) {
+    const maxUsedCpuRatio = options.config.get('maxUsedCpuRatio')!;
+
+    if (options.useProcessCpuUsage) {
+        const intervalMillis = (options.processCpuSnapshotIntervalSecs ?? 0.5) * 1000;
+
+        return SnapshotStore.fromInterval<CpuSnapshot>({
+            name: 'cpuInfo',
+            overloadedRatio: options.overloadedRatio ?? 0.4,
+            intervalMillis,
+            snapshotHistoryMillis: options.snapshotHistoryMillis,
+            handler(store, intervalCallback) {
+                const usedRatio = getCurrentProcessCpuTicks();
+                const now = new Date();
+                store.push(
+                    {
+                        createdAt: now,
+                        isOverloaded: usedRatio > maxUsedCpuRatio,
+                        usedRatio,
+                    },
+                    now,
+                );
+                intervalCallback();
+            },
+        });
+    }
+
     return SnapshotStore.fromEvent<CpuSnapshot, SystemInfo>({
         name: 'cpuInfo',
         overloadedRatio: options.overloadedRatio ?? 0.4,

--- a/packages/core/src/autoscaling/snapshotter.ts
+++ b/packages/core/src/autoscaling/snapshotter.ts
@@ -59,6 +59,19 @@ export interface SnapshotterOptions {
      */
     snapshotHistorySecs?: number;
 
+    /**
+     * Measures this process's own CPU usage (normalized to a single core) instead of
+     * the whole machine's aggregate CPU usage. Useful when running multiple independent
+     * crawler instances concurrently in the same Node.js process, since the machine-wide
+     * aggregate metric gets diluted by the number of cores and can fail to detect that
+     * the combined load of all instances is overloading Node's single JS thread.
+     *
+     * Not recommended for browser-based crawlers, since their CPU-heavy work (rendering)
+     * happens in separate browser processes this doesn't measure.
+     * @default false
+     */
+    useProcessCpuUsage?: boolean;
+
     /** @internal */
     log?: Log;
 
@@ -144,6 +157,7 @@ export class Snapshotter {
                 maxBlockedMillis: ow.optional.number,
                 maxUsedMemoryRatio: ow.optional.number,
                 maxClientErrors: ow.optional.number,
+                useProcessCpuUsage: ow.optional.boolean,
                 log: ow.optional.object,
                 client: ow.optional.object,
                 config: ow.optional.object,
@@ -157,6 +171,7 @@ export class Snapshotter {
             maxBlockedMillis = 50,
             maxUsedMemoryRatio = 0.9,
             maxClientErrors = 3,
+            useProcessCpuUsage = false,
             log = defaultLog,
             config = Configuration.getGlobalConfig(),
             client = config.getStorageClient(),
@@ -185,6 +200,7 @@ export class Snapshotter {
         this.cpuSignal = createCpuLoadSignal({
             snapshotHistoryMillis,
             config: this.config,
+            useProcessCpuUsage,
         });
 
         this.clientSignal = createClientLoadSignal({
@@ -276,7 +292,7 @@ export class Snapshotter {
      * @deprecated Kept for backward compatibility.
      */
     protected _snapshotCpu(systemInfo: SystemInfo) {
-        this.cpuSignal.handle(systemInfo);
+        (this.cpuSignal.handle as (payload: SystemInfo) => void)(systemInfo);
     }
 
     /**

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -14,7 +14,7 @@ export * from './internals/robots';
 export * from './internals/sitemap';
 export * from './internals/url';
 
-export { getCurrentCpuTicksV2 } from './internals/systemInfoV2/cpu-info';
+export { getCurrentCpuTicksV2, getCurrentProcessCpuTicks } from './internals/systemInfoV2/cpu-info';
 export { getMemoryInfoV2 } from './internals/systemInfoV2/memory-info';
 
 export { Dictionary, Awaitable, Constructor } from '@crawlee/types';

--- a/packages/utils/src/internals/systemInfoV2/cpu-info.ts
+++ b/packages/utils/src/internals/systemInfoV2/cpu-info.ts
@@ -26,6 +26,40 @@ let CLOCK_TICKS_CHECKED = false;
 
 const NANOSECONDS_PER_SECOND = 1e9;
 
+let previousProcessCpuUsage: NodeJS.CpuUsage | null = null;
+let previousProcessCpuUsageTime: bigint | null = null;
+
+/**
+ * Gets the CPU load of the current process only, normalized to a single core, regardless of
+ * how many cores the machine has. Unlike {@apilink getCurrentCpuTicks}, which averages usage
+ * across all cores (diluting the signal for CPU-bound work confined to a single Node.js thread,
+ * e.g. `CheerioCrawler`/`HttpCrawler` parsing), this reflects only the CPU time this process
+ * itself consumed.
+ *
+ * Not suitable for browser-based crawlers, since their CPU-heavy work (rendering) happens in
+ * separate browser processes this does not measure.
+ * @returns a number between 0 and 1 (can exceed 1 if the process uses more than one core, e.g. via worker threads)
+ * @internal
+ */
+export function getCurrentProcessCpuTicks(): number {
+    const usage = process.cpuUsage();
+    const now = process.hrtime.bigint();
+
+    if (previousProcessCpuUsage === null || previousProcessCpuUsageTime === null) {
+        previousProcessCpuUsage = usage;
+        previousProcessCpuUsageTime = now;
+        return 0;
+    }
+
+    const elapsedMicros = Number(now - previousProcessCpuUsageTime) / 1e3;
+    const cpuMicros = usage.user + usage.system - (previousProcessCpuUsage.user + previousProcessCpuUsage.system);
+
+    previousProcessCpuUsage = usage;
+    previousProcessCpuUsageTime = now;
+
+    return elapsedMicros ? cpuMicros / elapsedMicros : 0;
+}
+
 const previousTicks = { idle: 0, total: 0 };
 /**
  * Gets the "bare metal" cpu load.

--- a/test/core/autoscaling/cpu_load_signal.test.ts
+++ b/test/core/autoscaling/cpu_load_signal.test.ts
@@ -1,0 +1,57 @@
+import { Configuration } from '@crawlee/core';
+
+import { createCpuLoadSignal } from '../../../packages/core/src/autoscaling/cpu_load_signal';
+
+describe('createCpuLoadSignal()', () => {
+    test('useProcessCpuUsage samples on its own interval, independent of Configuration events', async () => {
+        vitest.useFakeTimers();
+
+        const config = new Configuration({ maxUsedCpuRatio: 0.5 });
+        const cpuUsageMock = vitest.spyOn(process, 'cpuUsage');
+        const hrtimeMock = vitest.spyOn(process.hrtime, 'bigint');
+
+        cpuUsageMock.mockReturnValueOnce({ user: 0, system: 0 });
+        hrtimeMock.mockReturnValueOnce(0n);
+
+        const signal = createCpuLoadSignal({
+            config,
+            useProcessCpuUsage: true,
+            processCpuSnapshotIntervalSecs: 0.5,
+        });
+
+        await signal.start();
+
+        // 450ms of CPU time consumed over a 500ms tick -> 0.9, above the 0.5 maxUsedCpuRatio.
+        cpuUsageMock.mockReturnValueOnce({ user: 400_000, system: 50_000 });
+        hrtimeMock.mockReturnValueOnce(500_000_000n);
+        await vitest.advanceTimersByTimeAsync(500);
+
+        const sample = signal.getSample();
+        const last = sample[sample.length - 1];
+        expect(last.isOverloaded).toBe(true);
+        expect(last.usedRatio).toBeCloseTo(0.9);
+
+        await signal.stop();
+        cpuUsageMock.mockRestore();
+        hrtimeMock.mockRestore();
+        vitest.useRealTimers();
+    });
+
+    test('default mode listens to Configuration SYSTEM_INFO events instead', async () => {
+        const config = new Configuration({ maxUsedCpuRatio: 0.5 });
+        const signal = createCpuLoadSignal({ config });
+
+        await signal.start();
+        config.getEventManager().emit('systemInfo' as any, {
+            createdAt: new Date(),
+            cpuCurrentUsage: 80,
+            isCpuOverloaded: true,
+        } as any);
+
+        const sample = signal.getSample();
+        expect(sample).toHaveLength(1);
+        expect(sample[0].isOverloaded).toBe(true);
+
+        await signal.stop();
+    });
+});

--- a/test/utils/cpu-infoV2.test.ts
+++ b/test/utils/cpu-infoV2.test.ts
@@ -9,6 +9,7 @@ import {
     getCpuQuota,
     getCurrentCpuTicks,
     getCurrentCpuTicksV2,
+    getCurrentProcessCpuTicks,
     getSystemCpuUsage,
     sampleCpuUsage,
 } from '../../packages/utils/src/internals/systemInfoV2/cpu-info';
@@ -47,6 +48,36 @@ describe('getCurrentCpuTicks()', () => {
         const load = getCurrentCpuTicks();
         expect(load).toBeCloseTo(0.75);
         cpusMock.mockRestore();
+    });
+});
+
+describe('getCurrentProcessCpuTicks()', () => {
+    test('returns 0 on the first call (no previous sample yet)', () => {
+        const cpuUsageMock = vitest.spyOn(process, 'cpuUsage').mockReturnValue({ user: 100_000, system: 0 });
+        const hrtimeMock = vitest.spyOn(process.hrtime, 'bigint').mockReturnValue(0n);
+        expect(getCurrentProcessCpuTicks()).toBe(0);
+        cpuUsageMock.mockRestore();
+        hrtimeMock.mockRestore();
+    });
+
+    test('normalizes process CPU usage to a single core, independent of core count', () => {
+        const cpuUsageMock = vitest.spyOn(process, 'cpuUsage');
+        const hrtimeMock = vitest.spyOn(process.hrtime, 'bigint');
+
+        // Prime the previous sample.
+        cpuUsageMock.mockReturnValueOnce({ user: 0, system: 0 });
+        hrtimeMock.mockReturnValueOnce(0n);
+        getCurrentProcessCpuTicks();
+
+        // 450ms of CPU time (user+system) consumed over a 500ms wall-clock window
+        // -> ~0.9 of a single core, same as a busy-loop pegging one core on any machine.
+        cpuUsageMock.mockReturnValueOnce({ user: 400_000, system: 50_000 });
+        hrtimeMock.mockReturnValueOnce(500_000_000n); // 500ms in nanoseconds
+        const load = getCurrentProcessCpuTicks();
+
+        expect(load).toBeCloseTo(0.9);
+        cpuUsageMock.mockRestore();
+        hrtimeMock.mockRestore();
     });
 });
 


### PR DESCRIPTION
Adds \`getCurrentProcessCpuTicks()\` (\`@crawlee/utils\`) and an opt-in \`useProcessCpuUsage\` option on \`AutoscaledPoolOptions.snapshotterOptions\`, off by default.

Context: \`AutoscaledPool\`'s CPU signal averages \`os.cpus()\` across all cores. For CPU-bound work confined to Node's single JS thread (Cheerio parsing), that dilutes the signal by core count and can hide real single-thread saturation — relevant e.g. when several independent crawler instances share one process (#3833). This option measures the process's own CPU time via \`process.cpuUsage()\`, normalized to one core, instead.

Lives on the pool, not \`Configuration\`: whether a crawler's CPU work is confined to one thread is a property of the crawler type (Cheerio/Http vs. browser-based), so each \`AutoscaledPool\` decides its own signal, independent of any \`Configuration\` shared with sibling instances. Not recommended for browser crawlers — their CPU-heavy work runs in separate browser processes this signal doesn't see.

Benchmarked with 10 isolated \`CheerioCrawler\` instances in one process (300 req each, \`maxConcurrency: 30\`), 3 runs per mode, long enough to cross several \`autoscaleIntervalSecs\` ticks:

| metric | default | \`useProcessCpuUsage: true\` |
|---|---|---|
| mean event-loop delay | 144.1ms | 51.6ms |
| p99 | 1395.7ms | 842.9ms |
| max | 2064.0ms | 1423.3ms |

Trade-off: 3 isolated instances, 1500 req each, throughput dropped from ~77 req/s to ~61 req/s (~21%) under the same test. The default signal underestimates load and lets concurrency climb past what the machine can sustain, buying throughput at the cost of the latency above; this option trades some of that throughput back for a smoother, more predictable event loop.