### PR TITLE
ci: exclude `@crawlee/fs-storage-native` from canary/pin version rewrite

### DIFF
--- a/scripts/copy.ts
+++ b/scripts/copy.ts
@@ -110,7 +110,7 @@ if (options.canary) {
     pkgJson.version = nextVersion;
 
     for (const dep of Object.keys(pkgJson.dependencies)) {
-        if (dep.startsWith('@crawlee/') || dep === 'crawlee') {
+        if ((dep.startsWith('@crawlee/') && dep !== '@crawlee/fs-storage-native') || dep === 'crawlee') {
             const prefix = pkgJson.dependencies[dep].startsWith('^') ? '^' : '';
             pkgJson.dependencies[dep] = prefix + nextVersion;
         }
@@ -126,7 +126,7 @@ if (options['pin-versions']) {
     const version = getRootVersion(false);
 
     for (const dep of Object.keys(pkgJson.dependencies ?? {})) {
-        if (dep.startsWith('@crawlee/') || dep === 'crawlee') {
+        if ((dep.startsWith('@crawlee/') && dep !== '@crawlee/fs-storage-native') || dep === 'crawlee') {
             pkgJson.dependencies[dep] = version;
         }
     }


### PR DESCRIPTION
`scripts/copy.ts` rewrites the version of every `@crawlee/*` dependency (and `crawlee`) to the monorepo version during canary publish and `pin-versions`. But `@crawlee/fs-storage-native` is an externally published package (pinned to `0.1.5-beta.18` in `@crawlee/fs-storage`) that is **not** versioned in lockstep with the monorepo, so rewriting it produced a non-existent version and broke CI publishing.

This excludes `@crawlee/fs-storage-native` from the version-rewrite loop in both the `canary` and `pin-versions` branches.