### PR TITLE
fix(utils): prevent ReDoS in social email regex

### DIFF
--- a/packages/utils/src/internals/social.ts
+++ b/packages/utils/src/internals/social.ts
@@ -3,8 +3,11 @@ import * as cheerio from 'cheerio';
 import { htmlToText } from './cheerio';
 
 // Regex inspired by https://zapier.com/blog/extract-links-email-phone-regex/
+// The dot-atom local part and domain labels use RFC 5321 length bounds ({1,64}, {0,62})
+// instead of unbounded quantifiers to avoid quadratic backtracking (ReDoS) on long
+// dotted or hyphenated inputs, e.g. text scraped by parseHandlesFromHtml().
 const EMAIL_REGEX_STRING =
-    '(?:[a-z0-9!#$%&\'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&\'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\\])';
+    '(?:[a-z0-9!#$%&\'*+/=?^_`{|}~-]{1,64}(?:\\.[a-z0-9!#$%&\'*+/=?^_`{|}~-]{1,64}){0,32}|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\\])';
 
 /**
  * Regular expression to exactly match a single email address.

--- a/test/utils/social.test.ts
+++ b/test/utils/social.test.ts
@@ -77,6 +77,16 @@ describe('utils.social', () => {
                 'some.super.long.email.address@some.super.long.domain.name.co.br',
             ]);
         });
+
+        test('does not hang on adversarial input (ReDoS)', () => {
+            // A long dotted local part with no valid domain used to trigger quadratic
+            // backtracking in EMAIL_REGEX_GLOBAL, freezing the event loop for seconds on
+            // scraped text. A long hyphen run in a domain label had the same issue.
+            const started = Date.now();
+            expect(emailsFromText(`x${'.a'.repeat(50000)}@`)).toEqual([]);
+            expect(emailsFromText(`a@${'a-'.repeat(50000)}!`)).toEqual([]);
+            expect(Date.now() - started).toBeLessThan(1000);
+        });
     });
 
     describe('emailsFromUrls()', () => {


### PR DESCRIPTION

```markdown
`social.parseHandlesFromHtml()` runs `emailsFromText()` on every text node of a
scraped page (`packages/utils/src/internals/social.ts`), and `emailsFromText()` /
`emailsFromUrls()` are exported directly. All of them match untrusted text against
`EMAIL_REGEX_GLOBAL`, built from `EMAIL_REGEX_STRING`.

The dot-atom local part `[...]+(?:\.[...]+)*` and each domain label
`[a-z0-9-]*[a-z0-9]` use unbounded quantifiers. On a long dotted or hyphenated
input that never completes a valid address, e.g. `x` + `.a`*n + `@` (no domain),
V8 explores every way to split the run and backtracks quadratically. Matching time
grows ~4x per input doubling (O(n^2)): a single ~60 KB text node blocks the event
loop for seconds, and it scales to tens of seconds on a larger page, so one crafted
crawled page can stall the crawler (the matching worker is single-threaded). This is
CWE-1333 (ReDoS).

The fix bounds those quantifiers with RFC 5321 lengths instead of leaving them
unbounded: local-part atoms `{1,64}`, dot-groups `{0,32}`, and the domain-label
inner run `{0,62}`. That makes the match linear while still accepting every
realistic address (a max-legal 64-char local part and 63-char label still match).
The quoted-string and IP-literal alternatives are unchanged. Only inputs longer than
what a valid email can contain are affected; matching against the original regex over
hundreds of thousands of random and structured strings showed no difference for any
in-range input.

A pure non-backtracking rewrite is not possible here: V8 has no atomic groups or
possessive quantifiers, and an anchored-lookahead form cannot be used because
`EMAIL_REGEX_GLOBAL` runs unanchored over scraped text.

Added an `emailsFromText()` regression test that feeds the adversarial inputs and
asserts they return `[]` well within a time budget; it fails on the old regex
(tens of seconds) and passes on the fixed one.
```
