### PR TITLE
fix(core): remove RequestList persist state listener on teardown

### DIFF
--- a/packages/core/src/storages/request_list.ts
+++ b/packages/core/src/storages/request_list.ts
@@ -403,6 +403,8 @@ export class RequestList implements IRequestList {
 
         // The proxy configuration used for `requestsFromUrl` requests.
         this.proxyConfiguration = proxyConfiguration;
+
+        this.persistState = this.persistState.bind(this);
     }
 
     /**
@@ -431,7 +433,7 @@ export class RequestList implements IRequestList {
         this.isInitialized = true;
         if (this.persistRequestsKey && !this.areRequestsPersisted) await this._persistRequests();
         if (this.persistStateKey) {
-            this.events.on(EventType.PERSIST_STATE, this.persistState.bind(this));
+            this.events.on(EventType.PERSIST_STATE, this.persistState);
         }
 
         return this;
@@ -516,6 +518,19 @@ export class RequestList implements IRequestList {
         } catch (e) {
             const err = e as Error;
             this.log.exception(err, 'Attempted to persist state, but failed.');
+        }
+    }
+
+    /**
+     * Removes the `PERSIST_STATE` event listener registered during initialization and persists
+     * the current state one last time. Call this when you are done with the `RequestList` to avoid
+     * leaking the listener (and the requests it retains) on the shared event manager.
+     */
+    async teardown(): Promise<void> {
+        this.events.off(EventType.PERSIST_STATE, this.persistState);
+
+        if (this.persistStateKey) {
+            await this.persistState();
         }
     }
 

--- a/test/core/request_list.test.ts
+++ b/test/core/request_list.test.ts
@@ -505,6 +505,21 @@ describe('RequestList', () => {
         expect(requestList2.getState()).toEqual(requestList.getState());
     });
 
+    test('teardown removes the persist state listener when persistStateKey is set', async () => {
+        const listenerCountBefore = events.listenerCount(EventType.PERSIST_STATE);
+
+        const requestList = await RequestList.open({
+            sources: [{ url: 'https://example.com/1' }],
+            persistStateKey: 'teardown-key',
+        });
+
+        expect(events.listenerCount(EventType.PERSIST_STATE)).toBe(listenerCountBefore + 1);
+
+        await requestList.teardown();
+
+        expect(events.listenerCount(EventType.PERSIST_STATE)).toBe(listenerCountBefore);
+    });
+
     test('should correctly persist its sources when persistRequestsKey is set', async () => {
         const PERSIST_REQUESTS_KEY = 'some-key';
         const getValueSpy = vitest.spyOn(KeyValueStore.prototype, 'getValue');


### PR DESCRIPTION


`RequestList.initialize()` registered its `PERSIST_STATE` event listener with an
inline `this.persistState.bind(this)` and never removed it. Because the bound
function was never stored anywhere, there was no reference to pass to
`events.off()`, so the listener could not be removed at all. Its closure also kept
a reference to the instance (and therefore the whole `requests` array) alive on the
shared event manager for the lifetime of the process.

As a result, every `RequestList` opened with a `persistStateKey` leaks one
`PERSIST_STATE` listener plus the requests it retains. In a process that opens many
lists this accumulates unbounded and eventually trips Node's
`MaxListenersExceededWarning` on the event manager.

`RequestList` is the only stateful component in the package that gets this wrong.
`SitemapRequestList`, `SessionPool`, `Statistics` and `RecoverableState` all store
the bound listener once and remove it with `events.off()`. This PR brings
`RequestList` in line with them.

### Changes

- Bind `persistState` once in the constructor.
- Register that stored reference in `initialize()` instead of an inline, unremovable
  bind.
- Add an `async teardown()` that removes the listener via `events.off()` and
  persists the state one last time, mirroring `SitemapRequestList.teardown()`.

The only adaptation vs `SitemapRequestList` is that the final `persistState()` in
`teardown()` is guarded by `if (this.persistStateKey)`: unlike
`SitemapRequestList` (which defaults a `persistStateKey`), `RequestList.persistState()`
throws when no key is set, so calling it unconditionally would make `teardown()`
throw for a list opened without a key.

`teardown()` is a class-only method here, exactly as it is on `SitemapRequestList`
(it is not part of the `IRequestList` interface), so this is not a breaking change.

### Notes

Like `SitemapRequestList.teardown()`, this new `RequestList.teardown()` is not
called automatically by `BasicCrawler` (which tears down the session pool and events
directly). The value of this change is twofold: the registered listener is now
removable at all, and there is a public, symmetric `teardown()` for code that
manages a `RequestList` / `SitemapRequestList` lifecycle directly.

### Test

Added a regression test in `test/core/request_list.test.ts` that opens a
`RequestList` with a `persistStateKey`, asserts the `PERSIST_STATE` listener count
increases by one, calls `teardown()`, and asserts the count returns to the baseline.
With the source fix reverted the test fails with
`TypeError: requestList.teardown is not a function`; with the fix it passes.

- `yarn vitest run test/core/request_list.test.ts` -> 23 passed
- `yarn vitest run test/core/sitemap_request_list.test.ts` -> 17 passed (unchanged)
