### PR TITLE
fix(core): clear `AutoscaledPool.pause()` polling interval on timeout

### DIFF
--- a/packages/core/src/autoscaling/autoscaled_pool.ts
+++ b/packages/core/src/autoscaling/autoscaled_pool.ts
@@ -430,8 +430,11 @@ export class AutoscaledPool {
         this.isStopped = true;
         await new Promise<void>((resolve, reject) => {
             let timeout: NodeJS.Timeout;
+            let interval: NodeJS.Timeout;
             if (timeoutSecs) {
                 timeout = setTimeout(() => {
+                    // Clean up the polling interval to prevent it from leaking on timeout.
+                    clearInterval(interval);
                     const err = new Error(
                         "The pool's running tasks did not finish" +
                             `in ${timeoutSecs} secs after pool.pause() invocation.`,
@@ -440,7 +443,7 @@ export class AutoscaledPool {
                 }, timeoutSecs);
             }
 
-            const interval = setInterval(() => {
+            interval = setInterval(() => {
                 if (this._currentConcurrency <= 0) {
                     // Clean up timeout and interval to prevent process hanging.
                     if (timeout) clearTimeout(timeout);

--- a/test/core/autoscaling/autoscaled_pool.test.ts
+++ b/test/core/autoscaling/autoscaled_pool.test.ts
@@ -497,43 +497,6 @@ describe('AutoscaledPool', () => {
         results.forEach((r, i) => expect(r).toEqual(i));
     });
 
-    test('should clear the polling interval when pause times out', async () => {
-        let resolveTask: () => void;
-        const taskStarted = new Promise<void>((res) => {
-            resolveTask = res;
-        });
-
-        // A task that stays in flight so currentConcurrency never drops to 0,
-        // forcing pause() to hit its timeout (reject) branch.
-        const pool = new AutoscaledPool({
-            minConcurrency: 1,
-            maxConcurrency: 1,
-            runTaskFunction: async () => {
-                resolveTask();
-                await new Promise<void>(() => {});
-            },
-            isFinishedFunction: async () => false,
-            isTaskReadyFunction: async () => true,
-        });
-
-        const setIntervalSpy = vitest.spyOn(globalThis, 'setInterval');
-        const clearIntervalSpy = vitest.spyOn(globalThis, 'clearInterval');
-
-        const runPromise = pool.run();
-        await taskStarted;
-
-        setIntervalSpy.mockClear();
-        await expect(pool.pause(50)).rejects.toThrow('running tasks did not finish');
-
-        // pause() creates exactly one polling interval; it must be cleared on the
-        // timeout path, otherwise the timer leaks and keeps firing forever.
-        const pollingInterval = setIntervalSpy.mock.results[0].value;
-        expect(clearIntervalSpy).toHaveBeenCalledWith(pollingInterval);
-
-        await pool.abort();
-        await runPromise;
-    });
-
     test('should timeout after taskTimeoutSecs', async () => {
         const runTaskFunction = async () => {
             await sleep(1e3);

--- a/test/core/autoscaling/autoscaled_pool.test.ts
+++ b/test/core/autoscaling/autoscaled_pool.test.ts
@@ -497,6 +497,43 @@ describe('AutoscaledPool', () => {
         results.forEach((r, i) => expect(r).toEqual(i));
     });
 
+    test('should clear the polling interval when pause times out', async () => {
+        let resolveTask: () => void;
+        const taskStarted = new Promise<void>((res) => {
+            resolveTask = res;
+        });
+
+        // A task that stays in flight so currentConcurrency never drops to 0,
+        // forcing pause() to hit its timeout (reject) branch.
+        const pool = new AutoscaledPool({
+            minConcurrency: 1,
+            maxConcurrency: 1,
+            runTaskFunction: async () => {
+                resolveTask();
+                await new Promise<void>(() => {});
+            },
+            isFinishedFunction: async () => false,
+            isTaskReadyFunction: async () => true,
+        });
+
+        const setIntervalSpy = vitest.spyOn(globalThis, 'setInterval');
+        const clearIntervalSpy = vitest.spyOn(globalThis, 'clearInterval');
+
+        const runPromise = pool.run();
+        await taskStarted;
+
+        setIntervalSpy.mockClear();
+        await expect(pool.pause(50)).rejects.toThrow('running tasks did not finish');
+
+        // pause() creates exactly one polling interval; it must be cleared on the
+        // timeout path, otherwise the timer leaks and keeps firing forever.
+        const pollingInterval = setIntervalSpy.mock.results[0].value;
+        expect(clearIntervalSpy).toHaveBeenCalledWith(pollingInterval);
+
+        await pool.abort();
+        await runPromise;
+    });
+
     test('should timeout after taskTimeoutSecs', async () => {
         const runTaskFunction = async () => {
             await sleep(1e3);


### PR DESCRIPTION

### What
`AutoscaledPool.pause(timeoutSecs)` starts a polling `setInterval` that resolves the
pause promise once concurrency drops to `0`, at which point it clears both the
interval and the timeout. When `timeoutSecs` elapses first, the timeout callback
only rejected the promise and never cleared that interval, so the polling timer
leaked and kept firing every `maybeRunIntervalMillis` (default 500 ms) for the rest
of the process lifetime.

### Why it matters
The timeout path is reachable in normal operation via `_pauseOnMigration()`, which
calls `this.autoscaledPool.pause(SAFE_MIGRATION_WAIT_MILLIS)` and `.catch()`es the
"running tasks did not finish" rejection. On a platform migration whose in-flight
requests take longer than the wait, the rejection is swallowed and a live timer is
left behind, reading `_currentConcurrency` on every tick for the remaining lifetime
of the process.

### Fix
Clear the interval on the reject path as well, mirroring the existing cleanup on the
resolve path. The change is three source lines: hoist `interval` to a `let`
declaration (next to the existing `let timeout`) and call `clearInterval(interval)`
at the top of the timeout callback before rejecting.

```diff
             let timeout: NodeJS.Timeout;
+            let interval: NodeJS.Timeout;
             if (timeoutSecs) {
                 timeout = setTimeout(() => {
+                    // Clean up the polling interval to prevent it from leaking on timeout.
+                    clearInterval(interval);
                     const err = new Error(
                         "The pool's running tasks did not finish" +
                             `in ${timeoutSecs} secs after pool.pause() invocation.`,
                     );
                     reject(err);
                 }, timeoutSecs);
             }

-            const interval = setInterval(() => {
+            interval = setInterval(() => {
```

The `setTimeout` callback runs asynchronously after the Promise executor has already
assigned `interval = setInterval(...)`, so there is no use-before-assignment issue
(`tsc` confirms).

### Test
Adds `should clear the polling interval when pause times out` in
`test/core/autoscaling/autoscaled_pool.test.ts`. It holds a task in flight so
concurrency never reaches `0`, forcing pause() onto the timeout branch, then asserts
the polling interval handle was passed to `clearInterval`. The spy is unambiguous
because task scheduling uses `betterSetInterval` (which is built on `setTimeout`),
so pause()'s interval is the only native `setInterval` in the flow. Reverting only
the source fix makes the new test fail with `clearInterval ... Number of calls: 0`.

### Checks run locally (Node 24.18.0, yarn 4.10.3)
- `yarn vitest run test/core/autoscaling/autoscaled_pool.test.ts` -> 22 passed
- `yarn vitest run test/core/autoscaling/` -> 40 passed (no sibling regressions)
- `yarn eslint` on the changed source and test files -> clean
- `biome format` on the changed files -> clean
- `tsc -p packages/core/tsconfig.build.json --noEmit` -> clean

### Out of scope (intentionally not touched)
There is a pre-existing missing space in the error message ("did not finish" +
"in ... secs" concatenates to "did not finishin ... secs") and the `timeoutSecs`
parameter is actually treated as milliseconds by the caller and `setTimeout`. Both
are separate from this leak fix and left for a follow-up to keep this diff surgical.

---

## Files changed
- `packages/core/src/autoscaling/autoscaled_pool.ts` (+4 / -1)
- `test/core/autoscaling/autoscaled_pool.test.ts` (+37)
