### PR TITLE
fix(core): let constructor options override crawlee.json

### DIFF
--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -508,7 +508,8 @@ export class Configuration {
             try {
                 const file = readFileSync(path);
                 const optionsFromFileConfig = JSON.parse(file.toString());
-                Object.assign(options, optionsFromFileConfig);
+                // The file is the baseline, so the constructor options take precedence over it.
+                options = { ...optionsFromFileConfig, ...options };
             } catch {
                 // ignore
             }

--- a/test/core/configuration.test.ts
+++ b/test/core/configuration.test.ts
@@ -1,0 +1,68 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { Configuration } from '@crawlee/core';
+
+describe('Configuration - crawlee.json precedence', () => {
+    let cwd: string;
+    const savedEnv: Record<string, string | undefined> = {};
+
+    function writeCrawleeJson(config: Record<string, unknown>) {
+        writeFileSync(join(cwd, 'crawlee.json'), JSON.stringify(config));
+    }
+
+    function stashEnv(...names: string[]) {
+        for (const name of names) {
+            savedEnv[name] = process.env[name];
+            delete process.env[name];
+        }
+    }
+
+    beforeEach(() => {
+        cwd = mkdtempSync(join(tmpdir(), 'crawlee-config-'));
+        vi.spyOn(process, 'cwd').mockReturnValue(cwd);
+    });
+
+    afterEach(() => {
+        for (const [name, value] of Object.entries(savedEnv)) {
+            if (value === undefined) {
+                delete process.env[name];
+            } else {
+                process.env[name] = value;
+            }
+            delete savedEnv[name];
+        }
+
+        rmSync(cwd, { recursive: true, force: true });
+    });
+
+    test('constructor options override crawlee.json', () => {
+        stashEnv('CRAWLEE_PERSIST_STATE_INTERVAL_MILLIS', 'CRAWLEE_DEFAULT_DATASET_ID');
+        writeCrawleeJson({ persistStateIntervalMillis: 111_111, defaultDatasetId: 'from-file' });
+
+        const config = new Configuration({ persistStateIntervalMillis: 222_222, defaultDatasetId: 'from-constructor' });
+
+        expect(config.get('persistStateIntervalMillis')).toBe(222_222);
+        expect(config.get('defaultDatasetId')).toBe('from-constructor');
+    });
+
+    test('crawlee.json applies for keys not provided in the constructor', () => {
+        stashEnv('CRAWLEE_DEFAULT_DATASET_ID');
+        writeCrawleeJson({ defaultDatasetId: 'from-file' });
+
+        const config = new Configuration();
+
+        expect(config.get('defaultDatasetId')).toBe('from-file');
+    });
+
+    test('environment variables override both crawlee.json and constructor options', () => {
+        stashEnv('CRAWLEE_PERSIST_STATE_INTERVAL_MILLIS');
+        writeCrawleeJson({ persistStateIntervalMillis: 111_111 });
+        process.env.CRAWLEE_PERSIST_STATE_INTERVAL_MILLIS = '333333';
+
+        const config = new Configuration({ persistStateIntervalMillis: 222_222 });
+
+        expect(config.get('persistStateIntervalMillis')).toBe(333_333);
+    });
+});


### PR DESCRIPTION

`Configuration.buildOptions()` loads `crawlee.json` from the working directory and
merges it with the constructor options using
`Object.assign(options, optionsFromFileConfig)`. Because `Object.assign(target,
source)` writes `source` over `target`, the file's values overwrite the options
passed to the `Configuration` constructor, so `crawlee.json` wins.

That is the inverse of the documented precedence. The `Configuration` JSDoc states:

```text
crawlee.json < constructor options < environment variables
```

and the configuration guide (`docs/guides/configuration.mdx`) says the same:
"`crawlee.json` is a baseline. The options provided in the `Configuration`
constructor will override the options provided in the JSON. Environment variables
will override both." The code comment right above the merge even calls the file
"the baseline".

Concretely, with a `crawlee.json` of
`{ "persistStateIntervalMillis": 111111, "defaultDatasetId": "from-file" }` in the
project root and the matching env vars unset:

```ts
const config = new Configuration({
    persistStateIntervalMillis: 222222,
    defaultDatasetId: 'from-constructor',
});

config.get('persistStateIntervalMillis'); // 111111 (from the file) - should be 222222
config.get('defaultDatasetId');           // 'from-file' - should be 'from-constructor'
```

### Fix

Swap the merge direction so the file config is applied first as the baseline and the
constructor options take precedence:

```ts
options = { ...optionsFromFileConfig, ...options };
```

The `pathExistsSync` guard and the surrounding `try/catch` are unchanged.
Environment-variable precedence is handled separately in `get()` (env vars are read
before instance options) and is deliberately left untouched, so the full documented
order `crawlee.json < constructor options < environment variables` holds.

### Tests

Adds `test/core/configuration.test.ts`, which points `process.cwd()` at a temp
directory containing a written `crawlee.json` and asserts:

- constructor options override `crawlee.json` (fails before this change, passes
  after);
- a key present only in `crawlee.json` is still applied;
- a matching `CRAWLEE_*` environment variable still overrides both.

```
yarn vitest run test/core/configuration.test.ts   # 3/3 pass
```
