### PR TITLE
test(e2e): use impit in the robots file test

### DIFF
--- a/test/e2e/cheerio-robots-file/actor/main.js
+++ b/test/e2e/cheerio-robots-file/actor/main.js
@@ -1,4 +1,5 @@
 import { CheerioCrawler } from '@crawlee/cheerio';
+import { Browser, ImpitHttpClient } from '@crawlee/impit-client';
 import { Actor } from 'apify';
 
 await Actor.init({
@@ -9,8 +10,9 @@ await Actor.init({
 });
 
 const crawler = new CheerioCrawler({
-    // The store rate-limits the platform's shared egress IP, so crawl through a proxy.
     proxyConfiguration: await Actor.createProxyConfiguration(),
+    // The store 429s plain HTTP clients; impersonating a browser gets us through.
+    httpClient: new ImpitHttpClient({ browser: Browser.Firefox }),
     maxRequestsPerCrawl: 10,
     respectRobotsTxtFile: true,
 });

--- a/test/e2e/cheerio-robots-file/actor/package.json
+++ b/test/e2e/cheerio-robots-file/actor/package.json
@@ -11,6 +11,7 @@
         "@crawlee/core": "file:./packages/core",
         "@crawlee/memory-storage": "file:./packages/memory-storage",
         "@crawlee/cheerio": "file:./packages/cheerio-crawler",
+        "@crawlee/impit-client": "file:./packages/impit-client",
         "@crawlee/types": "file:./packages/types",
         "@crawlee/utils": "file:./packages/utils"
     },


### PR DESCRIPTION
`cheerio-robots-file` is the last E2E failure on PLATFORM (43/44 otherwise). It 429s on the start URL and every retry, so `requestsFinished` is 0 and the test fails on its precondition — the robots.txt behaviour it actually asserts is fine.

The block keys off the **client**, not the IP:

| Client | IP | Result |
| --- | --- | --- |
| browser | Apify (AWS) | 200 |
| plain HTTP | Apify (AWS) | 429 |
| plain HTTP | Apify proxy | 429 |
| plain HTTP | GitHub runner | 200 |

The browser-driven tests reach the same store from the same address, and #3855 showed that routing this crawl through a proxy changed nothing on PLATFORM — it just moved the same bot-shaped request to a different datacenter IP.

So impersonate a browser instead, the same way `cheerio-impit-ts` already does (which passes on PLATFORM). The proxy stays in place.