### PR TITLE
chore: make `format:check` actually check the formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "lint": "oxlint packages test docs --tsconfig=tsconfig.json --type-aware",
         "lint:fix": "oxlint packages test docs --tsconfig=tsconfig.json --type-aware --fix",
         "format": "oxfmt packages test docs --write",
-        "format:check": "oxfmt packages test docs",
+        "format:check": "oxfmt packages test docs --check",
         "prepare": "husky"
     },
     "devDependencies": {

--- a/packages/browser-pool/test/remote-browser.test.ts
+++ b/packages/browser-pool/test/remote-browser.test.ts
@@ -83,7 +83,10 @@ function createMockLogger(): CrawleeLogger & { warning: ReturnType<typeof vi.fn>
 }
 
 /** A fake {@link RemoteConnection} that resolves to a fixed URL and records release() calls. */
-function createConnection(url = 'wss://remote:9222', context?: Record<string, unknown>): RemoteConnection & {
+function createConnection(
+    url = 'wss://remote:9222',
+    context?: Record<string, unknown>,
+): RemoteConnection & {
     resolve: ReturnType<typeof vi.fn>;
     release: ReturnType<typeof vi.fn>;
 } {
@@ -147,7 +150,9 @@ describe('Remote connection — PlaywrightPlugin', () => {
         const connection = createConnection();
         plugin.useRemoteConnection(connection);
 
-        await expect(plugin.launch(plugin.createLaunchContext())).rejects.toThrow(/Failed to connect to remote browser/);
+        await expect(plugin.launch(plugin.createLaunchContext())).rejects.toThrow(
+            /Failed to connect to remote browser/,
+        );
         expect(connection.release).toHaveBeenCalledWith(42);
     });
 
@@ -158,7 +163,9 @@ describe('Remote connection — PlaywrightPlugin', () => {
         connection.resolve.mockRejectedValueOnce(new Error('no session'));
         plugin.useRemoteConnection(connection);
 
-        await expect(plugin.launch(plugin.createLaunchContext())).rejects.toThrow(/resolve the remote browser endpoint/);
+        await expect(plugin.launch(plugin.createLaunchContext())).rejects.toThrow(
+            /resolve the remote browser endpoint/,
+        );
         expect(lib.connectOverCDP).not.toHaveBeenCalled();
         expect(connection.release).not.toHaveBeenCalled();
     });
@@ -198,7 +205,9 @@ describe('Remote connection — PuppeteerPlugin', () => {
         const connection = createConnection();
         plugin.useRemoteConnection(connection);
 
-        await expect(plugin.launch(plugin.createLaunchContext())).rejects.toThrow(/Failed to connect to remote browser/);
+        await expect(plugin.launch(plugin.createLaunchContext())).rejects.toThrow(
+            /Failed to connect to remote browser/,
+        );
         expect(connection.release).toHaveBeenCalledWith(42);
     });
 

--- a/test/core/browser_launchers/playwright_launcher.test.ts
+++ b/test/core/browser_launchers/playwright_launcher.test.ts
@@ -288,5 +288,4 @@ describe('launchPlaywright()', () => {
             recursive: true,
         });
     });
-
 });

--- a/test/core/browser_launchers/puppeteer_launcher.test.ts
+++ b/test/core/browser_launchers/puppeteer_launcher.test.ts
@@ -308,5 +308,4 @@ describe('launchPuppeteer()', () => {
             recursive: true,
         });
     });
-
 });


### PR DESCRIPTION
`format:check` ran bare `oxfmt`, which defaults to writing:

```
"format": "oxfmt packages test docs --write",
"format:check": "oxfmt packages test docs",
```

So the CI step (`.github/workflows/test-ci.yml:163`) rewrote the files inside the runner and exited 0. The formatting gate could never fail, and three files drifted past it.

Adds the missing `--check` and reformats the drift, which turned out to be exactly three files — all cosmetic (one wrapped signature, two stray blank lines). With the fix in place `pnpm format:check` correctly exits 1 on unformatted input.

Found while working on the timeout changes, where a stray `pnpm format:check` spontaneously reformatted files in a clean tree.