### PR TITLE
fix: avoid duplicate final crawler persistence

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -574,7 +574,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
     protected retryOnBlocked: boolean;
     protected respectRobotsTxtFile: boolean | { userAgent?: string };
     protected onSkippedRequest?: SkippedRequestCallback;
-    private _ownsEventManager: boolean = false;
+    private _ownsEventManager = false;
     private loggedPerRun = new Set<string>();
     private experiments: CrawlerExperiments;
     private readonly robotsTxtFileCache: LruCache<RobotsTxtFile>;

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -1041,8 +1041,8 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
         try {
             await this.autoscaledPool!.run();
         } finally {
-            await this.teardown();
             await this.stats.stopCapturing();
+            await this.teardown();
 
             process.off('SIGINT', sigintHandler);
             this.events.off(EventType.MIGRATING, boundPauseOnMigration);
@@ -1979,10 +1979,15 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
      * To stop the crawler gracefully (waiting for all running requests to finish), use {@apilink BasicCrawler.stop|`crawler.stop()`} instead.
      */
     async teardown(): Promise<void> {
-        this.events.emit(EventType.PERSIST_STATE, { isMigrating: false });
+        // When this crawler initialized the event manager, its close() call emits
+        // the final persistence event after the crawler-specific state has been
+        // saved. External event managers still need an explicit event here.
+        if (!this._closeEvents) {
+            this.events.emit(EventType.PERSIST_STATE, { isMigrating: false });
+        }
 
         if (this.useSessionPool) {
-            await this.sessionPool!.teardown();
+            await this.sessionPool!.teardown({ persistState: this._closeEvents === true });
         }
 
         if (this._closeEvents) {

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -574,7 +574,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
     protected retryOnBlocked: boolean;
     protected respectRobotsTxtFile: boolean | { userAgent?: string };
     protected onSkippedRequest?: SkippedRequestCallback;
-    private _closeEvents?: boolean;
+    private _ownsEventManager: boolean = false;
     private loggedPerRun = new Set<string>();
     private experiments: CrawlerExperiments;
     private readonly robotsTxtFileCache: LruCache<RobotsTxtFile>;
@@ -1358,7 +1358,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
     protected async _init(): Promise<void> {
         if (!this.events.isInitialized()) {
             await this.events.init();
-            this._closeEvents = true;
+            this._ownsEventManager = true;
         }
 
         this.autoscaledPool = new AutoscaledPool(this.autoscaledPoolOptions, this.config);
@@ -1982,15 +1982,15 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
         // When this crawler initialized the event manager, its close() call emits
         // the final persistence event after the crawler-specific state has been
         // saved. External event managers still need an explicit event here.
-        if (!this._closeEvents) {
+        if (!this._ownsEventManager) {
             this.events.emit(EventType.PERSIST_STATE, { isMigrating: false });
         }
 
         if (this.useSessionPool) {
-            await this.sessionPool!.teardown({ persistState: this._closeEvents === true });
+            await this.sessionPool!.teardown({ persistState: this._ownsEventManager });
         }
 
-        if (this._closeEvents) {
+        if (this._ownsEventManager) {
             await this.events.close();
         }
 

--- a/packages/core/src/session_pool/session_pool.ts
+++ b/packages/core/src/session_pool/session_pool.ts
@@ -384,10 +384,13 @@ export class SessionPool extends EventEmitter {
     /**
      * Removes listener from `persistState` event.
      * This function should be called after you are done with using the `SessionPool` instance.
+     * @param options - Set `persistState` to false when the final state was already persisted by the event manager.
      */
-    async teardown(): Promise<void> {
+    async teardown({ persistState = true }: { persistState?: boolean } = {}): Promise<void> {
         this.events.off(EventType.PERSIST_STATE, this._listener);
-        await this.persistState();
+        if (persistState) {
+            await this.persistState();
+        }
     }
 
     /**

--- a/test/core/crawlers/basic_crawler.test.ts
+++ b/test/core/crawlers/basic_crawler.test.ts
@@ -23,7 +23,7 @@ import {
     RequestList,
     RequestQueue,
 } from '@crawlee/basic';
-import { RequestState } from '@crawlee/core';
+import { RequestState, SessionPool, Statistics } from '@crawlee/core';
 import type { Dictionary } from '@crawlee/utils';
 import { RobotsTxtFile, sleep } from '@crawlee/utils';
 import express from 'express';
@@ -1333,6 +1333,52 @@ describe('BasicCrawler', () => {
     });
 
     describe('Uses SessionPool', () => {
+        it('persists statistics and the session pool once when finishing', async () => {
+            const persistStatistics = vitest.spyOn(Statistics.prototype, 'persistState');
+            const persistSessionPool = vitest.spyOn(SessionPool.prototype, 'persistState');
+            const config = new Configuration();
+            const crawler = new BasicCrawler(
+                {
+                    useSessionPool: true,
+                    requestHandler: async () => {
+                        persistStatistics.mockClear();
+                        persistSessionPool.mockClear();
+                    },
+                },
+                config,
+            );
+
+            await crawler.run(['https://example.com']);
+
+            expect(persistStatistics).toHaveBeenCalledTimes(1);
+            expect(persistSessionPool).toHaveBeenCalledTimes(1);
+        });
+
+        it('persists the session pool once with a shared event manager', async () => {
+            const persistStatistics = vitest.spyOn(Statistics.prototype, 'persistState');
+            const persistSessionPool = vitest.spyOn(SessionPool.prototype, 'persistState');
+            const config = new Configuration();
+            await config.getEventManager().init();
+            const crawler = new BasicCrawler(
+                {
+                    useSessionPool: true,
+                    requestHandler: async () => {
+                        persistStatistics.mockClear();
+                        persistSessionPool.mockClear();
+                    },
+                },
+                config,
+            );
+
+            await crawler.run(['https://example.com']);
+            expect(config.getEventManager().listenerCount(EventType.PERSIST_STATE)).toBe(0);
+            expect(persistSessionPool).toHaveBeenCalledTimes(1);
+            await config.getEventManager().close();
+
+            expect(persistStatistics).toHaveBeenCalledTimes(1);
+            expect(persistSessionPool).toHaveBeenCalledTimes(1);
+        });
+
         it('should use SessionPool when useSessionPool is true ', async () => {
             const url = 'https://example.com';
             const requestList = await RequestList.open({ sources: [{ url }] });


### PR DESCRIPTION
## Summary

Avoid duplicate final persistence during `BasicCrawler.run()` shutdown.

- Stop statistics before crawler teardown so the final statistics record is written once with its completion timestamp.
- Let a crawler-owned event manager emit the final persistence event after the session pool listener is removed.
- Keep the explicit persistence event for shared event managers, while preventing `SessionPool.teardown()` from writing the same state a second time.

## Root cause

The shutdown path emitted `PERSIST_STATE`, then directly persisted the session pool and statistics again. A crawler-owned event manager emitted another final event as it closed, which added a second write for statistics.

## Validation

- `corepack yarn vitest run test/core/crawlers/basic_crawler.test.ts --silent` (70 passed)
- `corepack yarn eslint packages/core/src/session_pool/session_pool.ts packages/basic-crawler/src/internals/basic-crawler.ts test/core/crawlers/basic_crawler.test.ts`
- `corepack yarn tsc-check-tests`
- `corepack yarn biome format --write ...`
- `git diff --check`

Fixes #3167