### PR TITLE
chore(ci): fix failing e2e and docs actions after rebase

### DIFF
--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -139,7 +139,7 @@ jobs:
             -   name: Start Docusaurus server
                 run: |
                     cd website
-                    nohup yarn docusaurus serve --port 3000 --no-open &
+                    nohup pnpm docusaurus serve --port 3000 --no-open &
                     sleep 5
                     curl -f http://localhost:3000 > /dev/null
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -56,7 +56,7 @@ jobs:
                 uses: actions/cache@v6
                 with:
                     path: ~/.cache/ms-playwright
-                    key: playwright-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+                    key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
                     restore-keys: |
                         playwright-${{ runner.os }}-
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -10,10 +10,6 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
 
-concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
-
 jobs:
     build_and_test:
         name: Build & Test

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -172,14 +172,6 @@ module.exports = {
                         to: '/js/docs/deployment/apify-platform',
                     },
                     {
-                        from: '/js/docs/experiments/experiments-system-infomation-v2',
-                        to: '/js/docs/experiments/experiments-system-information-v2',
-                    },
-                    {
-                        from: '/js/docs/next/experiments/experiments-system-infomation-v2',
-                        to: '/js/docs/next/experiments/experiments-system-information-v2',
-                    },
-                    {
                         from: '/js/docs/3.13/experiments/experiments-system-infomation-v2',
                         to: '/js/docs/3.13/experiments/experiments-system-information-v2',
                     },
@@ -193,7 +185,7 @@ module.exports = {
                     },
                     {
                         from: '/js/docs/3.16/experiments/experiments-system-infomation-v2',
-                        to: '/js/docs/experiments/experiments-system-information-v2',
+                        to: '/js/docs/3.16/experiments/experiments-system-information-v2',
                     },
                 ],
                 // createRedirects(existingPath) {

--- a/website/versioned_docs/version-3.17/upgrading/upgrading_v3.md
+++ b/website/versioned_docs/version-3.17/upgrading/upgrading_v3.md
@@ -31,7 +31,7 @@ The [`crawlee`](https://www.npmjs.com/package/crawlee) package consists of sever
 - [`@crawlee/memory-storage`](https://crawlee.dev/js/api/memory-storage): [`@apify/storage-local`](https://npmjs.com/package/@apify/storage-local) alternative
 - [`@crawlee/browser-pool`](https://crawlee.dev/js/api/browser-pool): previously [`browser-pool`](https://npmjs.com/package/browser-pool) package
 - [`@crawlee/utils`](https://crawlee.dev/js/api/utils): utility methods
-- [`@crawlee/types`](https://crawlee.dev/js/api/types): holds TS interfaces mainly about the [`StorageClient`](https://crawlee.dev/js/api/core/interface/StorageClient)
+- [`@crawlee/types`](https://crawlee.dev/js/api/types): holds TS interfaces mainly about the [`StorageClient`](https://crawlee.dev/js/api/3.17/core/interface/StorageClient)
 
 ### Installing Crawlee
 


### PR DESCRIPTION
Fixes the last outstanding issues after the master <- v4 rebase. This was a mix of incorrectly resolved conflicts and valid `v4` versioning changes in the docs.