### PR TITLE
chore(test): sitemap backpressure test hangs on cross-hostname URLs

### DIFF
--- a/test/core/sitemap_request_list.test.ts
+++ b/test/core/sitemap_request_list.test.ts
@@ -699,6 +699,7 @@ describe('SitemapRequestList', () => {
             sitemapUrls: [`${url}/sitemap.xml`],
             persistStateKey: 'backpressure-persist',
             maxBufferSize: 1,
+            enqueueStrategy: 'all',
         });
 
         // Wait until the first URL is buffered, i.e. the loader is parked on backpressure.


### PR DESCRIPTION
The default same-hostname enqueue strategy silently drops the test's not-exists.com URLs, so the loader never pushes anything and the test hangs waiting.

Regressed by the interaction between #3797 and #3863.