### PR TITLE
fix(sitemap): recognize sitemap_index as a valid input sitemap url

### DIFF
--- a/packages/utils/src/internals/sitemap.ts
+++ b/packages/utils/src/internals/sitemap.ts
@@ -598,7 +598,7 @@ export async function* discoverValidSitemaps(
             log.warning(`Failed to fetch robots.txt file for ${hostname}`, { error: err });
         }
 
-        const sitemapUrl = domainUrls.find((url) => /sitemap\.(?:xml|txt)(?:\.gz)?$/i.test(url));
+        const sitemapUrl = domainUrls.find((url) => /sitemap(?:_index)?\.(?:xml|txt)(?:\.gz)?$/i.test(url));
 
         if (sitemapUrl !== undefined) {
             if (addSitemapUrl(sitemapUrl)) {


### PR DESCRIPTION
Small fix on sitemap discovery to avoid head request when we already pass `/sitemap_index.<extension>` as an input.