### PR TITLE
refactor: move debug helpers to `@crawlee/core`

### DIFF
--- a/docs/public-api/crawlee-core.api.md
+++ b/docs/public-api/crawlee-core.api.md
@@ -21,6 +21,7 @@ import type { DatasetBackend } from '@crawlee/types';
 import type { DatasetInfo } from '@crawlee/types';
 import { Dictionary } from '@crawlee/types';
 import type { HttpRequestOptions } from '@crawlee/types';
+import type { IncomingMessage } from 'node:http';
 import type { ISession } from '@crawlee/types';
 import type { ISessionPool } from '@crawlee/types';
 import type { KeyValueStoreBackend } from '@crawlee/types';

--- a/docs/public-api/crawlee-utils.api.md
+++ b/docs/public-api/crawlee-utils.api.md
@@ -4,7 +4,6 @@
 
 ```ts
 
-import type { AllowedHttpMethods } from '@crawlee/types';
 import { Awaitable } from '@crawlee/types';
 import type { BaseHttpClient } from '@crawlee/types';
 import { Cheerio } from 'cheerio';
@@ -13,7 +12,6 @@ import { Constructor } from '@crawlee/types';
 import type { CrawleeLogger } from '@crawlee/types';
 import { Dictionary } from '@crawlee/types';
 import { Element as Element_2 } from 'domhandler';
-import type { IncomingMessage } from 'node:http';
 import type { SearchParams } from '@crawlee/types';
 
 export { Awaitable }
@@ -32,9 +30,6 @@ export function chunk<T>(array: readonly T[], chunkSize: number): T[][];
 export const CLOUDFLARE_RETRY_CSS_SELECTORS: string[];
 
 export { Constructor }
-
-// @public
-export function createRequestDebugInfo(request: Request_2, response?: IncomingMessage | Partial<BrowserResponseLike>, additionalFields?: Dictionary): Dictionary;
 
 export { Dictionary }
 
@@ -103,9 +98,6 @@ const FACEBOOK_REGEX: RegExp;
 
 // @public
 const FACEBOOK_REGEX_GLOBAL: RegExp;
-
-// @public (undocumented)
-export function getObjectType(value: unknown): string;
 
 // @public
 export function htmlToText(htmlOrCheerioElement: string | CheerioRoot): Promise<string>;

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -41,6 +41,7 @@ import {
     enqueueLinks,
     EnqueueStrategy,
     EventType,
+    getObjectType,
     KeyValueStore,
     log,
     LogLevel,
@@ -77,7 +78,7 @@ import type {
     SetStatusMessageOptions,
     StorageBackend,
 } from '@crawlee/types';
-import { getObjectType, isAsyncIterable, isIterable, RobotsTxtFile, ROTATE_PROXY_ERRORS } from '@crawlee/utils';
+import { isAsyncIterable, isIterable, RobotsTxtFile, ROTATE_PROXY_ERRORS } from '@crawlee/utils';
 import { stringify } from 'csv-stringify/sync';
 import { ensureDir, writeJSON } from 'fs-extra/esm';
 import ow from 'ow';

--- a/packages/core/src/debug.ts
+++ b/packages/core/src/debug.ts
@@ -1,26 +1,13 @@
 import type { IncomingMessage } from 'node:http';
 import { inspect } from 'node:util';
 
-import type { AllowedHttpMethods, Dictionary } from '@crawlee/types';
+import type { Dictionary } from '@crawlee/types';
 import ow from 'ow';
+
+import type { Request } from './request.js';
 
 interface BrowserResponseLike {
     status(): number;
-}
-
-interface Request<UserData extends Dictionary = Dictionary> {
-    id?: string;
-    url: string;
-    loadedUrl?: string;
-    uniqueKey: string;
-    method: AllowedHttpMethods;
-    payload?: string;
-    noRetry: boolean;
-    retryCount: number;
-    errorMessages: string[];
-    headers?: Record<string, string>;
-    userData: UserData;
-    handledAt?: string;
 }
 
 /**
@@ -31,6 +18,8 @@ interface Request<UserData extends Dictionary = Dictionary> {
  *   Puppeteer [`Response`](https://pptr.dev/#?product=Puppeteer&version=v1.11.0&show=api-class-response)
  *   or NodeJS [`http.IncomingMessage`](https://nodejs.org/api/http.html#http_class_http_serverresponse).
  * @param [additionalFields] Object containing additional fields to be added.
+ *
+ * @internal
  */
 export function createRequestDebugInfo(
     request: Request,
@@ -80,6 +69,12 @@ export function inspectValue(value: unknown): string {
     });
 }
 
+/**
+ * Returns the type of a value as a lowercase string, with `Date`, `Buffer` and `RegExp` reported
+ * by their constructor name. Used for building validation error messages.
+ *
+ * @internal
+ */
 export function getObjectType(value: unknown): string {
     const simple = typeof value;
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,4 +1,4 @@
-import { inspectValue } from '@crawlee/utils';
+import { inspectValue } from './debug.js';
 
 /**
  * Errors of `NonRetryableError` type will never be retried by the crawler.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+export * from './debug.js';
 export * from './errors.js';
 export * from './autoscaling/index.js';
 export * from './configuration.js';

--- a/packages/core/src/storages/request_queue.ts
+++ b/packages/core/src/storages/request_queue.ts
@@ -12,7 +12,6 @@ import type {
 import {
     chunkedAsyncIterable,
     downloadListOfUrls,
-    getObjectType,
     isAsyncIterable,
     isIterable,
     peekableAsyncIterable,
@@ -24,6 +23,7 @@ import type { ReadonlyDeep } from 'type-fest';
 import { LruCache } from '@apify/datastructures';
 
 import { Configuration } from '../configuration.js';
+import { getObjectType } from '../debug.js';
 import type { Constructor } from '../typedefs.js';
 import type { EventManager } from '../events/event_manager.js';
 import { EventType } from '../events/event_manager.js';

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -3,7 +3,6 @@ export * from './internals/cheerio.js';
 export * from './internals/chunk.js';
 export * from './internals/extract-urls.js';
 export * from './internals/general.js';
-export * from './internals/debug.js';
 export * as social from './internals/social.js';
 export * from './internals/typedefs.js';
 export * from './internals/open_graph_parser.js';


### PR DESCRIPTION
Moves the single-consumer `createRequestDebugInfo`, `getObjectType` and `inspectValue` helpers from the public `@crawlee/utils` API to `@crawlee/core`.

Related to https://github.com/apify/crawlee/issues/3079