### PR TITLE
fix(core): ignore explicitly undefined baseUrl in enqueueLinks helpers

### DIFF
--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -859,8 +859,8 @@ export async function browserCrawlerEnqueueLinks(
     if (containsEnqueueLinks(options)) {
         return options.enqueueLinks({
             urls,
-            baseUrl,
             ...enqueueLinksOptions,
+            baseUrl,
         });
     }
     return enqueueLinks({
@@ -868,8 +868,8 @@ export async function browserCrawlerEnqueueLinks(
         robotsTxtFile: options.robotsTxtFile,
         onSkippedRequest: options.onSkippedRequest,
         urls,
-        baseUrl,
         ...(enqueueLinksOptions as EnqueueLinksOptions),
+        baseUrl,
     });
 }
 

--- a/packages/cheerio-crawler/src/internals/cheerio-crawler.ts
+++ b/packages/cheerio-crawler/src/internals/cheerio-crawler.ts
@@ -294,8 +294,8 @@ export async function cheerioCrawlerEnqueueLinks(
     if (containsEnqueueLinks(options)) {
         return options.enqueueLinks({
             urls,
-            baseUrl,
             ...enqueueLinksOptions,
+            baseUrl,
         });
     }
     return enqueueLinks({
@@ -303,8 +303,8 @@ export async function cheerioCrawlerEnqueueLinks(
         robotsTxtFile: options.robotsTxtFile,
         onSkippedRequest: options.onSkippedRequest,
         urls,
-        baseUrl,
         ...enqueueLinksOptions,
+        baseUrl,
     });
 }
 

--- a/packages/jsdom-crawler/src/internals/jsdom-crawler.ts
+++ b/packages/jsdom-crawler/src/internals/jsdom-crawler.ts
@@ -395,8 +395,8 @@ export async function domCrawlerEnqueueLinks(options: EnqueueLinksInternalOption
     if (containsEnqueueLinks(options)) {
         return options.enqueueLinks({
             urls,
-            baseUrl,
             ...enqueueLinksOptions,
+            baseUrl,
         });
     }
 
@@ -405,8 +405,8 @@ export async function domCrawlerEnqueueLinks(options: EnqueueLinksInternalOption
         robotsTxtFile: options.robotsTxtFile,
         onSkippedRequest: options.onSkippedRequest,
         urls,
-        baseUrl,
         ...enqueueLinksOptions,
+        baseUrl,
     });
 }
 

--- a/packages/linkedom-crawler/src/internals/linkedom-crawler.ts
+++ b/packages/linkedom-crawler/src/internals/linkedom-crawler.ts
@@ -280,8 +280,8 @@ export async function linkedomCrawlerEnqueueLinks(
     if (containsEnqueueLinks(options)) {
         return options.enqueueLinks({
             urls,
-            baseUrl,
             ...enqueueLinksOptions,
+            baseUrl,
         });
     }
 
@@ -290,8 +290,8 @@ export async function linkedomCrawlerEnqueueLinks(
         robotsTxtFile: options.robotsTxtFile,
         onSkippedRequest: options.onSkippedRequest,
         urls,
-        baseUrl,
         ...enqueueLinksOptions,
+        baseUrl,
     });
 }
 

--- a/test/core/enqueue_links/enqueue_links.test.ts
+++ b/test/core/enqueue_links/enqueue_links.test.ts
@@ -911,6 +911,40 @@ describe('enqueueLinks()', () => {
             expect(enqueued[2].userData).toEqual({});
         });
 
+        test('ignores an explicitly undefined baseUrl and keeps the resolved one', async () => {
+            const { enqueued, requestQueue } = createRequestQueueMock();
+            await cheerioCrawlerEnqueueLinks({
+                options: { strategy: EnqueueStrategy.SameDomain, baseUrl: undefined },
+                $,
+                requestQueue,
+                originalRequestUrl: 'https://example.com',
+            });
+
+            expect(enqueued.map((request) => request.url)).toEqual([
+                'https://example.com/a/b/first',
+                'https://example.com/a/second',
+                'https://example.com/a/b/third',
+                'https://example.com/x/absolutepath',
+                'https://example.com/y/relativepath',
+            ]);
+        });
+
+        test('ignores an explicitly undefined baseUrl when delegating to the bound enqueueLinks', async () => {
+            let forwardedBaseUrl: string | undefined;
+
+            await cheerioCrawlerEnqueueLinks({
+                options: { strategy: EnqueueStrategy.SameDomain, baseUrl: undefined },
+                $,
+                originalRequestUrl: 'https://example.com',
+                enqueueLinks: async (options) => {
+                    forwardedBaseUrl = options?.baseUrl;
+                    return { processedRequests: [], unprocessedRequests: [] };
+                },
+            });
+
+            expect(forwardedBaseUrl).toBe('https://example.com');
+        });
+
         test('correctly resolves relative URLs with `urls` option', async () => {
             const { enqueued, requestQueue } = createRequestQueueMock();
             await cheerioCrawlerEnqueueLinks({


### PR DESCRIPTION
The per-crawler `*CrawlerEnqueueLinks` helpers built their call as `{ urls, baseUrl, ...enqueueLinksOptions }`, so a user options object carrying an explicit `baseUrl: undefined` key overwrote the internally resolved base URL:

```ts
await enqueueLinks({ strategy: 'same-domain', baseUrl: cfg.baseUrl }); // cfg.baseUrl is undefined
```

Neither `ow.optional.string` nor TypeScript (without `exactOptionalPropertyTypes`) rejects an explicitly present `undefined`, so this slipped through silently. Inside `enqueueLinks()` a falsy `baseUrl` leaves `enqueueStrategyPatterns` empty, and an empty pattern array means "no filtering" in both `createRequests` and `filterRequestsByPatterns` — so every link on the page got enqueued regardless of the requested strategy, turning a `same-domain` crawl into an unbounded off-domain one.

Moving `baseUrl` after the spread fixes it, and is safe because `resolveBaseUrlForEnqueueLinksFiltering` already returns `userProvidedBaseUrl` first when the user did supply one, so the resolved value equals the user's whenever it is set. `adaptive-playwright-crawler.ts` already used this ordering.

Affected: `cheerio-crawler`, `browser-crawler`, `jsdom-crawler`, `linkedom-crawler` (both the bound `options.enqueueLinks()` path and the direct `enqueueLinks()` path).