### PR TITLE
refactor!: unify `config` and `configuration` naming

### DIFF
--- a/docs/guides/configuration.mdx
+++ b/docs/guides/configuration.mdx
@@ -137,13 +137,13 @@ The last option to adjust Crawlee configuration is to use the <ApiLink to="core/
 
 ### Global Configuration
 
-By default, there is a global singleton instance of `Configuration` class, it is used by the crawlers and some other classes that depend on a configurable behavior. In most cases you don't need to adjust any options there, but if needed - you can access it via <ApiLink to="core/class/Configuration#getGlobalConfig">`Configuration.getGlobalConfig()`</ApiLink>, which delegates to the global <ApiLink to="core/class/ServiceLocator">`serviceLocator`</ApiLink> — the single source of truth for Crawlee's shared services (for example the configuration, event manager, storage backend, and logger). You can also reach the same instance directly via `serviceLocator.getConfiguration()` or swap services globally with `serviceLocator.setConfiguration(...)` before any crawler is created. Configuration values are accessible directly as properties on the instance.
+By default, there is a global singleton instance of `Configuration` class, it is used by the crawlers and some other classes that depend on a configurable behavior. In most cases you don't need to adjust any options there, but if needed - you can access it via <ApiLink to="core/class/Configuration#getGlobalConfiguration">`Configuration.getGlobalConfiguration()`</ApiLink>, which delegates to the global <ApiLink to="core/class/ServiceLocator">`serviceLocator`</ApiLink> — the single source of truth for Crawlee's shared services (for example the configuration, event manager, storage backend, and logger). You can also reach the same instance directly via `serviceLocator.getConfiguration()` or swap services globally with `serviceLocator.setConfiguration(...)` before any crawler is created. Configuration values are accessible directly as properties on the instance.
 
 ```js
 import { CheerioCrawler, Configuration, sleep } from 'crawlee';
 
 // Get the global configuration
-const config = Configuration.getGlobalConfig();
+const config = Configuration.getGlobalConfiguration();
 // Access configuration values directly as properties
 console.log(config.persistStateIntervalMillis);
 

--- a/docs/public-api/crawlee-core.api.md
+++ b/docs/public-api/crawlee-core.api.md
@@ -209,7 +209,7 @@ export interface Configuration extends ResolvedConfigValues {
 export class Configuration {
     constructor(options?: ConfigurationInput);
     protected static fields: Record<string, ConfigField>;
-    static getGlobalConfig(): Configuration;
+    static getGlobalConfiguration(): Configuration;
 }
 
 // @public (undocumented)
@@ -254,7 +254,7 @@ export { Cookie }
 // @public (undocumented)
 export interface CpuLoadSignalOptions {
     // (undocumented)
-    config: Configuration;
+    configuration: Configuration;
     // (undocumented)
     overloadedRatio?: number;
     // (undocumented)
@@ -345,7 +345,7 @@ export class Dataset<Data extends Dictionary = Dictionary> {
     // (undocumented)
     backend: DatasetBackend<Data>;
     // (undocumented)
-    readonly config: Configuration;
+    readonly configuration: Configuration;
     drop(): Promise<void>;
     entries(options?: DatasetIteratorOptions): AsyncIterable<[number, Data]> & Promise<[number, Data][]>;
     export(options?: DatasetExportOptions): Promise<Data[]>;
@@ -760,7 +760,7 @@ export interface KeyConsumer {
 export class KeyValueStore {
     [Symbol.asyncIterator]<T = unknown>(): AsyncGenerator<[string, T], void, undefined>;
     // (undocumented)
-    readonly config: Configuration;
+    readonly configuration: Configuration;
     drop(): Promise<void>;
     entries<T = unknown>(options?: KeyValueStoreIteratorOptions): AsyncIterable<[string, T]> & Promise<[string, T][]>;
     forEachKey(iteratee: KeyConsumer, options?: KeyValueStoreIteratorOptions): Promise<void>;
@@ -838,7 +838,7 @@ export class LocalEventManager extends EventManager {
     constructor(options: LocalEventManagerOptions);
     // (undocumented)
     close(): Promise<void>;
-    static fromConfig(config?: Configuration): LocalEventManager;
+    static fromConfiguration(configuration?: Configuration): LocalEventManager;
     init(): Promise<void>;
 }
 
@@ -883,7 +883,7 @@ export class MemoryLoadSignal implements LoadSignal {
 // @public (undocumented)
 export interface MemoryLoadSignalOptions {
     // (undocumented)
-    config: Configuration;
+    configuration: Configuration;
     // (undocumented)
     log?: CrawleeLogger;
     // (undocumented)
@@ -990,7 +990,7 @@ export type PseudoUrlObject = {
 export function purgeDefaultStorages(options?: PurgeDefaultStorageOptions): Promise<void>;
 
 // @public
-export function purgeDefaultStorages(config?: Configuration, storageBackend?: StorageBackend): Promise<void>;
+export function purgeDefaultStorages(configuration?: Configuration, storageBackend?: StorageBackend): Promise<void>;
 
 // @public (undocumented)
 export interface PushErrorMessageOptions {
@@ -1018,7 +1018,7 @@ export class RecoverableState<TStateModel = Record<string, unknown>> {
 
 // @public
 export interface RecoverableStateOptions<TStateModel = Record<string, unknown>> extends RecoverableStatePersistenceOptions {
-    config?: Configuration;
+    configuration?: Configuration;
     defaultState: TStateModel;
     deserialize?: (serializedState: string) => TStateModel;
     logger?: CrawleeLogger;
@@ -1082,7 +1082,7 @@ export class RequestHandlerError extends Error {
 
 // @public
 export class RequestHandlerResult {
-    constructor(config: Configuration, crawleeStateKey: string);
+    constructor(configuration: Configuration, crawleeStateKey: string);
     // (undocumented)
     addRequests: RestrictedCrawlingContext['addRequests'];
     get calls(): ReadonlyDeep<{
@@ -1638,7 +1638,7 @@ export class Snapshotter {
     // (undocumented)
     get clientSnapshots(): ClientSnapshot[];
     // (undocumented)
-    readonly config: Configuration;
+    readonly configuration: Configuration;
     // (undocumented)
     get cpuSnapshots(): CpuSnapshot[];
     // (undocumented)
@@ -1776,7 +1776,7 @@ export { StorageIdentifier }
 
 // @public
 export interface StorageOpenOptions {
-    config?: Configuration;
+    configuration?: Configuration;
     httpClient?: BaseHttpClient;
     proxyConfiguration?: IProxyConfiguration;
     storageBackend?: StorageBackend;
@@ -1839,7 +1839,7 @@ export function useState<State extends Dictionary = Dictionary>(name?: string, d
 // @public (undocumented)
 export interface UseStateOptions {
     // (undocumented)
-    config?: Configuration;
+    configuration?: Configuration;
     keyValueStoreName?: string | null;
 }
 

--- a/docs/public-api/crawlee-playwright.api.md
+++ b/docs/public-api/crawlee-playwright.api.md
@@ -235,7 +235,7 @@ function injectJQuery(page: Page, options?: {
 }): Promise<unknown>;
 
 // @public
-export function launchPlaywright(launchContext?: PlaywrightLaunchContext, config?: Configuration): Promise<Browser>;
+export function launchPlaywright(launchContext?: PlaywrightLaunchContext, configuration?: Configuration): Promise<Browser>;
 
 // @public
 function parseWithCheerio(page: Page, ignoreShadowRoots?: boolean, ignoreIframes?: boolean): Promise<CheerioRoot>;
@@ -404,7 +404,7 @@ function saveSnapshot(page: Page, options?: SaveSnapshotOptions): Promise<void>;
 
 // @public (undocumented)
 interface SaveSnapshotOptions {
-    config?: Configuration;
+    configuration?: Configuration;
     key?: string;
     keyValueStoreName?: string | null;
     saveHtml?: boolean;

--- a/docs/public-api/crawlee-puppeteer.api.md
+++ b/docs/public-api/crawlee-puppeteer.api.md
@@ -152,7 +152,7 @@ export type InterceptHandler = (request: HTTPRequest) => unknown;
 function isTargetRelevant(page: Page, target: Target): boolean;
 
 // @public
-export function launchPuppeteer(launchContext?: PuppeteerLaunchContext, config?: Configuration): Promise<Browser>;
+export function launchPuppeteer(launchContext?: PuppeteerLaunchContext, configuration?: Configuration): Promise<Browser>;
 
 // @public
 function parseWithCheerio(page: Page, ignoreShadowRoots?: boolean, ignoreIframes?: boolean): Promise<CheerioRoot>;
@@ -318,7 +318,7 @@ function saveSnapshot(page: Page, options?: SaveSnapshotOptions): Promise<void>;
 
 // @public (undocumented)
 export interface SaveSnapshotOptions {
-    config?: Configuration;
+    configuration?: Configuration;
     key?: string;
     keyValueStoreName?: string | null;
     saveHtml?: boolean;

--- a/docs/upgrading/upgrading_v4.md
+++ b/docs/upgrading/upgrading_v4.md
@@ -92,7 +92,7 @@ const crawler = new PlaywrightCrawler({
 });
 ```
 
-The browser *launchers* (`PlaywrightLauncher`, `PuppeteerLauncher`) keep their `(launchContext?, config?)` constructor signature — this change is only about the crawler classes.
+The browser *launchers* (`PlaywrightLauncher`, `PuppeteerLauncher`) keep their `(launchContext?, configuration?)` constructor signature — this change is only about the crawler classes.
 
 ## Removed symbols
 
@@ -577,7 +577,7 @@ The following methods and properties have been removed from `Configuration`:
 - `Configuration.resetGlobalState()` - use `serviceLocator.reset()` instead
 - `Configuration.storageManagers` - moved to `ServiceLocator.storageManagers`
 
-The `EventManager` and `LocalEventManager` constructors now accept an options object for configuring event intervals (e.g. `persistStateIntervalMillis`, `systemInfoIntervalMillis`). You can also use the new `LocalEventManager.fromConfig()` factory method to create an instance with intervals derived from a `Configuration` object.
+The `EventManager` and `LocalEventManager` constructors now accept an options object for configuring event intervals (e.g. `persistStateIntervalMillis`, `systemInfoIntervalMillis`). You can also use the new `LocalEventManager.fromConfiguration()` factory method to create an instance with intervals derived from a `Configuration` object.
 
 ### Migration guide
 
@@ -617,7 +617,7 @@ const crawler = new BasicCrawler({
     },
     configuration: new Configuration({ headless: false }),
     storageBackend: new MemoryStorageBackend(),
-    eventManager: LocalEventManager.fromConfig(),
+    eventManager: LocalEventManager.fromConfiguration(),
 });
 
 await crawler.run(['https://example.com']);
@@ -643,7 +643,7 @@ const crawler = new BasicCrawler({
 
 ### Accessing configuration
 
-`Configuration.getGlobalConfig()` remains as a utility function, but in most cases, you should use `serviceLocator.getConfiguration()` instead:
+`Configuration.getGlobalConfiguration()` remains as a utility function, but in most cases, you should use `serviceLocator.getConfiguration()` instead:
 
 ```typescript
 import { serviceLocator } from 'crawlee';
@@ -652,6 +652,40 @@ const config = serviceLocator.getConfiguration();
 ```
 
 Do note that the method is currently misnamed - in specific circumstances, it will not return the global configuration object, but the one from the currently active service locator.
+
+### `config` is renamed to `configuration` everywhere
+
+v3 used `config` and `configuration` interchangeably. v4 settles on `configuration`, matching Crawlee for Python.
+
+Renamed methods:
+
+| Before | After |
+| --- | --- |
+| `Configuration.getGlobalConfig()` | `Configuration.getGlobalConfiguration()` |
+| `LocalEventManager.fromConfig()` | `LocalEventManager.fromConfiguration()` |
+
+Renamed options — pass `configuration` instead of `config`:
+
+- `Dataset.open()`, `KeyValueStore.open()` and `RequestQueue.open()` (`StorageOpenOptions`)
+- `useState()` (`UseStateOptions`)
+- `purgeDefaultStorages()` (both the options object and the legacy positional argument)
+- `new Snapshotter()` (`SnapshotterOptions`)
+- `saveSnapshot()` in `@crawlee/playwright` and `@crawlee/puppeteer` (`SaveSnapshotOptions`)
+- `RecoverableStateOptions`, `RequestListOptions`, `CpuLoadSignalOptions` and `MemoryLoadSignalOptions`
+
+**Before:**
+```typescript
+const store = await KeyValueStore.open(null, { config: new Configuration({ persistStorage: false }) });
+```
+
+**After:**
+```typescript
+const store = await KeyValueStore.open(null, { configuration: new Configuration({ persistStorage: false }) });
+```
+
+Renamed properties — `Dataset.config`, `KeyValueStore.config`, `Snapshotter.config` and `BrowserLauncher.config` (including `PlaywrightLauncher`, `PuppeteerLauncher` and `StagehandLauncher`) are now `.configuration`.
+
+The `configuration` crawler option is unchanged, as are `serviceLocator.getConfiguration()` and `serviceLocator.setConfiguration()`.
 
 ## Cookie handling in `HttpCrawler` and `sendRequest`
 

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -1397,7 +1397,7 @@ export class BasicCrawler<
         await purgeDefaultStorages({
             onlyPurgeOnce: true,
             storageBackend: serviceLocator.getStorageBackend(),
-            config: serviceLocator.getConfiguration(),
+            configuration: serviceLocator.getConfiguration(),
         });
 
         if (requests) {
@@ -1537,7 +1537,7 @@ export class BasicCrawler<
         // subsequent instances get their own queue via a unique alias so they don't collide.
         const identifier = this.identity.instanceIndex === 0 ? null : { alias: `__default_${this.identity.id}__` };
 
-        const requestQueue = await RequestQueue.open(identifier, { config: serviceLocator.getConfiguration() });
+        const requestQueue = await RequestQueue.open(identifier, { configuration: serviceLocator.getConfiguration() });
         return this.ownedRequestQueue.set(requestQueue);
     }
 
@@ -1587,7 +1587,7 @@ export class BasicCrawler<
     }
 
     async useState<State extends Dictionary = Dictionary>(defaultValue = {} as State): Promise<State> {
-        const kvs = await KeyValueStore.open(null, { config: serviceLocator.getConfiguration() });
+        const kvs = await KeyValueStore.open(null, { configuration: serviceLocator.getConfiguration() });
 
         if (this.identity.hasExplicitId) {
             const stateKey = `${BasicCrawler.CRAWLEE_STATE_KEY}_${this.identity.id}`;
@@ -1759,7 +1759,7 @@ export class BasicCrawler<
      */
     async getDataset(identifier?: string | StorageIdentifier): Promise<Dataset> {
         return Dataset.open(identifier, {
-            config: serviceLocator.getConfiguration(),
+            configuration: serviceLocator.getConfiguration(),
         });
     }
 
@@ -1920,7 +1920,7 @@ export class BasicCrawler<
                     if (err.message.includes('Cannot persist state.')) {
                         this.log.error(
                             "The crawler attempted to persist its request list's state and failed due to missing or " +
-                                'invalid config. Make sure to use either RequestList.open() or the "stateKeyPrefix" option of RequestList ' +
+                                'invalid configuration. Make sure to use either RequestList.open() or the "stateKeyPrefix" option of RequestList ' +
                                 'constructor to ensure your crawling state is persisted through host migrations and restarts.',
                         );
                     } else {

--- a/packages/browser-crawler/src/internals/browser-launcher.ts
+++ b/packages/browser-crawler/src/internals/browser-launcher.ts
@@ -138,7 +138,7 @@ export abstract class BrowserLauncher<
      */
     constructor(
         launchContext: BrowserLaunchContext<LaunchOptions, Launcher>,
-        readonly config = Configuration.getGlobalConfig(),
+        readonly configuration = Configuration.getGlobalConfiguration(),
     ) {
         const {
             launcher,
@@ -189,7 +189,7 @@ export abstract class BrowserLauncher<
             ...this.launchOptions,
         };
 
-        if (this.config.disableBrowserSandbox) {
+        if (this.configuration.disableBrowserSandbox) {
             launchOptions.args.push('--no-sandbox');
         }
 
@@ -209,11 +209,11 @@ export abstract class BrowserLauncher<
     }
 
     protected getDefaultHeadlessOption(): boolean {
-        return this.config.headless && !this.config.xvfb;
+        return this.configuration.headless && !this.configuration.xvfb;
     }
 
     private getChromeExecutablePath(): string {
-        return this.config.chromeExecutablePath ?? this.getTypicalChromeExecutablePath();
+        return this.configuration.chromeExecutablePath ?? this.getTypicalChromeExecutablePath();
     }
 
     /**

--- a/packages/core/src/autoscaling/cpu_load_signal.ts
+++ b/packages/core/src/autoscaling/cpu_load_signal.ts
@@ -13,7 +13,7 @@ export interface CpuSnapshot extends LoadSnapshot {
 export interface CpuLoadSignalOptions {
     overloadedRatio?: number;
     snapshotHistoryMillis?: number;
-    config: Configuration;
+    configuration: Configuration;
 }
 
 /**

--- a/packages/core/src/autoscaling/memory_load_signal.ts
+++ b/packages/core/src/autoscaling/memory_load_signal.ts
@@ -20,7 +20,7 @@ export interface MemoryLoadSignalOptions {
     maxUsedMemoryRatio?: number;
     overloadedRatio?: number;
     snapshotHistoryMillis?: number;
-    config: Configuration;
+    configuration: Configuration;
     log?: CrawleeLogger;
 }
 
@@ -33,7 +33,7 @@ export class MemoryLoadSignal implements LoadSignal {
     readonly overloadedRatio: number;
 
     private readonly store: SnapshotStore<MemorySnapshot>;
-    private readonly config: Configuration;
+    private readonly configuration: Configuration;
     private readonly events: EventManager;
     private readonly log: CrawleeLogger;
     private readonly maxUsedMemoryRatio: number;
@@ -43,7 +43,7 @@ export class MemoryLoadSignal implements LoadSignal {
 
     constructor(options: MemoryLoadSignalOptions) {
         this.store = new SnapshotStore(options.snapshotHistoryMillis);
-        this.config = options.config;
+        this.configuration = options.configuration;
         this.events = serviceLocator.getEventManager();
         this.log = options.log ?? serviceLocator.getLogger().child({ prefix: 'MemoryLoadSignal' });
         this.maxUsedMemoryRatio = options.maxUsedMemoryRatio ?? 0.9;
@@ -52,12 +52,12 @@ export class MemoryLoadSignal implements LoadSignal {
     }
 
     async start(): Promise<void> {
-        const memoryMbytes = this.config.memoryMbytes ?? 0;
+        const memoryMbytes = this.configuration.memoryMbytes ?? 0;
 
         if (memoryMbytes > 0) {
             this.maxMemoryBytes = memoryMbytes * 1024 * 1024;
         } else {
-            this.maxMemoryRatio = this.config.availableMemoryRatio;
+            this.maxMemoryRatio = this.configuration.availableMemoryRatio;
             if (!this.maxMemoryRatio) {
                 throw new Error('availableMemoryRatio is not set in configuration.');
             } else {
@@ -138,7 +138,7 @@ export class MemoryLoadSignal implements LoadSignal {
     }
 
     private async _getTotalMemoryBytes(): Promise<number> {
-        const containerized = this.config.containerized ?? (await isContainerized());
+        const containerized = this.configuration.containerized ?? (await isContainerized());
         return (await getMemoryInfo({ containerized, logger: serviceLocator.getLogger() })).totalBytes;
     }
 }

--- a/packages/core/src/autoscaling/snapshotter.ts
+++ b/packages/core/src/autoscaling/snapshotter.ts
@@ -63,7 +63,7 @@ export interface SnapshotterOptions {
     client?: StorageBackend;
 
     /** @internal */
-    config?: Configuration;
+    configuration?: Configuration;
 }
 
 /**
@@ -95,7 +95,7 @@ export interface SnapshotterOptions {
 export class Snapshotter {
     readonly log: CrawleeLogger;
     readonly client: StorageBackend;
-    readonly config: Configuration;
+    readonly configuration: Configuration;
 
     private readonly memorySignal: MemoryLoadSignal;
     private readonly eventLoopSignal: EventLoopLoadSignal;
@@ -142,7 +142,7 @@ export class Snapshotter {
                 maxClientErrors: ow.optional.number,
                 log: ow.optional.object,
                 client: ow.optional.object,
-                config: ow.optional.object,
+                configuration: ow.optional.object,
             }),
         );
 
@@ -154,20 +154,20 @@ export class Snapshotter {
             maxUsedMemoryRatio = 0.9,
             maxClientErrors = 3,
             log = serviceLocator.getLogger(),
-            config = serviceLocator.getConfiguration(),
+            configuration = serviceLocator.getConfiguration(),
             client = serviceLocator.getStorageBackend(),
         } = options;
 
         this.log = log.child({ prefix: 'Snapshotter' });
         this.client = client;
-        this.config = config;
+        this.configuration = configuration;
 
         const snapshotHistoryMillis = snapshotHistorySecs * 1000;
 
         this.memorySignal = new MemoryLoadSignal({
             maxUsedMemoryRatio,
             snapshotHistoryMillis,
-            config: this.config,
+            configuration: this.configuration,
             log: this.log,
         });
 
@@ -179,7 +179,7 @@ export class Snapshotter {
 
         this.cpuSignal = createCpuLoadSignal({
             snapshotHistoryMillis,
-            config: this.config,
+            configuration: this.configuration,
         });
 
         this.clientSignal = createClientLoadSignal({

--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -112,7 +112,7 @@ export interface Configuration extends ResolvedConfigValues {}
 
 /**
  * `Configuration` is a value object holding Crawlee configuration. By default, there is a
- * global singleton instance of this class available via `Configuration.getGlobalConfig()`.
+ * global singleton instance of this class available via `Configuration.getGlobalConfiguration()`.
  * Places that depend on a configurable behaviour depend on this class, as they have the global
  * instance as the default value.
  *
@@ -121,7 +121,7 @@ export interface Configuration extends ResolvedConfigValues {}
  * import { BasicCrawler, Configuration } from 'crawlee';
  *
  * // Get the global configuration
- * const config = Configuration.getGlobalConfig();
+ * const config = Configuration.getGlobalConfiguration();
  * // Access configuration values directly as properties
  * console.log(config.headless);
  * console.log(config.persistStateIntervalMillis);
@@ -204,7 +204,7 @@ export class Configuration {
      *
      * Delegates to the global ServiceLocator, making it the single source of truth for service management.
      */
-    static getGlobalConfig(): Configuration {
+    static getGlobalConfiguration(): Configuration {
         return serviceLocator.getConfiguration();
     }
 

--- a/packages/core/src/crawlers/crawler_commons.ts
+++ b/packages/core/src/crawlers/crawler_commons.ts
@@ -253,7 +253,7 @@ export class RequestHandlerResult {
     private addRequestsCalls: Parameters<RestrictedCrawlingContext['addRequests']>[] = [];
 
     constructor(
-        private config: Configuration,
+        private configuration: Configuration,
         private crawleeStateKey: string,
     ) {}
 
@@ -346,11 +346,11 @@ export class RequestHandlerResult {
     };
 
     getKeyValueStore: RestrictedCrawlingContext['getKeyValueStore'] = async (identifier) => {
-        const store = await KeyValueStore.open(identifier, { config: this.config });
+        const store = await KeyValueStore.open(identifier, { configuration: this.configuration });
         const storeId = store.id;
 
         return {
-            id: storeId ?? this.config.defaultKeyValueStoreId,
+            id: storeId ?? this.configuration.defaultKeyValueStoreId,
             name: store.name,
             getValue: async (key) => this.getKeyValueStoreChangedValue(storeId, key) ?? (await store.getValue(key)),
             setValue: async (key, value, options) => {
@@ -362,7 +362,7 @@ export class RequestHandlerResult {
     };
 
     private getKeyValueStoreChangedValue = (storeKey: string | undefined, key: string) => {
-        const id = storeKey ?? this.config.defaultKeyValueStoreId;
+        const id = storeKey ?? this.configuration.defaultKeyValueStoreId;
         this._keyValueStoreChanges[id] ??= {};
         return this.keyValueStoreChanges[id][key]?.changedValue ?? null;
     };
@@ -373,7 +373,7 @@ export class RequestHandlerResult {
         changedValue: unknown,
         options?: RecordOptions,
     ) => {
-        const id = storeKey ?? this.config.defaultKeyValueStoreId;
+        const id = storeKey ?? this.configuration.defaultKeyValueStoreId;
         this._keyValueStoreChanges[id] ??= {};
         this._keyValueStoreChanges[id][key] = { changedValue, options };
     };

--- a/packages/core/src/crawlers/statistics.ts
+++ b/packages/core/src/crawlers/statistics.ts
@@ -287,7 +287,7 @@ export class Statistics {
      * displaying the current state in predefined intervals
      */
     async startCapturing() {
-        this.keyValueStore ??= await KeyValueStore.open(null, { config: serviceLocator.getConfiguration() });
+        this.keyValueStore ??= await KeyValueStore.open(null, { configuration: serviceLocator.getConfiguration() });
 
         if (this.state.crawlerStartedAt === null) {
             this.state.crawlerStartedAt = new Date();

--- a/packages/core/src/events/local_event_manager.ts
+++ b/packages/core/src/events/local_event_manager.ts
@@ -22,12 +22,12 @@ export class LocalEventManager extends EventManager {
      * Creates a new `LocalEventManager` based on the provided `Configuration`.
      * Uses the global configuration from the service locator if none is provided.
      */
-    static fromConfig(config?: Configuration): LocalEventManager {
-        const resolvedConfig = config ?? serviceLocator.getConfiguration();
+    static fromConfiguration(configuration?: Configuration): LocalEventManager {
+        const resolvedConfiguration = configuration ?? serviceLocator.getConfiguration();
 
         return new LocalEventManager({
-            persistStateIntervalMillis: resolvedConfig.persistStateIntervalMillis,
-            systemInfoIntervalMillis: resolvedConfig.systemInfoIntervalMillis,
+            persistStateIntervalMillis: resolvedConfiguration.persistStateIntervalMillis,
+            systemInfoIntervalMillis: resolvedConfiguration.systemInfoIntervalMillis,
         });
     }
 

--- a/packages/core/src/recoverable_state.ts
+++ b/packages/core/src/recoverable_state.ts
@@ -45,7 +45,7 @@ export interface RecoverableStateOptions<
     /**
      * Configuration instance to use
      */
-    config?: Configuration;
+    configuration?: Configuration;
 
     /**
      * Optional function to transform the state to a JSON string before persistence.
@@ -127,7 +127,9 @@ export class RecoverableState<TStateModel = Record<string, unknown>> {
             kvsIdentifier = { id: this.persistStateKvsId };
         }
 
-        this.keyValueStore = await KeyValueStore.open(kvsIdentifier, { config: serviceLocator.getConfiguration() });
+        this.keyValueStore = await KeyValueStore.open(kvsIdentifier, {
+            configuration: serviceLocator.getConfiguration(),
+        });
 
         await this.loadSavedState();
 

--- a/packages/core/src/service_locator.ts
+++ b/packages/core/src/service_locator.ts
@@ -115,9 +115,9 @@ interface ServiceLocatorInterface {
  *
  * const crawler = new BasicCrawler({
  *     requestHandler: async ({ request }) => { ... },
- *     configuration: new Configuration({ ... }),  // custom config
+ *     configuration: new Configuration({ ... }),           // custom configuration
  *     storageBackend: new MemoryStorageBackend(),          // custom storage
- *     eventManager: LocalEventManager.fromConfig(),  // custom events
+ *     eventManager: LocalEventManager.fromConfiguration(), // custom events
  * });
  * // Crawler has its own isolated ServiceLocator instance
  * ```
@@ -186,7 +186,7 @@ export class ServiceLocator implements ServiceLocatorInterface {
                         'It is advised to explicitly first set the configuration instead.',
                 );
             }
-            this.eventManager = LocalEventManager.fromConfig(this.getConfiguration());
+            this.eventManager = LocalEventManager.fromConfiguration(this.getConfiguration());
         }
         return this.eventManager;
     }
@@ -217,10 +217,10 @@ export class ServiceLocator implements ServiceLocatorInterface {
                         'It is advised to explicitly first set the configuration instead.',
                 );
             }
-            const config = this.getConfiguration();
-            this.storageBackend = config.persistStorage
+            const configuration = this.getConfiguration();
+            this.storageBackend = configuration.persistStorage
                 ? new FileSystemStorageBackend({
-                      localDataDirectory: config.storageDir,
+                      localDataDirectory: configuration.storageDir,
                       logger: this.getLogger().child({ prefix: 'FileSystemStorageBackend' }),
                   })
                 : new MemoryStorageBackend({

--- a/packages/core/src/session_pool/session_pool.ts
+++ b/packages/core/src/session_pool/session_pool.ts
@@ -240,7 +240,7 @@ export class SessionPool implements ISessionPool {
         this.keyValueStore = await KeyValueStore.open(
             this.persistStateKeyValueStoreId ? { id: this.persistStateKeyValueStoreId } : null,
             {
-                config: serviceLocator.getConfiguration(),
+                configuration: serviceLocator.getConfiguration(),
             },
         );
 

--- a/packages/core/src/storages/dataset.ts
+++ b/packages/core/src/storages/dataset.ts
@@ -200,7 +200,7 @@ export class Dataset<Data extends Dictionary = Dictionary> {
      */
     constructor(
         options: DatasetOptions,
-        readonly config = Configuration.getGlobalConfig(),
+        readonly configuration = Configuration.getGlobalConfiguration(),
     ) {
         this.id = options.metadata.id;
         this.name = options.metadata.name;
@@ -286,7 +286,7 @@ export class Dataset<Data extends Dictionary = Dictionary> {
      * @param [contentType] Only JSON and CSV are supported currently, defaults to JSON.
      */
     async exportTo(key: string, options?: DatasetExportToOptions, contentType?: string): Promise<Data[]> {
-        const kvStore = await KeyValueStore.open(options?.toKVS ?? null, { config: this.config });
+        const kvStore = await KeyValueStore.open(options?.toKVS ?? null, { configuration: this.configuration });
         const items = await this.export(options);
 
         if (contentType === 'text/csv') {
@@ -679,16 +679,16 @@ export class Dataset<Data extends Dictionary = Dictionary> {
         ow(
             options,
             ow.object.exactShape({
-                config: ow.optional.object.instanceOf(Configuration),
+                configuration: ow.optional.object.instanceOf(Configuration),
                 storageBackend: ow.optional.object,
             }),
         );
 
-        options.config ??= Configuration.getGlobalConfig();
+        options.configuration ??= Configuration.getGlobalConfiguration();
 
         const storageBackend = options.storageBackend ?? serviceLocator.getStorageBackend();
 
-        await purgeDefaultStorages({ onlyPurgeOnce: true, storageBackend, config: options.config });
+        await purgeDefaultStorages({ onlyPurgeOnce: true, storageBackend, configuration: options.configuration });
 
         const resolved = await resolveStorageIdentifier(identifier, storageBackend, 'Dataset');
 

--- a/packages/core/src/storages/key_value_store.ts
+++ b/packages/core/src/storages/key_value_store.ts
@@ -96,7 +96,7 @@ export class KeyValueStore {
      */
     constructor(
         options: KeyValueStoreOptions,
-        readonly config = Configuration.getGlobalConfig(),
+        readonly configuration = Configuration.getGlobalConfiguration(),
     ) {
         this.id = options.metadata.id;
         this.name = options.metadata.name;
@@ -670,15 +670,15 @@ export class KeyValueStore {
         ow(
             options,
             ow.object.exactShape({
-                config: ow.optional.object.instanceOf(Configuration),
+                configuration: ow.optional.object.instanceOf(Configuration),
                 storageBackend: ow.optional.object,
             }),
         );
 
-        options.config ??= Configuration.getGlobalConfig();
+        options.configuration ??= Configuration.getGlobalConfiguration();
         const storageBackend = options.storageBackend ?? serviceLocator.getStorageBackend();
 
-        await purgeDefaultStorages({ onlyPurgeOnce: true, storageBackend, config: options.config });
+        await purgeDefaultStorages({ onlyPurgeOnce: true, storageBackend, configuration: options.configuration });
 
         const resolved = await resolveStorageIdentifier(identifier, storageBackend, 'KeyValueStore');
 
@@ -871,7 +871,7 @@ export class KeyValueStore {
      */
     static async getInput<T = Dictionary | string | Buffer>(): Promise<T | null> {
         const store = await this.open();
-        return store.getValue<T>(store.config.inputKey);
+        return store.getValue<T>(store.configuration.inputKey);
     }
 }
 

--- a/packages/core/src/storages/request_list.ts
+++ b/packages/core/src/storages/request_list.ts
@@ -167,7 +167,7 @@ export interface RequestListOptions {
     keepDuplicateUrls?: boolean;
 
     /** @internal */
-    config?: Configuration;
+    configuration?: Configuration;
 
     /**
      * The HTTP client to be used to download `requestsFromUrl` URLs.

--- a/packages/core/src/storages/request_queue.ts
+++ b/packages/core/src/storages/request_queue.ts
@@ -955,7 +955,7 @@ export class RequestQueue implements IStorage, IRequestManager {
         ow(
             options,
             ow.object.exactShape({
-                config: ow.optional.object.instanceOf(Configuration),
+                configuration: ow.optional.object.instanceOf(Configuration),
                 storageBackend: ow.optional.object,
                 proxyConfiguration: ow.optional.object,
                 httpClient: ow.optional.object,
@@ -963,9 +963,9 @@ export class RequestQueue implements IStorage, IRequestManager {
         );
 
         const storageBackend = options.storageBackend ?? serviceLocator.getStorageBackend();
-        const config = options.config ?? serviceLocator.getConfiguration();
+        const configuration = options.configuration ?? serviceLocator.getConfiguration();
 
-        await purgeDefaultStorages({ onlyPurgeOnce: true, storageBackend, config });
+        await purgeDefaultStorages({ onlyPurgeOnce: true, storageBackend, configuration });
 
         const resolved = await resolveStorageIdentifier(identifier, storageBackend, 'RequestQueue');
 

--- a/packages/core/src/storages/sitemap_request_loader.ts
+++ b/packages/core/src/storages/sitemap_request_loader.ts
@@ -219,7 +219,6 @@ export class SitemapRequestLoader implements IRequestLoader {
                     ow.any(ow.string, ow.regExp, ow.object.hasKeys('glob'), ow.object.hasKeys('regexp')),
                 ),
                 regexps: ow.optional.array.ofType(ow.any(ow.regExp, ow.object.hasKeys('regexp'))),
-                config: ow.optional.object,
                 persistenceOptions: ow.optional.object,
             }),
         );

--- a/packages/core/src/storages/utils.ts
+++ b/packages/core/src/storages/utils.ts
@@ -15,7 +15,7 @@ interface PurgeDefaultStorageOptions {
      * If set to `true`, calling multiple times will only have effect at the first time.
      */
     onlyPurgeOnce?: boolean;
-    config?: Configuration;
+    configuration?: Configuration;
     storageBackend?: StorageBackend;
 }
 
@@ -44,32 +44,35 @@ export async function purgeDefaultStorages(options?: PurgeDefaultStorageOptions)
  * This is a shortcut for running (optional) `purge` method on the StorageBackend interface, in other words
  * it will call the `purge` method of the underlying storage implementation we are currently using.
  */
-export async function purgeDefaultStorages(config?: Configuration, storageBackend?: StorageBackend): Promise<void>;
 export async function purgeDefaultStorages(
-    configOrOptions?: Configuration | PurgeDefaultStorageOptions,
+    configuration?: Configuration,
+    storageBackend?: StorageBackend,
+): Promise<void>;
+export async function purgeDefaultStorages(
+    configurationOrOptions?: Configuration | PurgeDefaultStorageOptions,
     storageBackend?: StorageBackend,
 ) {
     const options: PurgeDefaultStorageOptions =
-        configOrOptions instanceof Configuration
+        configurationOrOptions instanceof Configuration
             ? {
                   storageBackend,
-                  config: configOrOptions,
+                  configuration: configurationOrOptions,
               }
-            : (configOrOptions ?? {});
-    const { config = serviceLocator.getConfiguration(), onlyPurgeOnce = false } = options;
+            : (configurationOrOptions ?? {});
+    const { configuration = serviceLocator.getConfiguration(), onlyPurgeOnce = false } = options;
     ({ storageBackend = serviceLocator.getStorageBackend() } = options);
 
     const casted = storageBackend as StorageBackend & { __purged?: boolean };
 
     // if `onlyPurgeOnce` is true, will purge anytime this function is called, otherwise - only on start
-    if (!onlyPurgeOnce || (config.purgeOnStart && !casted.__purged)) {
+    if (!onlyPurgeOnce || (configuration.purgeOnStart && !casted.__purged)) {
         casted.__purged = true;
         await casted.purge?.();
     }
 }
 
 export interface UseStateOptions {
-    config?: Configuration;
+    configuration?: Configuration;
     /**
      * The name of the key-value store you'd like the state to be stored in.
      * If not provided, the default store will be used.
@@ -84,7 +87,7 @@ export interface UseStateOptions {
  *
  * @param name The name of the store to use.
  * @param defaultValue If the store does not yet have a value in it, the value will be initialized with the `defaultValue` you provide.
- * @param options An optional object parameter where a custom `keyValueStoreName` and `config` can be passed in.
+ * @param options An optional object parameter where a custom `keyValueStoreName` and `configuration` can be passed in.
  */
 export async function useState<State extends Dictionary = Dictionary>(
     name?: string,
@@ -92,7 +95,7 @@ export async function useState<State extends Dictionary = Dictionary>(
     options?: UseStateOptions,
 ) {
     const kvStore = await KeyValueStore.open(options?.keyValueStoreName ? { name: options.keyValueStoreName } : null, {
-        config: options?.config || serviceLocator.getConfiguration(),
+        configuration: options?.configuration || serviceLocator.getConfiguration(),
     });
     return kvStore.getAutoSavedValue<State>(name || 'CRAWLEE_GLOBAL_STATE', defaultValue);
 }
@@ -219,7 +222,7 @@ export interface StorageOpenOptions {
     /**
      * SDK configuration instance, defaults to the static register.
      */
-    config?: Configuration;
+    configuration?: Configuration;
 
     /**
      * Optional storage backend that should be used to open storages.

--- a/packages/playwright-crawler/src/internals/playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/playwright-crawler.ts
@@ -296,7 +296,10 @@ export class PlaywrightCrawler<
                 playwrightUtils.infiniteScroll(context.page, options),
             listDownloads: async () => downloads,
             saveSnapshot: async (options?: SaveSnapshotOptions) =>
-                playwrightUtils.saveSnapshot(context.page, { ...options, config: serviceLocator.getConfiguration() }),
+                playwrightUtils.saveSnapshot(context.page, {
+                    ...options,
+                    configuration: serviceLocator.getConfiguration(),
+                }),
             enqueueLinksByClickingElements: async (
                 options: Omit<EnqueueLinksByClickingElementsOptions, 'page' | 'requestManager'>,
             ) =>

--- a/packages/playwright-crawler/src/internals/playwright-launcher.ts
+++ b/packages/playwright-crawler/src/internals/playwright-launcher.ts
@@ -88,7 +88,7 @@ export class PlaywrightLauncher extends BrowserLauncher<PlaywrightPlugin> {
      */
     constructor(
         launchContext: PlaywrightLaunchContext = {},
-        override readonly config = Configuration.getGlobalConfig(),
+        override readonly configuration = Configuration.getGlobalConfiguration(),
     ) {
         ow(launchContext, 'PlaywrightLauncherOptions', ow.object.exactShape(PlaywrightLauncher.optionsShape));
 
@@ -106,11 +106,11 @@ export class PlaywrightLauncher extends BrowserLauncher<PlaywrightPlugin> {
                 ...rest,
                 launchOptions: {
                     ...launchOptions,
-                    executablePath: getDefaultExecutablePath(launchContext, config),
+                    executablePath: getDefaultExecutablePath(launchContext, configuration),
                 },
                 launcher,
             },
-            config,
+            configuration,
         );
 
         this.Plugin = PlaywrightPlugin;
@@ -122,8 +122,11 @@ export class PlaywrightLauncher extends BrowserLauncher<PlaywrightPlugin> {
  * @returns default path to browser.
  * @ignore
  */
-function getDefaultExecutablePath(launchContext: PlaywrightLaunchContext, config: Configuration): string | undefined {
-    const pathFromPlaywrightImage = config.defaultBrowserPath;
+function getDefaultExecutablePath(
+    launchContext: PlaywrightLaunchContext,
+    configuration: Configuration,
+): string | undefined {
+    const pathFromPlaywrightImage = configuration.defaultBrowserPath;
     const { launchOptions = {} } = launchContext;
 
     if (launchOptions.executablePath) {
@@ -170,15 +173,15 @@ function getDefaultExecutablePath(launchContext: PlaywrightLaunchContext, config
  *   Optional settings passed to `browserType.launch()`. In addition to
  *   [Playwright's options](https://playwright.dev/docs/api/class-browsertype?_highlight=launch#browsertypelaunchoptions)
  *   the object may contain our own  {@apilink PlaywrightLaunchContext} that enable additional features.
- * @param [config]
+ * @param [configuration]
  * @returns
  *   Promise that resolves to Playwright's `Browser` instance.
  */
 export async function launchPlaywright(
     launchContext?: PlaywrightLaunchContext,
-    config = Configuration.getGlobalConfig(),
+    configuration = Configuration.getGlobalConfiguration(),
 ): Promise<Browser> {
-    const playwrightLauncher = new PlaywrightLauncher(launchContext, config);
+    const playwrightLauncher = new PlaywrightLauncher(launchContext, configuration);
 
     return playwrightLauncher.launch();
 }

--- a/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
+++ b/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
@@ -529,9 +529,9 @@ export interface SaveSnapshotOptions {
 
     /**
      * Configuration of the crawler that will be used to save the snapshot.
-     * @default Configuration.getGlobalConfig()
+     * @default Configuration.getGlobalConfiguration()
      */
-    config?: Configuration;
+    configuration?: Configuration;
 }
 
 /**
@@ -549,7 +549,7 @@ export async function saveSnapshot(page: Page, options: SaveSnapshotOptions = {}
             saveScreenshot: ow.optional.boolean,
             saveHtml: ow.optional.boolean,
             keyValueStoreName: ow.optional.string,
-            config: ow.optional.object,
+            configuration: ow.optional.object,
         }),
     );
 
@@ -559,12 +559,12 @@ export async function saveSnapshot(page: Page, options: SaveSnapshotOptions = {}
         saveScreenshot = true,
         saveHtml = true,
         keyValueStoreName,
-        config,
+        configuration,
     } = options;
 
     try {
         const store = await KeyValueStore.open(keyValueStoreName ? { name: keyValueStoreName } : null, {
-            config: config ?? Configuration.getGlobalConfig(),
+            configuration: configuration ?? Configuration.getGlobalConfiguration(),
         });
 
         if (saveScreenshot) {

--- a/packages/puppeteer-crawler/src/internals/puppeteer-crawler.ts
+++ b/packages/puppeteer-crawler/src/internals/puppeteer-crawler.ts
@@ -284,7 +284,10 @@ export class PuppeteerCrawler<
             infiniteScroll: async (options?: InfiniteScrollOptions) =>
                 puppeteerUtils.infiniteScroll(context.page, options),
             saveSnapshot: async (options?: SaveSnapshotOptions) =>
-                puppeteerUtils.saveSnapshot(context.page, { ...options, config: serviceLocator.getConfiguration() }),
+                puppeteerUtils.saveSnapshot(context.page, {
+                    ...options,
+                    configuration: serviceLocator.getConfiguration(),
+                }),
             closeCookieModals: async () => puppeteerUtils.closeCookieModals(context.page),
         };
     }

--- a/packages/puppeteer-crawler/src/internals/puppeteer-launcher.ts
+++ b/packages/puppeteer-crawler/src/internals/puppeteer-launcher.ts
@@ -83,7 +83,7 @@ export class PuppeteerLauncher extends BrowserLauncher<PuppeteerPlugin, unknown>
      */
     constructor(
         launchContext: PuppeteerLaunchContext = {},
-        override readonly config = Configuration.getGlobalConfig(),
+        override readonly configuration = Configuration.getGlobalConfiguration(),
     ) {
         ow(launchContext, 'PuppeteerLauncher', ow.object.exactShape(PuppeteerLauncher.optionsShape));
 
@@ -97,7 +97,7 @@ export class PuppeteerLauncher extends BrowserLauncher<PuppeteerPlugin, unknown>
                 ...browserLauncherOptions,
                 launcher,
             },
-            config,
+            configuration,
         );
 
         this.Plugin = PuppeteerPlugin;
@@ -137,15 +137,15 @@ export class PuppeteerLauncher extends BrowserLauncher<PuppeteerPlugin, unknown>
  * @param [launchContext]
  *   All `PuppeteerLauncher` parameters are passed via an launchContext object.
  *   If you want to pass custom `puppeteer.launch(options)` options you can use the `PuppeteerLaunchContext.launchOptions` property.
- * @param [config]
+ * @param [configuration]
  * @returns
  *   Promise that resolves to Puppeteer's `Browser` instance.
  */
 export async function launchPuppeteer(
     launchContext?: PuppeteerLaunchContext,
-    config = Configuration.getGlobalConfig(),
+    configuration = Configuration.getGlobalConfiguration(),
 ): Promise<Browser> {
-    const puppeteerLauncher = new PuppeteerLauncher(launchContext, config);
+    const puppeteerLauncher = new PuppeteerLauncher(launchContext, configuration);
 
     return puppeteerLauncher.launch();
 }

--- a/packages/puppeteer-crawler/src/internals/utils/puppeteer_utils.ts
+++ b/packages/puppeteer-crawler/src/internals/utils/puppeteer_utils.ts
@@ -741,9 +741,9 @@ export interface SaveSnapshotOptions {
 
     /**
      * Configuration of the crawler that will be used to save the snapshot.
-     * @default Configuration.getGlobalConfig()
+     * @default Configuration.getGlobalConfiguration()
      */
-    config?: Configuration;
+    configuration?: Configuration;
 }
 
 /**
@@ -761,7 +761,7 @@ export async function saveSnapshot(page: Page, options: SaveSnapshotOptions = {}
             saveScreenshot: ow.optional.boolean,
             saveHtml: ow.optional.boolean,
             keyValueStoreName: ow.optional.string,
-            config: ow.optional.object,
+            configuration: ow.optional.object,
         }),
     );
 
@@ -771,12 +771,12 @@ export async function saveSnapshot(page: Page, options: SaveSnapshotOptions = {}
         saveScreenshot = true,
         saveHtml = true,
         keyValueStoreName,
-        config,
+        configuration,
     } = options;
 
     try {
         const store = await KeyValueStore.open(keyValueStoreName ? { name: keyValueStoreName } : null, {
-            config: config ?? Configuration.getGlobalConfig(),
+            configuration: configuration ?? Configuration.getGlobalConfiguration(),
         });
 
         if (saveScreenshot) {

--- a/packages/stagehand-crawler/src/internals/stagehand-launcher.ts
+++ b/packages/stagehand-crawler/src/internals/stagehand-launcher.ts
@@ -77,7 +77,7 @@ export class StagehandLauncher extends BrowserLauncher<StagehandPlugin> {
      */
     constructor(
         launchContext: StagehandLaunchContext = {},
-        override readonly config = Configuration.getGlobalConfig(),
+        override readonly configuration = Configuration.getGlobalConfiguration(),
     ) {
         ow(launchContext, 'StagehandLaunchContext', ow.object.exactShape(StagehandLauncher.optionsShape));
 
@@ -97,11 +97,11 @@ export class StagehandLauncher extends BrowserLauncher<StagehandPlugin> {
                 ...rest,
                 launchOptions: {
                     ...launchOptions,
-                    executablePath: getDefaultExecutablePath(launchContext, config),
+                    executablePath: getDefaultExecutablePath(launchContext, configuration),
                 },
                 launcher,
             },
-            config,
+            configuration,
         );
 
         this.stagehandOptions = {
@@ -130,8 +130,11 @@ export class StagehandLauncher extends BrowserLauncher<StagehandPlugin> {
  * Gets the default executable path for the browser.
  * @ignore
  */
-function getDefaultExecutablePath(launchContext: StagehandLaunchContext, config: Configuration): string | undefined {
-    const pathFromPlaywrightImage = config.defaultBrowserPath;
+function getDefaultExecutablePath(
+    launchContext: StagehandLaunchContext,
+    configuration: Configuration,
+): string | undefined {
+    const pathFromPlaywrightImage = configuration.defaultBrowserPath;
     const { launchOptions = {} } = launchContext;
 
     if (launchOptions.executablePath) {

--- a/test/core/autoscaling/snapshotter.test.ts
+++ b/test/core/autoscaling/snapshotter.test.ts
@@ -373,18 +373,18 @@ describe('Snapshotter', () => {
             // Mock memory info to be able to inject custom memory measurement data.
             vitest.spyOn(LocalEventManager.prototype as any, 'getMemoryInfo').mockResolvedValue(memoryData);
 
-            let config: Configuration;
+            let configuration: Configuration;
             if (dynamic) {
                 // Dynamic: Allow usage of 50 % of available memory through ratio
-                config = new Configuration({ availableMemoryRatio: allowedMemoryUsageRatio });
+                configuration = new Configuration({ availableMemoryRatio: allowedMemoryUsageRatio });
             } else {
                 // Static: Allow usage of 50 % of available memory through fixed value
-                config = new Configuration({
+                configuration = new Configuration({
                     memoryMbytes: (allowedMemoryUsageRatio * initialTotalBytes) / 1024 / 1024,
                 });
             }
 
-            const snapshotter = new Snapshotter({ config });
+            const snapshotter = new Snapshotter({ configuration });
             vitest.spyOn(LocalEventManager.prototype, 'init').mockImplementation(async () => {});
             const eventManager = serviceLocator.getEventManager() as LocalEventManager;
             await snapshotter.start();


### PR DESCRIPTION
v3 used `config` and `configuration` interchangeably across the public API. This settles on `configuration` everywhere, matching Crawlee for Python.

Renamed methods:

| Before | After |
| --- | --- |
| `Configuration.getGlobalConfig()` | `Configuration.getGlobalConfiguration()` |
| `LocalEventManager.fromConfig()` | `LocalEventManager.fromConfiguration()` |

Renamed `config` options to `configuration` in `StorageOpenOptions` (`Dataset.open()`, `KeyValueStore.open()`, `RequestQueue.open()`), `UseStateOptions`, `purgeDefaultStorages()`, `SnapshotterOptions`, `SaveSnapshotOptions` (Playwright and Puppeteer), `RecoverableStateOptions`, `RequestListOptions`, `CpuLoadSignalOptions` and `MemoryLoadSignalOptions`.

Renamed `config` properties to `configuration` on `Dataset`, `KeyValueStore`, `Snapshotter` and `BrowserLauncher` (plus the Playwright, Puppeteer and Stagehand launchers).

The `configuration` crawler option and `serviceLocator.getConfiguration()` / `setConfiguration()` were already consistent and are unchanged.

The BC is documented in the v4 upgrading guide.

Closes #3706