### PR TITLE
fix(core): keep crawler enqueue limits when options carry explicit undefined

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -383,6 +383,9 @@ export interface BasicCrawlerOptions<Context extends CrawlingContext = BasicCraw
      * 2. because they don't match enqueueLinks filters,
      * 3. because they are redirected to a URL that doesn't match the enqueueLinks strategy,
      * 4. or because the {@apilink BasicCrawlerOptions.maxRequestsPerCrawl|`maxRequestsPerCrawl`} limit has been reached
+     *
+     * When `enqueueLinks` is called with its own `onSkippedRequest` callback, both are invoked — this one first,
+     * then the `enqueueLinks` one.
      */
     onSkippedRequest?: SkippedRequestCallback;
 

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -1746,8 +1746,9 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
     /**
      * Wrapper around the crawling context's `enqueueLinks` method:
      * - Injects `crawlDepth` to each request being added based on the crawling context request.
-     * - Provides defaults for the `enqueueLinks` options based on the crawler configuration.
-     *      - These options can be overridden by the user.
+     * - Combines the `enqueueLinks` options with the crawler configuration - the user options take precedence,
+     *   but the crawler limits are always enforced (the `limit` is capped by the remaining `maxRequestsPerCrawl`
+     *   budget and skipped requests are always reported to the crawler too).
      * @internal
      */
     protected async enqueueLinksWithCrawlDepth(
@@ -1767,6 +1768,8 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
             return options.transformRequestFunction?.(newRequest) ?? newRequest;
         };
 
+        const limit = this.calculateEnqueuedRequestLimit(options.limit);
+
         // Create a request-scoped callback that logs enqueueLimit once per request handler call
         // Only log if an explicit limit was passed to enqueueLinks (not the internal maxRequestsPerCrawl-derived limit)
         let loggedEnqueueLimitForThisRequest = false;
@@ -1774,13 +1777,16 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
             if (skippedOptions.reason === 'enqueueLimit') {
                 if (!loggedEnqueueLimitForThisRequest && options.limit !== undefined) {
                     this.log.info(
-                        `Skipping URLs in the handler for ${request.url} due to the enqueueLinks limit of ${options.limit}.`,
+                        limit === options.limit
+                            ? `Skipping URLs in the handler for ${request.url} due to the enqueueLinks limit of ${options.limit}.`
+                            : `Skipping URLs in the handler for ${request.url} due to the remaining maxRequestsPerCrawl budget of ${limit}, which is lower than the enqueueLinks limit of ${options.limit}.`,
                     );
                     loggedEnqueueLimitForThisRequest = true;
                 }
             }
 
             await this.handleSkippedRequest(skippedOptions);
+            await options.onSkippedRequest?.(skippedOptions);
         };
 
         // `enqueueLinks` applies `options.label`/`options.userData` to every newly enqueued request, so a single
@@ -1788,15 +1794,15 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
         await this.validateRequestUserData({ label: options.label, userData: options.userData });
 
         return enqueueLinks({
-            requestQueue,
-            robotsTxtFile: await this.getRobotsTxtFileForUrl(request!.url),
-            respectRobotsTxtFile: this.respectRobotsTxtFile,
-            onSkippedRequest,
-            limit: this.calculateEnqueuedRequestLimit(options.limit),
-
-            // Allow user options to override defaults set above ⤴
             ...options,
 
+            // The options below are merged with the user options, so an explicitly `undefined` value
+            // (e.g. `enqueueLinks({ urls, limit: config.limit })`) cannot discard the crawler defaults ⤵
+            requestQueue: options.requestQueue ?? requestQueue,
+            robotsTxtFile: options.robotsTxtFile ?? (await this.getRobotsTxtFileForUrl(request.url)),
+            respectRobotsTxtFile: options.respectRobotsTxtFile ?? this.respectRobotsTxtFile,
+            onSkippedRequest,
+            limit,
             transformRequestFunction: transformRequestFunctionWrapper,
         });
     }

--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -642,7 +642,9 @@ export abstract class BrowserCrawler<
         const contextEnqueueLinks = crawlingContext.enqueueLinks;
         crawlingContext.enqueueLinks = async (enqueueOptions) => {
             return browserCrawlerEnqueueLinks({
-                options: { ...enqueueOptions, limit: this.calculateEnqueuedRequestLimit(enqueueOptions?.limit) },
+                // `contextEnqueueLinks` clamps `limit` by the remaining `maxRequestsPerCrawl` budget itself;
+                // pre-clamping it here would make the crawler log the internal limit as a user-provided one
+                options: enqueueOptions,
                 page,
                 requestQueue: await this.getRequestQueue(),
                 robotsTxtFile: await this.getRobotsTxtFileForUrl(crawlingContext.request.url),

--- a/packages/cheerio-crawler/src/internals/cheerio-crawler.ts
+++ b/packages/cheerio-crawler/src/internals/cheerio-crawler.ts
@@ -197,7 +197,9 @@ export class CheerioCrawler extends HttpCrawler<CheerioCrawlingContext> {
             body,
             enqueueLinks: async (enqueueOptions?: EnqueueLinksOptions) => {
                 return cheerioCrawlerEnqueueLinks({
-                    options: { ...enqueueOptions, limit: this.calculateEnqueuedRequestLimit(enqueueOptions?.limit) },
+                    // `originalEnqueueLinks` clamps `limit` by the remaining `maxRequestsPerCrawl` budget itself;
+                    // pre-clamping it here would make the crawler log the internal limit as a user-provided one
+                    options: enqueueOptions,
                     $,
                     requestQueue: await this.getRequestQueue(),
                     robotsTxtFile: await this.getRobotsTxtFileForUrl(crawlingContext.request.url),

--- a/packages/core/src/enqueue_links/enqueue_links.ts
+++ b/packages/core/src/enqueue_links/enqueue_links.ts
@@ -34,7 +34,11 @@ import {
 export { EnqueueStrategy };
 
 export interface EnqueueLinksOptions extends RequestQueueOperationOptions {
-    /** Limit the amount of actually enqueued URLs to this number. Useful for testing across the entire crawling scope. */
+    /**
+     * Limit the amount of actually enqueued URLs to this number. Useful for testing across the entire crawling scope.
+     * When called from a crawler context, the limit is further capped by what's left of the crawler's
+     * {@apilink BasicCrawlerOptions.maxRequestsPerCrawl|`maxRequestsPerCrawl`} budget.
+     */
     limit?: number;
 
     /** An array of URLs to enqueue. */

--- a/packages/core/src/enqueue_links/enqueue_links.ts
+++ b/packages/core/src/enqueue_links/enqueue_links.ts
@@ -201,6 +201,9 @@ export interface EnqueueLinksOptions extends RequestQueueOperationOptions {
      * 1. based on robots.txt file,
      * 2. because they don't match enqueueLinks filters,
      * 3. or because the maxRequestsPerCrawl limit has been reached
+     *
+     * When calling `enqueueLinks` through a crawler context, this callback runs in addition to (after) the
+     * crawler-level `onSkippedRequest`, it does not replace it.
      */
     onSkippedRequest?: SkippedRequestCallback;
 }

--- a/test/core/crawlers/basic_crawler.test.ts
+++ b/test/core/crawlers/basic_crawler.test.ts
@@ -2108,6 +2108,215 @@ describe('BasicCrawler', () => {
             expect(visitedUrls).toContain('http://example.com/');
             expect(visitedUrls).toContain('http://example.com/new');
         });
+
+        test('enqueueLinks should respect maxRequestsPerCrawl when passed an explicitly undefined limit', async () => {
+            const requestQueue = await RequestQueue.open();
+            const onSkippedRequest = vitest.fn();
+
+            const requestsToAdd = Array.from({ length: 6 }, (_, i) => `http://example.com/${i + 1}`);
+
+            const crawler = new BasicCrawler({
+                requestQueue,
+                maxRequestsPerCrawl: 5,
+                onSkippedRequest,
+                requestHandler: async (context) => {
+                    if (context.request.label) {
+                        return;
+                    }
+
+                    crawler.stats.state.requestsFinished = 2;
+
+                    // e.g. `enqueueLinks({ urls, limit: config.limit })` where `config.limit` is not set
+                    await context.enqueueLinks({ urls: requestsToAdd, limit: undefined, label: 'child' });
+                },
+            });
+
+            await crawler.run(['http://example.com']);
+
+            // 2 requests already finished and 1 is in progress, so only 2 more fit into the limit
+            expect(requestQueue.getTotalCount()).toBe(3);
+
+            const skippedUrls = onSkippedRequest.mock.calls
+                .map((call) => call[0])
+                .filter(({ reason }) => reason === 'enqueueLimit')
+                .map(({ url }) => url)
+                .sort();
+
+            expect(skippedUrls).toEqual([
+                'http://example.com/3',
+                'http://example.com/4',
+                'http://example.com/5',
+                'http://example.com/6',
+            ]);
+        });
+
+        test('enqueueLinks should clamp an explicit limit to the remaining maxRequestsPerCrawl budget', async () => {
+            const requestQueue = await RequestQueue.open();
+
+            const requestsToAdd = Array.from({ length: 6 }, (_, i) => `http://example.com/${i + 1}`);
+
+            const crawler = new BasicCrawler({
+                requestQueue,
+                maxRequestsPerCrawl: 5,
+                requestHandler: async (context) => {
+                    if (context.request.label) {
+                        return;
+                    }
+
+                    crawler.stats.state.requestsFinished = 2;
+
+                    await context.enqueueLinks({ urls: requestsToAdd, limit: 4, label: 'child' });
+                },
+            });
+
+            const infoSpy = vitest.spyOn(crawler.log, 'info');
+
+            await crawler.run(['http://example.com']);
+
+            // The user limit of 4 is higher than what's left of maxRequestsPerCrawl, so only 2 are enqueued
+            expect(requestQueue.getTotalCount()).toBe(3);
+
+            // ...and the log message must not blame the user limit of 4 for it
+            expect(infoSpy).toHaveBeenCalledWith(
+                expect.stringContaining('due to the remaining maxRequestsPerCrawl budget of 2'),
+            );
+        });
+
+        test('enqueueLinks should keep reporting skipped requests when the user passes onSkippedRequest', async () => {
+            const requestQueue = await RequestQueue.open();
+            const crawlerOnSkippedRequest = vitest.fn();
+            const userOnSkippedRequest = vitest.fn();
+
+            const requestsToAdd = Array.from({ length: 3 }, (_, i) => `http://example.com/${i + 1}`);
+
+            const crawler = new BasicCrawler({
+                requestQueue,
+                onSkippedRequest: crawlerOnSkippedRequest,
+                requestHandler: async (context) => {
+                    if (context.request.label) {
+                        return;
+                    }
+
+                    await context.enqueueLinks({
+                        urls: requestsToAdd,
+                        limit: 1,
+                        label: 'child',
+                        onSkippedRequest: userOnSkippedRequest,
+                    });
+                },
+            });
+
+            await crawler.run(['http://example.com']);
+
+            const skipped = [
+                { url: 'http://example.com/2', reason: 'enqueueLimit' },
+                { url: 'http://example.com/3', reason: 'enqueueLimit' },
+            ];
+
+            for (const mock of [crawlerOnSkippedRequest, userOnSkippedRequest]) {
+                expect(mock.mock.calls.map((call) => call[0]).sort((a, b) => a.url.localeCompare(b.url))).toEqual(
+                    skipped,
+                );
+            }
+        });
+
+        test('enqueueLinks should keep the crawler robots.txt file when passed an explicitly undefined robotsTxtFile', async () => {
+            const requestQueue = await RequestQueue.open();
+
+            const crawler = new (class MockedRobotsTxtCrawler extends BasicCrawler {
+                override async getRobotsTxtFileForUrl(_: string) {
+                    return RobotsTxtFile.from(
+                        'http://example.com/robots.txt',
+                        `User-agent: *
+                         Disallow: /no
+                        `,
+                    );
+                }
+            })({
+                requestQueue,
+                maxConcurrency: 1,
+                respectRobotsTxtFile: true,
+                requestHandler: async (context) => {
+                    if (context.request.label) {
+                        return;
+                    }
+
+                    await context.enqueueLinks({
+                        urls: ['http://example.com/yes', 'http://example.com/no'],
+                        robotsTxtFile: undefined,
+                        label: 'child',
+                    });
+                },
+            });
+
+            await crawler.run(['http://example.com/start']);
+
+            // The disallowed URL should never make it into the queue
+            expect(requestQueue.getTotalCount()).toBe(2);
+        });
+
+        test('enqueueLinks should keep the crawler user-agent when passed an explicitly undefined respectRobotsTxtFile', async () => {
+            const requestQueue = await RequestQueue.open();
+            const isAllowedSpy = vitest.fn((_url: string, _userAgent?: string) => true);
+
+            const crawler = new (class MockedRobotsTxtCrawler extends BasicCrawler {
+                override async getRobotsTxtFileForUrl(_: string) {
+                    return { isAllowed: isAllowedSpy } as unknown as RobotsTxtFile;
+                }
+            })({
+                requestQueue,
+                maxConcurrency: 1,
+                respectRobotsTxtFile: { userAgent: 'MyCrawler' },
+                requestHandler: async (context) => {
+                    if (context.request.label) {
+                        return;
+                    }
+
+                    await context.enqueueLinks({
+                        urls: ['http://example.com/child'],
+                        respectRobotsTxtFile: undefined,
+                        label: 'child',
+                    });
+                },
+            });
+
+            await crawler.run(['http://example.com/start']);
+
+            expect(isAllowedSpy).toHaveBeenCalledWith('http://example.com/child', 'MyCrawler');
+            // the crawler user-agent must not fall back to the `*` default
+            expect(isAllowedSpy.mock.calls.map(([, userAgent]) => userAgent)).not.toContain('*');
+        });
+
+        test('enqueueLinks should use the request queue from the options, and the crawler one when it is undefined', async () => {
+            const requestQueue = await RequestQueue.open();
+            const customQueue = await RequestQueue.open('custom-queue');
+
+            const crawler = new BasicCrawler({
+                requestQueue,
+                requestHandler: async (context) => {
+                    if (context.request.label) {
+                        return;
+                    }
+
+                    await context.enqueueLinks({
+                        urls: ['http://example.com/custom'],
+                        requestQueue: customQueue,
+                        label: 'child',
+                    });
+
+                    await context.enqueueLinks({
+                        urls: ['http://example.com/default'],
+                        requestQueue: undefined,
+                        label: 'child',
+                    });
+                },
+            });
+
+            await crawler.run(['http://example.com/start']);
+
+            expect(customQueue.getTotalCount()).toBe(1);
+            expect(requestQueue.getTotalCount()).toBe(2);
+        });
     });
 
     describe('addRequests input validation', () => {

--- a/test/core/crawlers/cheerio_crawler.test.ts
+++ b/test/core/crawlers/cheerio_crawler.test.ts
@@ -1411,6 +1411,22 @@ describe('CheerioCrawler', () => {
         expect(succeeded[0]).toEqual('Redirecting outside');
     });
 
+    test('enqueueLinks should not log an enqueueLinks limit when only maxRequestsPerCrawl clamps', async () => {
+        const crawler = new CheerioCrawler({
+            maxRequestsPerCrawl: 1,
+            requestHandler: async ({ enqueueLinks }) => {
+                await enqueueLinks({ strategy: EnqueueStrategy.All });
+            },
+        });
+
+        const infoSpy = vitest.spyOn(crawler.log, 'info');
+
+        await crawler.run([`${serverAddress}/special/html-type`]);
+
+        // The user passed no `limit`, so the skips must not be attributed to one
+        expect(infoSpy).not.toHaveBeenCalledWith(expect.stringContaining('Skipping URLs in the handler'));
+    });
+
     test('enqueueLinks should respect maxCrawlDepth', async () => {
         const succeeded: string[] = [];
 


### PR DESCRIPTION
Follow-up to #3924, same bug class one level down.

`BasicCrawler`'s context-bound `enqueueLinks` built its call as `{ requestQueue, robotsTxtFile, respectRobotsTxtFile, onSkippedRequest, limit, ...options }`, so a user options object carrying an explicitly present `undefined` key silently discarded the computed value:

```ts
await enqueueLinks({ urls, limit: config.limit }); // config.limit is not set
```

Neither `ow.optional.number` nor TypeScript (without `exactOptionalPropertyTypes`) rejects an explicit `undefined`, so the `calculateEnqueuedRequestLimit()` result was dropped — the queue kept growing past the remaining `maxRequestsPerCrawl` budget and the `enqueueLimit` skips were never reported to `onSkippedRequest`. `maxRequestsPerCrawl` is still enforced as a stop condition via `isMaxPagesExceeded()`, so the effect was queue bloat and missing reporting rather than an unbounded crawl. The same applied to `robotsTxtFile` and `respectRobotsTxtFile` (robots.txt filtering silently disabled at enqueue time), and to `requestQueue`, where the explicit `undefined` made `ow` throw instead.

Unlike #3924 this isn't a pure reordering, so the semantics for each computed key:

- **`limit`** — now `min(user limit, remaining maxRequestsPerCrawl budget)`. This is what `addRequests()` (`maxNewRequests` after the spread) and the per-crawler `*CrawlerEnqueueLinks` helpers have always done; this path was the outlier. A user limit larger than the remaining budget is now capped, which is a user-visible change.
- **`onSkippedRequest`** — composed instead of replaced: the crawler's reporting (logging, crawler-level `onSkippedRequest`) runs, then the user's callback. Previously passing a callback to `enqueueLinks` silently disabled the crawler-level one.
- **`requestQueue`, `robotsTxtFile`, `respectRobotsTxtFile`** — `??` fallbacks, so a defined user value still wins.

The enqueue-limit log message now also distinguishes the two causes, instead of blaming the user's `limit` when the `maxRequestsPerCrawl` clamp is what bit.

Not covered here: `JSDOMCrawler` and `LinkeDOMCrawler` never route `context.enqueueLinks` through this wrapper at all (they call the standalone `enqueueLinks()` directly, unlike `CheerioCrawler`/`BrowserCrawler` which forward the bound context function), so `crawlDepth` injection and `maxCrawlDepth` are inert there. Separate issue, separate fix.
