### PR TITLE
chore(deps): bump brace-expansion in website lockfile to resolve security alert

### DIFF
--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -6480,11 +6480,11 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^2.0.2":
-  version: 2.1.2
-  resolution: "brace-expansion@npm:2.1.2"
+  version: 2.1.3
+  resolution: "brace-expansion@npm:2.1.3"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/5442ecab84045d21826268bc56c81a6ef4215327ee1f5ee153f67928e93f7a915d130ecec9966623143277fa3cce036ebb50020024bcc4d78853cdd6af9a19f8
+  checksum: 10c0/62bef43c5755b4978662d66d0844635cc171610644da7d0266db8c0180c21c6e8ff7b969a27d2f2ec7893b6efd9c33dc73383d84a467669832f2da1fd3771f99
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
Lockfile-only bump of `brace-expansion` to its patched versions in `website/yarn.lock` (high — ReDoS), within existing ranges.

The root `yarn.lock` already carries the patched `^`-range copies (brace-expansion 5.0.8, axios 1.18.1); `docs/yarn.lock` and `website/versioned_docs/version-3.17/yarn.lock` only contain the already-patched 1.x line (1.1.16).

### Not addressed here (need a decision on `resolutions`)
The remaining root alerts can't close via a lockfile bump because dev tooling pins vulnerable versions:
- `axios` 1.16.0 and `brace-expansion` 5.0.6 — pinned **exactly** by `nx@22.7.5` (same nx-pin pattern already handled with existing resolutions).
- `@hono/node-server` < 2.0.5 — the consumer requires `^1.19.9`; the only fix is `2.0.5`, a **major (1.x→2.x)** bump.
- `adm-zip` < 0.6.0 — pinned to `^0.5.x` by `generative-bayesian-network` (dev fingerprint tooling); 0.6.0 is a semver-major-ish jump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)