### PR TITLE
refactor!: drop transitive re-exports of `@crawlee/types` symbols

### DIFF
--- a/docs/guides/remote_browser.mdx
+++ b/docs/guides/remote_browser.mdx
@@ -18,7 +18,7 @@ Use this when you need IPs in specific regions, want to offload CPU/memory from 
 
 ## How it works
 
-Set the crawler's `remoteBrowser` option with the connection details. The crawler builds a <ApiLink to="browser-pool/class/RemoteBrowserPool">`RemoteBrowserPool`</ApiLink> around its own browser plugin, so the connection is always for the matching browser — there's no plugin to construct and no way to mismatch the pool with the crawler. The pool (an <ApiLink to="browser-pool/interface/IBrowserPool">`IBrowserPool`</ApiLink> wrapping the regular <ApiLink to="browser-pool/class/BrowserPool">`BrowserPool`</ApiLink>) owns everything remote: resolving the endpoint, releasing sessions when browsers close, and capping how many remote browsers run at once.
+Set the crawler's `remoteBrowser` option with the connection details. The crawler builds a <ApiLink to="browser-pool/class/RemoteBrowserPool">`RemoteBrowserPool`</ApiLink> around its own browser plugin, so the connection is always for the matching browser — there's no plugin to construct and no way to mismatch the pool with the crawler. The pool (an <ApiLink to="types/interface/IBrowserPool">`IBrowserPool`</ApiLink> wrapping the regular <ApiLink to="browser-pool/class/BrowserPool">`BrowserPool`</ApiLink>) owns everything remote: resolving the endpoint, releasing sessions when browsers close, and capping how many remote browsers run at once.
 
 ## Basic usage
 

--- a/docs/guides/request_storage.mdx
+++ b/docs/guides/request_storage.mdx
@@ -88,4 +88,4 @@ import { purgeDefaultStorages } from 'crawlee';
 await purgeDefaultStorages();
 ```
 
-Calling this function will clean up the default request storage directory (and also the request list stored in default key-value store). This is a shortcut for running (optional) `purge` method on the <ApiLink to="core/interface/StorageBackend">`StorageBackend`</ApiLink> interface, in other words it will call the `purge` method of the underlying storage implementation we are currently using. You can make sure the storage is purged only once for a given execution context if you set `onlyPurgeOnce` to `true` in the `options` object.
+Calling this function will clean up the default request storage directory (and also the request list stored in default key-value store). This is a shortcut for running (optional) `purge` method on the <ApiLink to="types/interface/StorageBackend">`StorageBackend`</ApiLink> interface, in other words it will call the `purge` method of the underlying storage implementation we are currently using. You can make sure the storage is purged only once for a given execution context if you set `onlyPurgeOnce` to `true` in the `options` object.

--- a/docs/guides/result_storage.mdx
+++ b/docs/guides/result_storage.mdx
@@ -110,4 +110,4 @@ import { purgeDefaultStorages } from 'crawlee';
 await purgeDefaultStorages();
 ```
 
-Calling this function will clean up the default results storage directories except the `INPUT` key in default key-value store directory. This is a shortcut for running (optional) `purge` method on the <ApiLink to="core/interface/StorageBackend">`StorageBackend`</ApiLink> interface, in other words it will call the `purge` method of the underlying storage implementation we are currently using. In addition, this method will make sure the storage is purged only once for a given execution context, so it is safe to call it multiple times.
+Calling this function will clean up the default results storage directories except the `INPUT` key in default key-value store directory. This is a shortcut for running (optional) `purge` method on the <ApiLink to="types/interface/StorageBackend">`StorageBackend`</ApiLink> interface, in other words it will call the `purge` method of the underlying storage implementation we are currently using. In addition, this method will make sure the storage is purged only once for a given execution context, so it is safe to call it multiple times.

--- a/docs/public-api/crawlee-basic.api.md
+++ b/docs/public-api/crawlee-basic.api.md
@@ -54,7 +54,7 @@ import { Statistics } from '@crawlee/core';
 import type { StatisticsOptions } from '@crawlee/core';
 import type { StatisticState } from '@crawlee/core';
 import type { StorageBackend } from '@crawlee/types';
-import type { StorageIdentifier } from '@crawlee/core';
+import type { StorageIdentifier } from '@crawlee/types';
 import { StringPredicate } from 'ow';
 import { TimeoutError } from '@apify/timeout';
 import type { TypedRequestsLike } from '@crawlee/core';

--- a/docs/public-api/crawlee-browser-pool.api.md
+++ b/docs/public-api/crawlee-browser-pool.api.md
@@ -16,8 +16,8 @@ import { EventEmitter } from 'node:events';
 import { FingerprintGenerator as FingerprintGenerator_2 } from 'fingerprint-generator';
 import type { FingerprintGeneratorOptions as FingerprintGeneratorOptions_2 } from 'fingerprint-generator';
 import { FingerprintInjector } from 'fingerprint-injector';
-import { IBrowserPool } from '@crawlee/types';
-import { NewPageOptions } from '@crawlee/types';
+import type { IBrowserPool } from '@crawlee/types';
+import type { NewPageOptions } from '@crawlee/types';
 import type { Page } from 'playwright';
 import type { PageState } from '@crawlee/types';
 import type Puppeteer from 'puppeteer';
@@ -356,8 +356,6 @@ export interface IBrowserLaunchContext {
     useIncognitoPages?: boolean;
 }
 
-export { IBrowserPool }
-
 // @public (undocumented)
 export type InferBrowserPluginArray<Input extends readonly unknown[], Result extends BrowserPlugin[] = []> = Input extends readonly [infer FirstValue, ...infer Rest] | [infer FirstValue, ...infer Rest] ? FirstValue extends PlaywrightPlugin ? InferBrowserPluginArray<Rest, [...Result, PlaywrightPlugin]> : FirstValue extends PuppeteerPlugin ? InferBrowserPluginArray<Rest, [...Result, PuppeteerPlugin]> : never : Input extends [] ? Result : Input extends readonly (infer U)[] ? [
 U
@@ -404,8 +402,6 @@ export interface LaunchContextOptions<Library extends CommonLibrary = CommonLibr
     useIncognitoPages?: boolean;
     userDataDir?: string;
 }
-
-export { NewPageOptions }
 
 // @public (undocumented)
 export const enum OperatingSystemsName {

--- a/docs/public-api/crawlee-browser.api.md
+++ b/docs/public-api/crawlee-browser.api.md
@@ -6,7 +6,7 @@
 
 import { AnyPredicate } from 'ow';
 import { ArrayPredicate } from 'ow';
-import type { Awaitable } from '@crawlee/basic';
+import type { Awaitable } from '@crawlee/types';
 import { BasePredicate } from 'ow';
 import { BasicCrawler } from '@crawlee/basic';
 import type { BasicCrawlerOptions } from '@crawlee/basic';
@@ -24,8 +24,7 @@ import type { Constructor } from '@crawlee/types';
 import { ContextPipeline } from '@crawlee/basic';
 import type { CrawlerRemoteBrowserOptions } from '@crawlee/browser-pool';
 import type { CrawlingContext } from '@crawlee/basic';
-import type { Dictionary } from '@crawlee/basic';
-import type { Dictionary as Dictionary_2 } from '@crawlee/types';
+import type { Dictionary } from '@crawlee/types';
 import type { EnqueueLinksOptions } from '@crawlee/basic';
 import type { ErrorHandler } from '@crawlee/basic';
 import type { GetUserDataFromRequest } from '@crawlee/basic';

--- a/docs/public-api/crawlee-core.api.md
+++ b/docs/public-api/crawlee-core.api.md
@@ -4,16 +4,16 @@
 
 ```ts
 
-import { AllowedHttpMethods } from '@crawlee/types';
+import type { AllowedHttpMethods } from '@crawlee/types';
 import { AsyncEventEmitter } from '@vladfrangu/async_event_emitter';
-import { Awaitable } from '@crawlee/types';
+import type { Awaitable } from '@crawlee/types';
 import type { BaseHttpClient } from '@crawlee/types';
 import type { BatchAddRequestsResult } from '@crawlee/types';
 import type { BetterIntervalID } from '@apify/utilities';
 import type { BinaryLike } from 'node:crypto';
-import { Constructor } from '@crawlee/types';
-import { Cookie } from '@crawlee/types';
-import { Cookie as Cookie_2 } from 'tough-cookie';
+import type { Constructor } from '@crawlee/types';
+import { Cookie } from 'tough-cookie';
+import type { Cookie as Cookie_2 } from '@crawlee/types';
 import { CookieJar } from 'tough-cookie';
 import { CrawleeLogger } from '@crawlee/types';
 import type { CrawleeLoggerOptions } from '@crawlee/types';
@@ -37,7 +37,7 @@ import { ParseSitemapOptions } from '@crawlee/utils';
 import type { ProcessedRequest } from '@crawlee/types';
 import type { ProxyInfo } from '@crawlee/types';
 import { PseudoUrl } from '@apify/pseudo_url';
-import { QueueOperationInfo } from '@crawlee/types';
+import type { QueueOperationInfo } from '@crawlee/types';
 import { Readable } from 'node:stream';
 import type { ReadonlyDeep } from 'type-fest';
 import type { RequestQueueBackend } from '@crawlee/types';
@@ -49,8 +49,8 @@ import { SessionState } from '@crawlee/types';
 import type { SetRequired } from 'type-fest';
 import type { StandardSchemaV1 } from '@standard-schema/spec';
 import type * as storage from '@crawlee/types';
-import { StorageBackend } from '@crawlee/types';
-import { StorageIdentifier } from '@crawlee/types';
+import type { StorageBackend } from '@crawlee/types';
+import type { StorageIdentifier } from '@crawlee/types';
 import { tryAbsoluteURL } from '@crawlee/utils';
 import { z } from 'zod';
 
@@ -117,8 +117,6 @@ export interface AutoscaledPoolOptions {
     systemStatusOptions?: SystemStatusOptions;
     taskTimeoutSecs?: number;
 }
-
-export { Awaitable }
 
 // @public
 export abstract class BaseCrawleeLogger implements CrawleeLogger {
@@ -218,8 +216,6 @@ export type ConfigurationInput = FieldsInput<typeof crawleeConfigFields>;
 // @public @deprecated (undocumented)
 export type ConfigurationOptions = ConfigurationInput;
 
-export { Constructor }
-
 // @public
 export interface ContextMiddleware<TCrawlingContext, TCrawlingContextExtension> {
     action: (context: TCrawlingContext) => Awaitable<TCrawlingContextExtension>;
@@ -248,8 +244,6 @@ export class ContextPipelineInitializationError extends Error {
 export class ContextPipelineInterruptedError extends Error {
     constructor(message?: string);
 }
-
-export { Cookie }
 
 // @public (undocumented)
 export interface CpuLoadSignalOptions {
@@ -377,7 +371,7 @@ export class Dataset<Data extends Dictionary = Dictionary> {
 // @public
 export interface DatasetConsumer<Data> {
     // (undocumented)
-    (item: Data, index: number): Awaitable_2<void>;
+    (item: Data, index: number): Awaitable<void>;
 }
 
 // @public (undocumented)
@@ -421,7 +415,7 @@ export interface DatasetIteratorOptions extends Omit<DatasetDataOptions, 'offset
 
 // @public
 export interface DatasetMapper<Data, R> {
-    (item: Data, index: number): Awaitable_2<R>;
+    (item: Data, index: number): Awaitable<R>;
 }
 
 // @public (undocumented)
@@ -434,7 +428,7 @@ export interface DatasetOptions {
 // @public
 export interface DatasetReducer<T, Data> {
     // (undocumented)
-    (memo: T, item: Data, index: number): Awaitable_2<T>;
+    (memo: T, item: Data, index: number): Awaitable<T>;
 }
 
 // @public
@@ -455,8 +449,6 @@ export interface DefaultStorageIdentifier {
     // (undocumented)
     name?: never;
 }
-
-export { Dictionary }
 
 // @public
 export function enqueueLinks(options: SetRequired<Omit<EnqueueLinksOptions, 'requestManager'>, 'urls'> & {
@@ -753,7 +745,7 @@ export interface KeyConsumer {
     // (undocumented)
     (key: string, index: number, info: {
         size: number;
-    }): Awaitable_2<void>;
+    }): Awaitable<void>;
 }
 
 // @public
@@ -996,8 +988,6 @@ export function purgeDefaultStorages(config?: Configuration, storageBackend?: St
 export interface PushErrorMessageOptions {
     omitStack?: boolean;
 }
-
-export { QueueOperationInfo }
 
 // @public (undocumented)
 export interface RecordOptions {
@@ -1343,22 +1333,22 @@ export class RetryRequestError extends Error {
 
 // @public
 export class Router<Context extends Omit<RestrictedCrawlingContext, 'enqueueLinks'>, Routes extends Record<keyof Routes, Dictionary> = Record<string, GetUserDataFromRequest<Context['request']>>> {
-    addDefaultHandler<UserData extends Dictionary = DefaultRouteUserData<Routes, GetUserDataFromRequest<Context['request']>>>(handler: (ctx: RouterHandlerContext<Context, UserData, Routes>) => Awaitable_2<void>): void;
-    addHandler<Label extends keyof Routes & string>(label: Label, handler: (ctx: RouterHandlerContext<Context, Routes[Label], Routes>) => Awaitable_2<void>): void;
-    addHandler<UserData extends Dictionary = GetUserDataFromRequest<Context['request']>>(label: RouterLabel<Routes>, handler: (ctx: RouterHandlerContext<Context, UserData, Routes>) => Awaitable_2<void>): void;
+    addDefaultHandler<UserData extends Dictionary = DefaultRouteUserData<Routes, GetUserDataFromRequest<Context['request']>>>(handler: (ctx: RouterHandlerContext<Context, UserData, Routes>) => Awaitable<void>): void;
+    addHandler<Label extends keyof Routes & string>(label: Label, handler: (ctx: RouterHandlerContext<Context, Routes[Label], Routes>) => Awaitable<void>): void;
+    addHandler<UserData extends Dictionary = GetUserDataFromRequest<Context['request']>>(label: RouterLabel<Routes>, handler: (ctx: RouterHandlerContext<Context, UserData, Routes>) => Awaitable<void>): void;
     static create<Context extends Omit<RestrictedCrawlingContext, 'enqueueLinks'> = CrawlingContext, Routes extends Record<keyof Routes, Dictionary> = Record<string, GetUserDataFromRequest<Context['request']>>>(routes?: RouterRoutes<Context, Routes>): RouterHandler<Context, Routes>;
     // (undocumented)
     static create<Context extends Omit<RestrictedCrawlingContext, 'enqueueLinks'> = CrawlingContext, UserData extends Dictionary = GetUserDataFromRequest<Context['request']>>(routes?: RouterRoutes<Context, Record<string, UserData>>): RouterHandler<Context, Record<string, UserData>>;
     // (undocumented)
     static create<Context extends Omit<RestrictedCrawlingContext, 'enqueueLinks'> = CrawlingContext, const Schemas extends RouteSchemas = RouteSchemas>(schemas: Schemas): RouterHandler<Context, RoutesFromSchemas<Schemas>>;
-    getHandler(label?: string | symbol): (ctx: Context) => Awaitable_2<void>;
-    use(middleware: (ctx: Context) => Awaitable_2<void>): void;
+    getHandler(label?: string | symbol): (ctx: Context) => Awaitable<void>;
+    use(middleware: (ctx: Context) => Awaitable<void>): void;
 }
 
 // @public (undocumented)
 export interface RouterHandler<Context extends Omit<RestrictedCrawlingContext, 'enqueueLinks'> = CrawlingContext, Routes extends Record<keyof Routes, Dictionary> = Record<string, GetUserDataFromRequest<Context['request']>>> extends Router<Context, Routes> {
     // (undocumented)
-    (ctx: Context): Awaitable_2<void>;
+    (ctx: Context): Awaitable<void>;
 }
 
 // @public
@@ -1378,7 +1368,7 @@ export type RouterLabel<Routes extends Record<keyof Routes, Dictionary>> = strin
 export type RouterRoutes<Context, Routes extends Record<keyof Routes, Dictionary>> = {
     [Label in keyof Routes]: (ctx: Omit<Context, 'request'> & {
         request: Request_2<Routes[Label]>;
-    }) => Awaitable_2<void>;
+    }) => Awaitable<void>;
 };
 
 // @public
@@ -1770,10 +1760,6 @@ export interface StatisticState {
     statsPersistedAt: Date | string | null;
 }
 
-export { StorageBackend }
-
-export { StorageIdentifier }
-
 // @public
 export interface StorageOpenOptions {
     config?: Configuration;
@@ -1844,7 +1830,7 @@ export interface UseStateOptions {
 }
 
 // @public
-export const withCheckedStorageAccess: <T>(checkFunction: () => void, callback: () => Awaitable_2<T>) => Promise<T>;
+export const withCheckedStorageAccess: <T>(checkFunction: () => void, callback: () => Awaitable<T>) => Promise<T>;
 
 // (No @packageDocumentation comment for this package)
 

--- a/docs/upgrading/upgrading_v4.md
+++ b/docs/upgrading/upgrading_v4.md
@@ -429,6 +429,10 @@ In v3, we introduced a new way to detect available resources for the crawler, av
 
 As part of this change, the low-level resource- and environment-detection helpers exported from `@crawlee/utils` were **removed**: `getMemoryInfo()` (and the `MemoryInfo` interface), `isContainerized()`, `isDocker()`, `isLambda()`, and `getCgroupsVersion()`. These backed the old detection path and are no longer part of the public API. Resource detection is now handled internally by the crawler's autoscaling; if you called any of these directly, read the equivalent values from the OS (`node:os`) or the relevant cgroup files yourself.
 
+## `@crawlee/types` symbols are no longer re-exported
+
+Every type owned by `@crawlee/types` now has exactly one import site: `@crawlee/types` itself. The remaining transitive re-exports were dropped, so `Dictionary`, `Awaitable`, `Constructor`, `StorageBackend`, `Cookie`, `QueueOperationInfo`, `AllowedHttpMethods` and `StorageIdentifier` are no longer available from `@crawlee/core` (nor, in turn, from `@crawlee/basic` and the `crawlee` meta-package), and `IBrowserPool` / `NewPageOptions` are no longer available from `@crawlee/browser-pool`. Add `@crawlee/types` to your dependencies and import them from there — most of the package's types (`ISession`, `ProxyInfo`, `RequestSchema`, …) already required this.
+
 ## Removed and relocated `@crawlee/utils` exports
 
 Besides the resource-detection helpers above, several other `@crawlee/utils` exports were removed or moved:

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -26,7 +26,6 @@ import type {
     Source,
     StatisticsOptions,
     StatisticState,
-    StorageIdentifier,
     TypedRequestsLike,
 } from '@crawlee/core';
 import {
@@ -78,6 +77,7 @@ import type {
     ProxyInfo,
     SetStatusMessageOptions,
     StorageBackend,
+    StorageIdentifier,
 } from '@crawlee/types';
 import { isAsyncIterable, isIterable, RobotsTxtFile, ROTATE_PROXY_ERRORS } from '@crawlee/utils';
 import { stringify } from 'csv-stringify/sync';

--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -1,10 +1,8 @@
 import type {
-    Awaitable,
     BasicCrawlerOptions,
     BasicCrawlingContext,
     ContextMiddleware,
     CrawlingContext,
-    Dictionary,
     EnqueueLinksOptions,
     ErrorHandler,
     GetUserDataFromRequest,
@@ -42,7 +40,14 @@ import type {
     LaunchContext,
 } from '@crawlee/browser-pool';
 import { BrowserPool, RemoteBrowserPool } from '@crawlee/browser-pool';
-import type { BatchAddRequestsResult, Cookie as CookieObject, IBrowserPool, ISession } from '@crawlee/types';
+import type {
+    Awaitable,
+    BatchAddRequestsResult,
+    Cookie as CookieObject,
+    Dictionary,
+    IBrowserPool,
+    ISession,
+} from '@crawlee/types';
 import type { RobotsTxtFile } from '@crawlee/utils';
 import { CLOUDFLARE_RETRY_CSS_SELECTORS, RETRY_CSS_SELECTORS, sleep } from '@crawlee/utils';
 import ow from 'ow';

--- a/packages/browser-pool/src/index.ts
+++ b/packages/browser-pool/src/index.ts
@@ -63,4 +63,3 @@ export type {
 } from './remote-browser-pool.js';
 export type { InferBrowserPluginArray, UnwrapPromise } from './utils.js';
 export { anonymizeProxySugar, type AnonymizeProxySugarOptions } from './anonymize-proxy.js';
-export type { IBrowserPool, NewPageOptions } from '@crawlee/types';

--- a/packages/core/src/crawlers/crawler_commons.ts
+++ b/packages/core/src/crawlers/crawler_commons.ts
@@ -1,4 +1,11 @@
-import type { Dictionary, HttpRequestOptions, ISession, ProxyInfo, SendRequestOptions } from '@crawlee/types';
+import type {
+    Dictionary,
+    HttpRequestOptions,
+    ISession,
+    ProxyInfo,
+    SendRequestOptions,
+    StorageIdentifier,
+} from '@crawlee/types';
 import type { ReadonlyDeep, SetRequired } from 'type-fest';
 
 import type { Configuration } from '../configuration.js';
@@ -8,7 +15,6 @@ import type { Request, RequestOptions, Source } from '../request.js';
 import type { Dataset } from '../storages/dataset.js';
 import { KeyValueStore, type RecordOptions } from '../storages/key_value_store.js';
 import type { RequestQueueOperationOptions } from '../storages/request_queue.js';
-import type { StorageIdentifier } from '../storages/storage_instance_manager.js';
 
 /** @internal */
 export type IsAny<T> = 0 extends 1 & T ? true : false;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,4 +19,3 @@ export * from './validators.js';
 export * from './cookie_utils.js';
 export * from './recoverable_state.js';
 export { PseudoUrl } from '@apify/pseudo_url';
-export type { Dictionary, Awaitable, Constructor, StorageBackend, Cookie, QueueOperationInfo } from '@crawlee/types';

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -2,7 +2,7 @@ import type { BinaryLike } from 'node:crypto';
 import crypto from 'node:crypto';
 import util from 'node:util';
 
-import type { Dictionary } from '@crawlee/types';
+import type { AllowedHttpMethods, Dictionary } from '@crawlee/types';
 import type { BasePredicate } from 'ow';
 import ow from 'ow';
 
@@ -11,7 +11,6 @@ import { cryptoRandomObjectId, normalizeUrl } from '@apify/utilities';
 import type { EnqueueLinksOptions } from './enqueue_links/enqueue_links.js';
 import type { SkippedRequestReason } from './enqueue_links/shared.js';
 import { serviceLocator } from './service_locator.js';
-import type { AllowedHttpMethods } from './typedefs.js';
 import { keys } from './typedefs.js';
 
 // new properties on the Request object breaks serialization

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -1,4 +1,4 @@
-import type { Dictionary } from '@crawlee/types';
+import type { Awaitable, Dictionary } from '@crawlee/types';
 import type { StandardSchemaV1 } from '@standard-schema/spec';
 
 import type {
@@ -10,7 +10,6 @@ import type {
 } from './crawlers/crawler_commons.js';
 import { MissingRouteError, RequestValidationError } from './errors.js';
 import type { Request } from './request.js';
-import type { Awaitable } from './typedefs.js';
 
 /**
  * The key of the default route — the fallback handler registered via {@apilink Router.addDefaultHandler}.

--- a/packages/core/src/storages/access_checking.ts
+++ b/packages/core/src/storages/access_checking.ts
@@ -1,6 +1,6 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 
-import type { Awaitable } from '../typedefs.js';
+import type { Awaitable } from '@crawlee/types';
 import { tryCancel } from '@apify/timeout';
 
 const storage = new AsyncLocalStorage<{ checkFunction: () => void }>();

--- a/packages/core/src/storages/dataset.ts
+++ b/packages/core/src/storages/dataset.ts
@@ -1,16 +1,21 @@
-import type { DatasetBackend, DatasetInfo, Dictionary, PaginatedList } from '@crawlee/types';
+import type {
+    Awaitable,
+    DatasetBackend,
+    DatasetInfo,
+    Dictionary,
+    PaginatedList,
+    StorageIdentifier,
+} from '@crawlee/types';
 import { stringify } from 'csv-stringify/sync';
 import ow from 'ow';
 
 import { Configuration } from '../configuration.js';
 import type { CrawleeLogger } from '../log.js';
 import { serviceLocator } from '../service_locator.js';
-import type { Awaitable } from '../typedefs.js';
 import { checkStorageAccess } from './access_checking.js';
 import { KeyValueStore } from './key_value_store.js';
 import type { DatasetStats } from './storage_stats.js';
 import { StorageStatsTracker } from './storage_stats.js';
-import type { StorageIdentifier } from './storage_instance_manager.js';
 import type { StorageOpenOptions } from './utils.js';
 import { resolveStorageIdentifier } from './storage_instance_manager.js';
 import { createDualIterable, purgeDefaultStorages } from './utils.js';

--- a/packages/core/src/storages/key_value_store.ts
+++ b/packages/core/src/storages/key_value_store.ts
@@ -1,16 +1,21 @@
-import type { Dictionary, KeyValueStoreBackend, KeyValueStoreInfo, KeyValueStoreItemData } from '@crawlee/types';
+import type {
+    Awaitable,
+    Dictionary,
+    KeyValueStoreBackend,
+    KeyValueStoreInfo,
+    KeyValueStoreItemData,
+    StorageIdentifier,
+} from '@crawlee/types';
 import ow, { ArgumentError } from 'ow';
 
 import { KEY_VALUE_STORE_KEY_REGEX } from '@apify/consts';
 
 import { Configuration } from '../configuration.js';
 import { serviceLocator } from '../service_locator.js';
-import type { Awaitable } from '../typedefs.js';
 import { checkStorageAccess } from './access_checking.js';
 import { parseValue, serializeValue } from './key_value_store_codec.js';
 import type { KeyValueStoreStats } from './storage_stats.js';
 import { StorageStatsTracker } from './storage_stats.js';
-import type { StorageIdentifier } from './storage_instance_manager.js';
 import type { StorageOpenOptions } from './utils.js';
 import { resolveStorageIdentifier } from './storage_instance_manager.js';
 import { createDualIterable, purgeDefaultStorages } from './utils.js';

--- a/packages/core/src/storages/request_queue.ts
+++ b/packages/core/src/storages/request_queue.ts
@@ -3,11 +3,13 @@ import { inspect } from 'node:util';
 import type {
     BaseHttpClient,
     BatchAddRequestsResult,
+    Constructor,
     Dictionary,
     ProcessedRequest,
     QueueOperationInfo,
     RequestQueueBackend,
     RequestQueueInfo,
+    StorageIdentifier,
 } from '@crawlee/types';
 import {
     chunkedAsyncIterable,
@@ -24,7 +26,6 @@ import { LruCache } from '@apify/datastructures';
 
 import { Configuration } from '../configuration.js';
 import { getObjectType } from '../debug.js';
-import type { Constructor } from '../typedefs.js';
 import type { EventManager } from '../events/event_manager.js';
 import { EventType } from '../events/event_manager.js';
 import type { CrawleeLogger } from '../log.js';
@@ -36,7 +37,7 @@ import { checkStorageAccess } from './access_checking.js';
 import type { IRequestManager, RequestsLike } from './request_manager.js';
 import type { RequestQueueStats } from './storage_stats.js';
 import { StorageStatsTracker } from './storage_stats.js';
-import type { IStorage, StorageIdentifier } from './storage_instance_manager.js';
+import type { IStorage } from './storage_instance_manager.js';
 import type { StorageOpenOptions } from './utils.js';
 import { resolveStorageIdentifier } from './storage_instance_manager.js';
 import { getRequestId, purgeDefaultStorages } from './utils.js';

--- a/packages/core/src/storages/storage_instance_manager.ts
+++ b/packages/core/src/storages/storage_instance_manager.ts
@@ -1,4 +1,5 @@
 import type {
+    Constructor,
     DatasetBackend,
     KeyValueStoreBackend,
     RequestQueueBackend,
@@ -6,10 +7,6 @@ import type {
     StorageIdentifier,
 } from '@crawlee/types';
 import { AsyncQueue } from '@sapphire/async-queue';
-
-import type { Constructor } from '../typedefs.js';
-
-export type { StorageIdentifier } from '@crawlee/types';
 
 /**
  * Matches an `IStorage` – a storage "frontend" (Dataset, KeyValueStore, RequestQueue).

--- a/packages/core/src/typedefs.ts
+++ b/packages/core/src/typedefs.ts
@@ -1,10 +1,4 @@
 /** @ignore */
-export type Constructor<T = unknown> = new (...args: any[]) => T;
-
-/** @ignore */
-export type Awaitable<T> = T | PromiseLike<T>;
-
-/** @ignore */
 export function entries<T extends {}>(obj: T) {
     return Object.entries(obj) as [keyof T, T[keyof T]][];
 }
@@ -13,5 +7,3 @@ export function entries<T extends {}>(obj: T) {
 export function keys<T extends {}>(obj: T) {
     return Object.keys(obj) as (keyof T)[];
 }
-
-export type { AllowedHttpMethods } from '@crawlee/types';

--- a/test/core/crawlers/adaptive_playwright_crawler.test.ts
+++ b/test/core/crawlers/adaptive_playwright_crawler.test.ts
@@ -6,7 +6,6 @@ import {
     type CrawleeLogger,
     type CrawleeLoggerOptions,
     Dataset,
-    type Dictionary,
     EventType,
     KeyValueStore,
     MemoryStorageBackend,
@@ -27,6 +26,7 @@ import {
     RequestList,
     RequestValidationError,
 } from '@crawlee/playwright';
+import type { Dictionary } from '@crawlee/types';
 import { sleep } from 'crawlee';
 import express from 'express';
 import { z } from 'zod';

--- a/test/core/storages/utils.test.ts
+++ b/test/core/storages/utils.test.ts
@@ -1,4 +1,4 @@
-import type { Dictionary } from '@crawlee/core';
+import type { Dictionary } from '@crawlee/types';
 import { Configuration, KeyValueStore, MemoryStorageBackend, serviceLocator, useState } from '@crawlee/core';
 
 describe('useState', () => {


### PR DESCRIPTION
Stacked on #3931.

Ten `@crawlee/types` symbols were still reachable through other packages: `Dictionary`, `Awaitable`, `Constructor`, `StorageBackend`, `Cookie`, `QueueOperationInfo`, `AllowedHttpMethods` and `StorageIdentifier` via `@crawlee/core` (and therefore `@crawlee/basic` and the `crawlee` meta-package), plus `IBrowserPool` and `NewPageOptions` via `@crawlee/browser-pool`. They now have a single import site, which is already how the other ~35 symbols of that package work — nothing re-exported `ISession`, `ProxyInfo` or `RequestSchema`.

`core/src/typedefs.ts` additionally declared its own `Constructor` and `Awaitable`, so internal consumers were using structurally-identical shadow copies of the `@crawlee/types` ones; those are gone too and the file is down to the `entries`/`keys` helpers.

This is what removed the duplicate `Dictionary` / `Dictionary_2` aliases from `crawlee-browser.api.md` — the browser crawler was reaching the same type through two paths.

One consequence worth a decision: `import type { Dictionary } from 'crawlee'` no longer resolves, since the meta-package only got it through `@crawlee/core`. I did not add `export type * from '@crawlee/types'` to the meta-package, because that would newly expose ~35 types there rather than restore a status quo — but the v4 upgrade guide does point users at the meta-package for relocated types, so say the word if you would rather keep `Dictionary` reachable from `crawlee`.