### PR TITLE
fix(impit-client): honor redirect handler for session cookie parity

### DIFF
--- a/packages/impit-client/src/index.ts
+++ b/packages/impit-client/src/index.ts
@@ -2,7 +2,14 @@ import { pipeline, Readable, Transform } from 'node:stream';
 import { type ReadableStream } from 'node:stream/web';
 import { isGeneratorObject } from 'node:util/types';
 
-import type { BaseHttpClient, HttpRequest, HttpResponse, ResponseTypes, StreamingHttpResponse } from '@crawlee/core';
+import type {
+    BaseHttpClient,
+    HttpRequest,
+    HttpResponse,
+    RedirectHandler,
+    ResponseTypes,
+    StreamingHttpResponse,
+} from '@crawlee/core';
 import type { HttpMethod, ImpitOptions, ImpitResponse, RequestInit } from 'impit';
 import { Impit } from 'impit';
 import type { CookieJar as ToughCookieJar } from 'tough-cookie';
@@ -18,6 +25,8 @@ interface ResponseWithRedirects {
     response: ImpitResponse;
     redirectUrls: URL[];
 }
+
+type SimpleHeaders = Record<string, string | string[] | undefined>;
 
 /**
  * A HTTP client implementation based on the `impit library.
@@ -120,6 +129,33 @@ export class ImpitHttpClient implements BaseHttpClient {
     }
 
     /**
+     * Converts Fetch/Impit headers into the simple header map expected by {@apilink RedirectHandler}.
+     * Preserves multiple `set-cookie` values when available.
+     */
+    private intoSimpleHeaders(headers: Headers): SimpleHeaders {
+        const result: SimpleHeaders = {};
+
+        for (const [key, value] of headers.entries()) {
+            if (key.toLowerCase() === 'set-cookie') continue;
+            result[key] = value;
+        }
+
+        const setCookies =
+            typeof headers.getSetCookie === 'function' ? headers.getSetCookie() : ([] as string[]);
+
+        if (setCookies.length === 1) {
+            result['set-cookie'] = setCookies[0];
+        } else if (setCookies.length > 1) {
+            result['set-cookie'] = setCookies;
+        } else {
+            const single = headers.get('set-cookie');
+            if (single) result['set-cookie'] = single;
+        }
+
+        return result;
+    }
+
+    /**
      * Common implementation for `sendRequest` and `stream` methods.
      * @param request `HttpRequest` object
      * @returns `HttpResponse` object
@@ -130,6 +166,7 @@ export class ImpitHttpClient implements BaseHttpClient {
             redirectCount?: number;
             redirectUrls?: URL[];
         },
+        onRedirect?: RedirectHandler,
     ): Promise<ResponseWithRedirects> {
         if ((redirects?.redirectCount ?? 0) > this.maxRedirects) {
             throw new Error(`Too many redirects, maximum is ${this.maxRedirects}.`);
@@ -159,16 +196,44 @@ export class ImpitHttpClient implements BaseHttpClient {
                 throw new Error('Redirect response missing location header.');
             }
 
+            const nextRedirectUrls = [...(redirects?.redirectUrls ?? []), redirectUrl];
+            const updatedRequest: { url?: string | URL; headers: SimpleHeaders } = {
+                url: redirectUrl.href,
+                headers: { ...(request.headers ?? {}) },
+            };
+
+            // Match GotScrapingHttpClient: allow HttpCrawler to persist redirect cookies into the session
+            // and mutate Cookie / URL for the next hop.
+            onRedirect?.(
+                {
+                    redirectUrls: nextRedirectUrls,
+                    url,
+                    statusCode: response.status,
+                    statusMessage: response.statusText,
+                    headers: this.intoSimpleHeaders(response.headers),
+                    trailers: {},
+                    complete: true,
+                },
+                updatedRequest,
+            );
+
+            const nextUrl =
+                typeof updatedRequest.url === 'string' ? updatedRequest.url : (updatedRequest.url?.href ?? redirectUrl.href);
+
             return this.getResponse(
                 {
                     ...request,
                     method: this.shouldRewriteRedirectToGet(response.status, request.method) ? 'GET' : request.method,
-                    url: redirectUrl.href,
+                    url: nextUrl,
+                    headers: updatedRequest.headers,
+                    // Body must not be replayed on redirect hops that rewrite to GET.
+                    body: this.shouldRewriteRedirectToGet(response.status, request.method) ? undefined : request.body,
                 },
                 {
                     redirectCount: (redirects?.redirectCount ?? 0) + 1,
-                    redirectUrls: [...(redirects?.redirectUrls ?? []), redirectUrl],
+                    redirectUrls: nextRedirectUrls,
                 },
+                onRedirect,
             );
         }
 
@@ -243,8 +308,8 @@ export class ImpitHttpClient implements BaseHttpClient {
     /**
      * @inheritDoc
      */
-    async stream(request: HttpRequest): Promise<StreamingHttpResponse> {
-        const { response, redirectUrls } = await this.getResponse(request);
+    async stream(request: HttpRequest, onRedirect?: RedirectHandler): Promise<StreamingHttpResponse> {
+        const { response, redirectUrls } = await this.getResponse(request, undefined, onRedirect);
         const [stream, getDownloadProgress] = this.getStreamWithProgress(response);
 
         return {

--- a/packages/impit-client/src/index.ts
+++ b/packages/impit-client/src/index.ts
@@ -129,26 +129,21 @@ export class ImpitHttpClient implements BaseHttpClient {
     }
 
     /**
-     * Converts Fetch/Impit headers into the simple header map expected by {@apilink RedirectHandler}.
-     * Preserves multiple `set-cookie` values when available.
+     * Converts Fetch/Impit headers into a simple header map.
+     * `Object.fromEntries` would keep only the last `set-cookie` value, so those are collected separately.
      */
     private intoSimpleHeaders(headers: Headers): SimpleHeaders {
         const result: SimpleHeaders = {};
 
         for (const [key, value] of headers.entries()) {
-            if (key.toLowerCase() === 'set-cookie') continue;
+            if (key === 'set-cookie') continue;
             result[key] = value;
         }
 
-        const setCookies = typeof headers.getSetCookie === 'function' ? headers.getSetCookie() : ([] as string[]);
+        const setCookies = headers.getSetCookie();
 
-        if (setCookies.length === 1) {
-            result['set-cookie'] = setCookies[0];
-        } else if (setCookies.length > 1) {
-            result['set-cookie'] = setCookies;
-        } else {
-            const single = headers.get('set-cookie');
-            if (single) result['set-cookie'] = single;
+        if (setCookies.length > 0) {
+            result['set-cookie'] = setCookies.length === 1 ? setCookies[0] : setCookies;
         }
 
         return result;
@@ -227,8 +222,6 @@ export class ImpitHttpClient implements BaseHttpClient {
                     method: this.shouldRewriteRedirectToGet(response.status, request.method) ? 'GET' : request.method,
                     url: nextUrl,
                     headers: updatedRequest.headers,
-                    // Body must not be replayed on redirect hops that rewrite to GET.
-                    body: this.shouldRewriteRedirectToGet(response.status, request.method) ? undefined : request.body,
                 },
                 {
                     redirectCount: (redirects?.redirectCount ?? 0) + 1,
@@ -269,7 +262,7 @@ export class ImpitHttpClient implements BaseHttpClient {
         }
 
         return {
-            headers: Object.fromEntries(response.headers.entries()),
+            headers: this.intoSimpleHeaders(response.headers),
             statusCode: response.status,
             url: response.url,
             request,
@@ -324,7 +317,7 @@ export class ImpitHttpClient implements BaseHttpClient {
             },
             uploadProgress: { percent: 100, transferred: 0 },
             redirectUrls,
-            headers: Object.fromEntries(response.headers.entries()),
+            headers: this.intoSimpleHeaders(response.headers),
             trailers: {},
         };
     }

--- a/packages/impit-client/src/index.ts
+++ b/packages/impit-client/src/index.ts
@@ -140,8 +140,7 @@ export class ImpitHttpClient implements BaseHttpClient {
             result[key] = value;
         }
 
-        const setCookies =
-            typeof headers.getSetCookie === 'function' ? headers.getSetCookie() : ([] as string[]);
+        const setCookies = typeof headers.getSetCookie === 'function' ? headers.getSetCookie() : ([] as string[]);
 
         if (setCookies.length === 1) {
             result['set-cookie'] = setCookies[0];
@@ -218,7 +217,9 @@ export class ImpitHttpClient implements BaseHttpClient {
             );
 
             const nextUrl =
-                typeof updatedRequest.url === 'string' ? updatedRequest.url : (updatedRequest.url?.href ?? redirectUrl.href);
+                typeof updatedRequest.url === 'string'
+                    ? updatedRequest.url
+                    : (updatedRequest.url?.href ?? redirectUrl.href);
 
             return this.getResponse(
                 {

--- a/test/core/crawlers/http_crawler.test.ts
+++ b/test/core/crawlers/http_crawler.test.ts
@@ -39,6 +39,12 @@ router.set('/cookies', (req, res) => {
     res.end(JSON.stringify(req.headers.cookie));
 });
 
+router.set('/setCookie', (req, res) => {
+    res.setHeader('content-type', 'text/html');
+    res.setHeader('set-cookie', 'first=1');
+    res.end();
+});
+
 router.set('/redirectWithoutCookies', (req, res) => {
     res.setHeader('location', '/cookies');
     res.statusCode = 302;
@@ -236,6 +242,27 @@ describe.each(
         await crawler.run([`${url}/redirectAndCookies`]);
 
         expect(results).toStrictEqual(['foo=bar']);
+    });
+
+    test('handles cookies from redirects when the session already has cookies', async () => {
+        const results: string[] = [];
+
+        const crawler = new HttpCrawler({
+            httpClient,
+            sessionPoolOptions: {
+                maxPoolSize: 1,
+                // isolated so that cookies stored by the other tests / clients don't leak in
+                persistStateKey: `SDK_SESSION_POOL_STATE_${httpClient.constructor.name}`,
+            },
+            maxConcurrency: 1,
+            requestHandler: async ({ body }) => {
+                results.push(body.toString());
+            },
+        });
+
+        await crawler.run([`${url}/setCookie`, `${url}/redirectAndCookies`]);
+
+        expect(results[1]).toBe('"first=1; foo=bar"');
     });
 
     test('handles cookies from redirects - no empty cookie header', async () => {

--- a/test/core/impit_http_client.test.ts
+++ b/test/core/impit_http_client.test.ts
@@ -9,6 +9,50 @@ vi.mock('impit', () => ({
     ),
 }));
 
+function createRedirectResponse(status: number, location: string, setCookie?: string | string[]) {
+    const setCookies = setCookie === undefined ? [] : Array.isArray(setCookie) ? setCookie : [setCookie];
+    const headerEntries: [string, string][] = [['location', location]];
+
+    return {
+        status,
+        statusText: 'Found',
+        url: 'http://example.com/start',
+        headers: {
+            entries: () => headerEntries[Symbol.iterator](),
+            get: (name: string) => {
+                const key = name.toLowerCase();
+                if (key === 'location') return location;
+                if (key === 'set-cookie') return setCookies[0] ?? null;
+                return null;
+            },
+            getSetCookie: () => setCookies,
+        },
+        body: undefined,
+    };
+}
+
+function createFinalResponse(body = 'ok') {
+    return {
+        status: 200,
+        statusText: 'OK',
+        url: 'http://example.com/final',
+        headers: {
+            entries: () => [['content-type', 'text/plain']][Symbol.iterator](),
+            get: (name: string) => (name.toLowerCase() === 'content-length' ? String(body.length) : null),
+            getSetCookie: () => [],
+        },
+        body: new ReadableStream({
+            start(controller) {
+                controller.enqueue(new TextEncoder().encode(body));
+                controller.close();
+            },
+        }),
+        text: async () => body,
+        json: async () => ({ body }),
+        bytes: async () => Buffer.from(body),
+    };
+}
+
 describe('ImpitHttpClient', () => {
     beforeEach(() => {
         vi.mocked(Impit).mockClear();
@@ -30,5 +74,69 @@ describe('ImpitHttpClient', () => {
         (httpClient as any).getClient({ proxyUrl: 'http://proxy.example' });
 
         expect(Impit).toHaveBeenCalledTimes(2);
+    });
+
+    test('stream() invokes onRedirect and forwards mutated Cookie header to the next hop', async () => {
+        const httpClient = new ImpitHttpClient({ cacheClients: false });
+        const fetchMock = vi.fn();
+
+        vi.mocked(Impit).mockImplementation(
+            class {
+                fetch = fetchMock;
+            } as any,
+        );
+
+        fetchMock
+            .mockResolvedValueOnce(createRedirectResponse(302, '/final', 'session=abc'))
+            .mockResolvedValueOnce(createFinalResponse('done'));
+
+        const onRedirect = vi.fn((redirectResponse, updatedRequest) => {
+            expect(redirectResponse.statusCode).toBe(302);
+            expect(redirectResponse.headers['set-cookie']).toEqual('session=abc');
+            updatedRequest.headers.Cookie = 'session=abc';
+        });
+
+        const response = await httpClient.stream(
+            {
+                url: 'http://example.com/start',
+                method: 'GET',
+                headers: {},
+            },
+            onRedirect,
+        );
+
+        expect(onRedirect).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+
+        const secondCallHeaders = fetchMock.mock.calls[1][1].headers as Headers;
+        expect(secondCallHeaders.get('Cookie')).toBe('session=abc');
+        expect(fetchMock.mock.calls[1][0]).toBe('http://example.com/final');
+        expect(response.statusCode).toBe(200);
+        expect(response.redirectUrls).toEqual([new URL('http://example.com/final')]);
+    });
+
+    test('stream() follows redirects without onRedirect for API compatibility', async () => {
+        const httpClient = new ImpitHttpClient({ cacheClients: false });
+        const fetchMock = vi.fn();
+
+        vi.mocked(Impit).mockImplementation(
+            class {
+                fetch = fetchMock;
+            } as any,
+        );
+
+        fetchMock
+            .mockResolvedValueOnce(createRedirectResponse(302, 'http://example.com/final'))
+            .mockResolvedValueOnce(createFinalResponse('done'));
+
+        const response = await httpClient.stream({
+            url: 'http://example.com/start',
+            method: 'GET',
+            headers: {},
+        });
+
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(response.statusCode).toBe(200);
+        expect(response.redirectUrls).toHaveLength(1);
     });
 });

--- a/test/core/impit_http_client.test.ts
+++ b/test/core/impit_http_client.test.ts
@@ -10,7 +10,10 @@ vi.mock('impit', () => ({
 }));
 
 function createRedirectResponse(status: number, location: string, setCookie?: string | string[]) {
-    const setCookies = setCookie === undefined ? [] : Array.isArray(setCookie) ? setCookie : [setCookie];
+    let setCookies: string[] = [];
+    if (setCookie !== undefined) {
+        setCookies = Array.isArray(setCookie) ? setCookie : [setCookie];
+    }
     const headerEntries: [string, string][] = [['location', location]];
 
     return {

--- a/test/core/impit_http_client.test.ts
+++ b/test/core/impit_http_client.test.ts
@@ -9,27 +9,15 @@ vi.mock('impit', () => ({
     ),
 }));
 
-function createRedirectResponse(status: number, location: string, setCookie?: string | string[]) {
-    let setCookies: string[] = [];
-    if (setCookie !== undefined) {
-        setCookies = Array.isArray(setCookie) ? setCookie : [setCookie];
-    }
-    const headerEntries: [string, string][] = [['location', location]];
+function createRedirectResponse(status: number, location: string, setCookie: string[] = []) {
+    const headers = new Headers({ location });
+    for (const cookie of setCookie) headers.append('set-cookie', cookie);
 
     return {
         status,
         statusText: 'Found',
         url: 'http://example.com/start',
-        headers: {
-            entries: () => headerEntries[Symbol.iterator](),
-            get: (name: string) => {
-                const key = name.toLowerCase();
-                if (key === 'location') return location;
-                if (key === 'set-cookie') return setCookies[0] ?? null;
-                return null;
-            },
-            getSetCookie: () => setCookies,
-        },
+        headers,
         body: undefined,
     };
 }
@@ -39,11 +27,7 @@ function createFinalResponse(body = 'ok') {
         status: 200,
         statusText: 'OK',
         url: 'http://example.com/final',
-        headers: {
-            entries: () => [['content-type', 'text/plain']][Symbol.iterator](),
-            get: (name: string) => (name.toLowerCase() === 'content-length' ? String(body.length) : null),
-            getSetCookie: () => [],
-        },
+        headers: new Headers({ 'content-type': 'text/plain', 'content-length': String(body.length) }),
         body: new ReadableStream({
             start(controller) {
                 controller.enqueue(new TextEncoder().encode(body));
@@ -90,12 +74,10 @@ describe('ImpitHttpClient', () => {
         );
 
         fetchMock
-            .mockResolvedValueOnce(createRedirectResponse(302, '/final', 'session=abc'))
+            .mockResolvedValueOnce(createRedirectResponse(302, '/final', ['session=abc', 'other=def']))
             .mockResolvedValueOnce(createFinalResponse('done'));
 
-        const onRedirect = vi.fn((redirectResponse, updatedRequest) => {
-            expect(redirectResponse.statusCode).toBe(302);
-            expect(redirectResponse.headers['set-cookie']).toEqual('session=abc');
+        const onRedirect = vi.fn((_redirectResponse, updatedRequest) => {
             updatedRequest.headers.Cookie = 'session=abc';
         });
 
@@ -110,6 +92,10 @@ describe('ImpitHttpClient', () => {
 
         expect(onRedirect).toHaveBeenCalledTimes(1);
         expect(fetchMock).toHaveBeenCalledTimes(2);
+
+        const [redirectResponse] = onRedirect.mock.calls[0];
+        expect(redirectResponse.statusCode).toBe(302);
+        expect(redirectResponse.headers['set-cookie']).toEqual(['session=abc', 'other=def']);
 
         const secondCallHeaders = fetchMock.mock.calls[1][1].headers as Headers;
         expect(secondCallHeaders.get('Cookie')).toBe('session=abc');


### PR DESCRIPTION
## Summary
- `ImpitHttpClient.stream` ignored the `onRedirect` callback that `HttpCrawler` uses to persist `Set-Cookie` from intermediate redirects into the session and forward `Cookie` on the next hop.
- Align Impit with `GotScrapingHttpClient` redirect behavior so Impit-backed crawls keep redirect cookies.
- Add unit tests covering `onRedirect` invocation and Cookie header forwarding.

## Test plan
- [x] `yarn test test/core/impit_http_client.test.ts`
- [x] `yarn test test/core/crawlers/http_crawler.test.ts` (redirect cookie cases for Impit + Got)