### PR TITLE
fix(core): preserve subclass overrides when binding methods to a scoped service locator

### DIFF
--- a/packages/core/src/service_locator.ts
+++ b/packages/core/src/service_locator.ts
@@ -311,11 +311,17 @@ export function bindMethodsToServiceLocator(
     target: {},
 ): { run: <T>(fn: () => T) => T; enterScope: () => void; exitScope: () => void } {
     let proto = Object.getPrototypeOf(target);
+    const seenKeys = new Set<string | symbol>();
 
     while (proto !== null && proto !== Object.prototype) {
         const propertyKeys = [...Object.getOwnPropertyNames(proto), ...Object.getOwnPropertySymbols(proto)];
 
         for (const propertyKey of propertyKeys) {
+            // The chain is walked derived-first, so the first occurrence of a key is the one dynamic
+            // dispatch would pick — a subclass override must not be clobbered by its base version.
+            if (seenKeys.has(propertyKey)) continue;
+            seenKeys.add(propertyKey);
+
             const descriptor = Object.getOwnPropertyDescriptor(proto, propertyKey);
 
             // We use property descriptors rather than accessing target[propertyKey] directly,

--- a/packages/core/test/core/service_locator.test.ts
+++ b/packages/core/test/core/service_locator.test.ts
@@ -1,6 +1,7 @@
 import type { CrawleeLogger } from '@crawlee/core';
 import {
     ApifyLogAdapter,
+    bindMethodsToServiceLocator,
     Configuration,
     LocalEventManager,
     MemoryStorageBackend,
@@ -375,6 +376,45 @@ describe('ServiceLocator', () => {
 
             const child = crawlerLocator.getChildLog('Crawler Module');
             expect(child.getOptions()).toEqual({ prefix: 'Crawler Module' });
+        });
+    });
+
+    describe('bindMethodsToServiceLocator', () => {
+        test('wrapped methods resolve the scoped service locator', () => {
+            const scopedLogger = makeMockLogger();
+            const scopedLocator = new ServiceLocator(undefined, undefined, undefined, scopedLogger);
+
+            class Service {
+                getLogger() {
+                    return serviceLocator.getLogger();
+                }
+            }
+
+            const service = new Service();
+            bindMethodsToServiceLocator(scopedLocator, service);
+
+            expect(service.getLogger()).toBe(scopedLogger);
+        });
+
+        test('subclass method overrides are not clobbered by their base class versions', () => {
+            const scopedLocator = new ServiceLocator();
+
+            class Base {
+                whoAmI() {
+                    return 'base';
+                }
+            }
+
+            class Derived extends Base {
+                override whoAmI() {
+                    return `derived (super says ${super.whoAmI()})`;
+                }
+            }
+
+            const instance = new Derived();
+            bindMethodsToServiceLocator(scopedLocator, instance);
+
+            expect(instance.whoAmI()).toBe('derived (super says base)');
         });
     });
 


### PR DESCRIPTION
`bindMethodsToServiceLocator()` wraps every prototype method as an own property on the crawler instance so that calls resolve the crawler's scoped service locator. The walk goes derived-first but assigned wrappers unconditionally, so a method defined on both a subclass and a base class got wrapped twice, and the base version, assigned last, won.

Any crawler constructed with scoped services (`logger`, `storageBackend`, `eventManager`, or a custom `configuration`) therefore lost all its method overrides. `AdaptivePlaywrightCrawler` fell back to `BasicCrawler.runRequestHandler()`: no rendering type prediction or detection, no log replay, and an `_init()` that never initialized the predictor. Every other crawler subclass lost its `buildContextPipeline()` override the same way.

This also explains why the log replay tests added in #3803 kept passing with the replay line reverted. They pass a custom `logger`, so the adaptive code path never ran and the request handler logged straight to the real logger. With this fix they fail without the replay lines and pass with them (checked in both directions).

The fix skips a method once a more derived version of it has been handled. A key seen as a getter or setter at a derived level also blocks wrapping its base version, since dynamic dispatch would pick the derived accessor.


Closes #3934
