### PR TITLE
refactor!: trim internal helpers from the `@crawlee/utils` public API

### DIFF
--- a/docs/public-api/crawlee-core.api.md
+++ b/docs/public-api/crawlee-core.api.md
@@ -51,7 +51,6 @@ import type { StandardSchemaV1 } from '@standard-schema/spec';
 import type * as storage from '@crawlee/types';
 import { StorageBackend } from '@crawlee/types';
 import { StorageIdentifier } from '@crawlee/types';
-import { tryAbsoluteURL } from '@crawlee/utils';
 import { z } from 'zod';
 
 // @public (undocumented)
@@ -1762,8 +1761,6 @@ export interface SystemInfo {
     // (undocumented)
     memTotalBytes?: number;
 }
-
-export { tryAbsoluteURL }
 
 // @public (undocumented)
 export type UrlPatternObject = {

--- a/docs/public-api/crawlee-http.api.md
+++ b/docs/public-api/crawlee-http.api.md
@@ -11,7 +11,7 @@ import { BasePredicate } from 'ow';
 import { BasicCrawler } from '@crawlee/basic';
 import { BasicCrawlerOptions } from '@crawlee/basic';
 import { BooleanPredicate } from 'ow';
-import { CheerioRoot } from '@crawlee/utils';
+import type { CheerioRoot } from '@crawlee/utils';
 import { ConcurrencySystem } from '@crawlee/basic';
 import type { ConcurrencySystemOptions } from '@crawlee/basic';
 import { ContextPipeline } from '@crawlee/basic';

--- a/docs/public-api/crawlee-utils.api.md
+++ b/docs/public-api/crawlee-utils.api.md
@@ -19,9 +19,6 @@ export { CheerioAPI }
 // @public (undocumented)
 export type CheerioRoot = CheerioAPI;
 
-// @public (undocumented)
-export const CLOUDFLARE_RETRY_CSS_SELECTORS: string[];
-
 // @public
 const DISCORD_REGEX: RegExp;
 
@@ -97,9 +94,6 @@ const LINKEDIN_REGEX: RegExp;
 // @public
 const LINKEDIN_REGEX_GLOBAL: RegExp;
 
-// @public
-export function mergeAsyncIterables<T>(...iterables: AsyncIterable<T>[]): AsyncIterable<T>;
-
 // @public (undocumented)
 export interface OpenGraphProperty {
     // (undocumented)
@@ -147,9 +141,6 @@ const PINTEREST_REGEX: RegExp;
 const PINTEREST_REGEX_GLOBAL: RegExp;
 
 // @public
-export const RETRY_CSS_SELECTORS: string[];
-
-// @public
 export class RobotsTxtFile {
     static find(url: string, options?: {
         signal?: AbortSignal;
@@ -164,9 +155,6 @@ export class RobotsTxtFile {
     parseSitemaps(): Promise<Sitemap>;
     parseUrlsFromSitemaps(): Promise<string[]>;
 }
-
-// @public
-export const ROTATE_PROXY_ERRORS: string[];
 
 // @public
 export class Sitemap {
@@ -246,9 +234,6 @@ const TIKTOK_REGEX: RegExp;
 
 // @public
 const TIKTOK_REGEX_GLOBAL: RegExp;
-
-// @public
-export function tryAbsoluteURL(href: string, baseUrl: string): string | undefined;
 
 // @public
 const TWITTER_REGEX: RegExp;

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -61,6 +61,7 @@ import {
     RequestQueue,
     RequestState,
     RetryRequestError,
+    ROTATE_PROXY_ERRORS,
     Router,
     ServiceLocator,
     serviceLocator,
@@ -83,7 +84,7 @@ import type {
     SetStatusMessageOptions,
     StorageBackend,
 } from '@crawlee/types';
-import { isAsyncIterable, isIterable, RobotsTxtFile, ROTATE_PROXY_ERRORS } from '@crawlee/utils';
+import { isAsyncIterable, isIterable, RobotsTxtFile } from '@crawlee/utils';
 import { stringify } from 'csv-stringify/sync';
 import { ensureDir, writeJSON } from 'fs-extra/esm';
 import ow, { ArgumentError } from 'ow';

--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -16,6 +16,7 @@ import type {
 import {
     BasicCrawler,
     browserPoolCookieToToughCookie,
+    CLOUDFLARE_RETRY_CSS_SELECTORS,
     ContextPipeline,
     cookieStringToToughCookie,
     enqueueLinks,
@@ -24,9 +25,9 @@ import {
     OwnedOrInjected,
     RequestState,
     resolveBaseUrlForEnqueueLinksFiltering,
+    RETRY_CSS_SELECTORS,
     SessionError,
     toughCookieToBrowserPoolCookie,
-    tryAbsoluteURL,
     validators,
 } from '@crawlee/basic';
 import type {
@@ -49,7 +50,7 @@ import type {
     ISession,
 } from '@crawlee/types';
 import type { RobotsTxtFile } from '@crawlee/utils';
-import { CLOUDFLARE_RETRY_CSS_SELECTORS, RETRY_CSS_SELECTORS, sleep } from '@crawlee/utils';
+import { sleep, tryAbsoluteURL } from '@crawlee/utils';
 import ow from 'ow';
 import type { ReadonlyDeep } from 'type-fest';
 

--- a/packages/core/src/blocked.ts
+++ b/packages/core/src/blocked.ts
@@ -1,7 +1,11 @@
+/**
+ * @internal
+ */
 export const CLOUDFLARE_RETRY_CSS_SELECTORS = ['#turnstile-wrapper iframe[src^="https://challenges.cloudflare.com"]'];
 
 /**
  * CSS selectors for elements that should trigger a retry, as the crawler is likely getting blocked.
+ * @internal
  */
 export const RETRY_CSS_SELECTORS = [
     ...CLOUDFLARE_RETRY_CSS_SELECTORS,
@@ -11,6 +15,7 @@ export const RETRY_CSS_SELECTORS = [
 
 /**
  * Content of proxy errors that should trigger a retry, as the proxy is likely getting blocked / is malfunctioning.
+ * @internal
  */
 export const ROTATE_PROXY_ERRORS = [
     'ECONNRESET',

--- a/packages/core/src/enqueue_links/shared.ts
+++ b/packages/core/src/enqueue_links/shared.ts
@@ -8,8 +8,6 @@ import { purlToRegExp } from '@apify/pseudo_url';
 import type { RequestOptions } from '../request.js';
 import type { EnqueueLinksOptions } from './enqueue_links.js';
 
-export { tryAbsoluteURL } from '@crawlee/utils';
-
 const MAX_ENQUEUE_LINKS_CACHE_SIZE = 1000;
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+export * from './blocked.js';
 export * from './debug.js';
 export * from './errors.js';
 export * from './autoscaling/index.js';

--- a/packages/http-crawler/src/internals/http-crawler.ts
+++ b/packages/http-crawler/src/internals/http-crawler.ts
@@ -25,10 +25,10 @@ import {
     Router,
     SessionError,
 } from '@crawlee/basic';
-import { type LoadedRequest, getCookiesFromResponse } from '@crawlee/core';
+import { type LoadedRequest, getCookiesFromResponse, RETRY_CSS_SELECTORS } from '@crawlee/core';
 import { ResponseWithUrl } from '@crawlee/http-client';
 import type { Awaitable, Dictionary, ISession } from '@crawlee/types';
-import { type CheerioRoot, RETRY_CSS_SELECTORS } from '@crawlee/utils';
+import type { CheerioRoot } from '@crawlee/utils';
 import type { RequestLike, ResponseLike } from 'content-type';
 import contentTypeParser from 'content-type';
 import iconv from 'iconv-lite';

--- a/packages/jsdom-crawler/src/internals/jsdom-crawler.ts
+++ b/packages/jsdom-crawler/src/internals/jsdom-crawler.ts
@@ -21,10 +21,9 @@ import {
     NavigationSkippedError,
     resolveBaseUrlForEnqueueLinksFiltering,
     Router,
-    tryAbsoluteURL,
 } from '@crawlee/http';
 import type { Dictionary } from '@crawlee/types';
-import { type CheerioRoot, type RobotsTxtFile, sleep } from '@crawlee/utils';
+import { type CheerioRoot, type RobotsTxtFile, sleep, tryAbsoluteURL } from '@crawlee/utils';
 import type { DOMWindow } from 'jsdom';
 import { JSDOM, ResourceLoader, VirtualConsole } from 'jsdom';
 import ow from 'ow';

--- a/packages/linkedom-crawler/src/internals/linkedom-crawler.ts
+++ b/packages/linkedom-crawler/src/internals/linkedom-crawler.ts
@@ -21,10 +21,9 @@ import {
     NavigationSkippedError,
     resolveBaseUrlForEnqueueLinksFiltering,
     Router,
-    tryAbsoluteURL,
 } from '@crawlee/http';
 import type { Dictionary } from '@crawlee/types';
-import { type CheerioRoot, type RobotsTxtFile, sleep } from '@crawlee/utils';
+import { type CheerioRoot, type RobotsTxtFile, sleep, tryAbsoluteURL } from '@crawlee/utils';
 import * as cheerio from 'cheerio';
 import { DOMParser } from 'linkedom/cached';
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,4 +1,3 @@
-export * from './internals/blocked.js';
 export * from './internals/cheerio.js';
 export * from './internals/extract-urls.js';
 export * from './internals/general.js';

--- a/packages/utils/src/internals/extract-urls.ts
+++ b/packages/utils/src/internals/extract-urls.ts
@@ -109,6 +109,7 @@ export function extractUrls(options: ExtractUrlsOptions): string[] {
 
 /**
  * Helper function used to validate URLs used when extracting URLs from a page
+ * @internal
  */
 export function tryAbsoluteURL(href: string, baseUrl: string): string | undefined {
     try {

--- a/packages/utils/src/internals/iterables-internal.ts
+++ b/packages/utils/src/internals/iterables-internal.ts
@@ -1,0 +1,69 @@
+/**
+ * Converts any iterable or async iterable to an async iterable.
+ *
+ * @yields Each item from the input iterable
+ *
+ * **Example usage:**
+ * ```ts
+ * const syncArray = [1, 2, 3];
+ * for await (const item of asyncifyIterable(syncArray)) {
+ *   console.log(item); // 1, 2, 3
+ * }
+ * ```
+ */
+export async function* asyncifyIterable<T>(iterable: Iterable<T> | AsyncIterable<T>): AsyncIterable<T> {
+    yield* iterable;
+}
+
+// Source - https://stackoverflow.com/a/71288323
+/**
+ * Merges multiple async iterables into a single async iterable, yielding values concurrently.
+ *
+ * **Example usage:**
+ * ```ts
+ * const asyncIterable1 = async function* () {
+ *   yield 1; yield 3; yield 5;
+ * };
+ *
+ * const asyncIterable2 = async function* () {
+ *   yield 2; yield 4; yield 6;
+ * };
+ *
+ * for await (const value of mergeAsyncIterables(asyncIterable1(), asyncIterable2())) {
+ *   console.log(value);
+ * }
+ * ```
+ */
+export async function* mergeAsyncIterables<T>(...iterables: AsyncIterable<T>[]): AsyncIterable<T> {
+    const asyncIterators = iterables.map((iterable) => iterable[Symbol.asyncIterator]());
+    const results = [];
+    let count = asyncIterators.length;
+    const never: Promise<never> = new Promise(() => {});
+    async function getNext(asyncIterator: AsyncIterator<T>, index: number) {
+        const result = await asyncIterator.next();
+        return {
+            index,
+            result,
+        };
+    }
+    const nextPromises = asyncIterators.map(getNext);
+    try {
+        while (count) {
+            const { index, result } = await Promise.race(nextPromises);
+            if (result.done) {
+                nextPromises[index] = never;
+                results[index] = result.value;
+                count--;
+            } else {
+                nextPromises[index] = getNext(asyncIterators[index], index);
+                yield result.value;
+            }
+        }
+    } finally {
+        for (const [index, iterator] of asyncIterators.entries()) {
+            // no await here - see https://github.com/tc39/proposal-async-iteration/issues/126
+            if (nextPromises[index] !== never && iterator.return != null) void iterator.return();
+        }
+    }
+    return results;
+}

--- a/packages/utils/src/internals/iterables.ts
+++ b/packages/utils/src/internals/iterables.ts
@@ -1,5 +1,7 @@
 import { inspect } from 'node:util';
 
+import { asyncifyIterable } from './iterables-internal.js';
+
 /**
  * Type guard that checks if a value is iterable (has Symbol.iterator).
  * @internal
@@ -44,24 +46,6 @@ export function isAsyncIterable<T>(value: unknown): value is AsyncIterable<T> {
     }
 
     return typeof Object(value)[Symbol.asyncIterator] === 'function';
-}
-
-/**
- * Converts any iterable or async iterable to an async iterable.
- * @internal
- *
- * @yields Each item from the input iterable
- *
- * **Example usage:**
- * ```ts
- * const syncArray = [1, 2, 3];
- * for await (const item of asyncifyIterable(syncArray)) {
- *   console.log(item); // 1, 2, 3
- * }
- * ```
- */
-export async function* asyncifyIterable<T>(iterable: Iterable<T> | AsyncIterable<T>): AsyncIterable<T> {
-    yield* iterable;
 }
 
 /**
@@ -225,57 +209,4 @@ export function peekableAsyncIterable<T>(iterable: AsyncIterable<T> | Iterable<T
             return peekableIterator;
         },
     };
-}
-
-// Source - https://stackoverflow.com/a/71288323
-/**
- * Merges multiple async iterables into a single async iterable, yielding values concurrently.
- *
- * **Example usage:**
- * ```ts
- * const asyncIterable1 = async function* () {
- *   yield 1; yield 3; yield 5;
- * };
- *
- * const asyncIterable2 = async function* () {
- *   yield 2; yield 4; yield 6;
- * };
- *
- * for await (const value of mergeAsyncIterables(asyncIterable1(), asyncIterable2())) {
- *   console.log(value);
- * }
- * ```
- */
-export async function* mergeAsyncIterables<T>(...iterables: AsyncIterable<T>[]): AsyncIterable<T> {
-    const asyncIterators = iterables.map((iterable) => iterable[Symbol.asyncIterator]());
-    const results = [];
-    let count = asyncIterators.length;
-    const never: Promise<never> = new Promise(() => {});
-    async function getNext(asyncIterator: AsyncIterator<T>, index: number) {
-        const result = await asyncIterator.next();
-        return {
-            index,
-            result,
-        };
-    }
-    const nextPromises = asyncIterators.map(getNext);
-    try {
-        while (count) {
-            const { index, result } = await Promise.race(nextPromises);
-            if (result.done) {
-                nextPromises[index] = never;
-                results[index] = result.value;
-                count--;
-            } else {
-                nextPromises[index] = getNext(asyncIterators[index], index);
-                yield result.value;
-            }
-        }
-    } finally {
-        for (const [index, iterator] of asyncIterators.entries()) {
-            // no await here - see https://github.com/tc39/proposal-async-iteration/issues/126
-            if (nextPromises[index] !== never && iterator.return != null) void iterator.return();
-        }
-    }
-    return results;
 }

--- a/packages/utils/src/internals/sitemap.ts
+++ b/packages/utils/src/internals/sitemap.ts
@@ -10,7 +10,7 @@ import { fileTypeStream } from 'file-type';
 import sax from 'sax';
 import MIMEType from 'whatwg-mimetype';
 
-import { mergeAsyncIterables } from './iterables.js';
+import { mergeAsyncIterables } from './iterables-internal.js';
 import { RobotsTxtFile } from './robots.js';
 
 interface SitemapUrlData {

--- a/test/utils/iterables.test.ts
+++ b/test/utils/iterables.test.ts
@@ -1,5 +1,7 @@
-import { asyncifyIterable, chunkedAsyncIterable, peekableAsyncIterable } from '@crawlee/utils';
+import { chunkedAsyncIterable, peekableAsyncIterable } from '@crawlee/utils';
 import { describe, expect, it } from 'vitest';
+
+import { asyncifyIterable } from '../../packages/utils/src/internals/iterables-internal.js';
 
 describe('asyncifyIterable', () => {
     it('should convert a regular array to async iterable', async () => {


### PR DESCRIPTION
Moves the blocked-detection constants (`CLOUDFLARE_RETRY_CSS_SELECTORS`, `RETRY_CSS_SELECTORS`, `ROTATE_PROXY_ERRORS`) into `@crawlee/core` as package-internal symbols, since the crawler packages are their only consumers.

Splits `iterables.ts` into the half other packages import and a package-private `iterables-internal.ts` that the index does not re-export, so `asyncifyIterable` and `mergeAsyncIterables` are no longer reachable from the package entrypoint at all — the former is only used by `peekableAsyncIterable` and its own test, the latter only by the sitemap parser. Follows the same package-private pattern as `byte_utils.ts` / `weighted_avg.ts` in `@crawlee/core`, with the test importing the module by relative path.

Marks `tryAbsoluteURL` as `@internal`; it has to stay exported for the DOM-crawler link extractors. The bare `export { tryAbsoluteURL } from '@crawlee/utils'` in `enqueue_links/shared.ts` is dropped, since a release tag on a re-export statement does not trim it from the `@crawlee/core` surface; the crawler packages import it from `@crawlee/utils` directly.

What remains on the `@crawlee/utils` entrypoint is either user-facing (`RobotsTxtFile`, sitemap parsing, `parseOpenGraph`, `social`, `htmlToText`, `extractUrls`, `downloadListOfUrls`, `sleep`, the Cheerio type aliases, and the two URL regexes that are documented defaults of `ExtractUrlsOptions.urlRegExp`) or an `@internal` helper that genuinely has to cross a package boundary — `expandShadowRoots`, `applySearchParams`, `isIterable`/`isAsyncIterable`, `chunkedAsyncIterable`/`peekableAsyncIterable`. Those last ones can only be hidden completely by giving the package a second entrypoint, which would be a new convention for this repo and is left out of scope here.

Related to #3079