### PR TITLE
perf: lazy-load `cheerio` in `playwright`/`puppeteer` `parseWithCheerio`

### DIFF
--- a/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
+++ b/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
@@ -25,7 +25,6 @@ import vm from 'node:vm';
 import { Configuration, KeyValueStore, type Request, serviceLocator, SessionError, validators } from '@crawlee/browser';
 import type { BatchAddRequestsResult, Dictionary } from '@crawlee/types';
 import { type CheerioRoot, expandShadowRoots, sleep } from '@crawlee/utils';
-import * as cheerio from 'cheerio';
 import ow from 'ow';
 import type { Download, Page, Response, Route } from 'playwright';
 
@@ -611,7 +610,8 @@ export async function parseWithCheerio(
         ? null
         : ((await page.evaluate(`(${expandShadowRoots.toString()})(document)`)) as string);
     const pageContent = html || (await page.content());
-    const $ = cheerio.load(pageContent);
+    const { load } = await import('cheerio');
+    const $ = load(pageContent);
 
     if (page.frames().length > 1 && !ignoreIframes) {
         const frames = await page.$$('iframe');

--- a/packages/puppeteer-crawler/src/internals/utils/puppeteer_utils.ts
+++ b/packages/puppeteer-crawler/src/internals/utils/puppeteer_utils.ts
@@ -26,7 +26,6 @@ import type { Request } from '@crawlee/browser';
 import { Configuration, KeyValueStore, serviceLocator, validators } from '@crawlee/browser';
 import type { BatchAddRequestsResult, Dictionary } from '@crawlee/types';
 import { type CheerioRoot, expandShadowRoots, sleep } from '@crawlee/utils';
-import * as cheerio from 'cheerio';
 import type { ProtocolMapping } from 'devtools-protocol/types/protocol-mapping.js';
 import ow from 'ow';
 // @ts-ignore This only throws when compiled against puppeteer 25+ (ESM only), we only import types, so its alllll gooooood
@@ -235,7 +234,8 @@ export async function parseWithCheerio(
         : ((await page.evaluate(`(${expandShadowRoots.toString()})(document)`)) as string);
     const pageContent = html || (await page.content());
 
-    return cheerio.load(pageContent);
+    const { load } = await import('cheerio');
+    return load(pageContent);
 }
 
 /**


### PR DESCRIPTION
Extends the fix from #3836 (which already made `@crawlee/utils` and `http-crawler` lazy-load cheerio) to the two remaining spots that were still importing it eagerly: `playwright-utils.ts` and `puppeteer_utils.ts`. Both only use cheerio inside `parseWithCheerio()`, so every Playwright/Puppeteer crawler paid cheerio's import cost even when the handler never calls it.

Related to #3549.