### PR TITLE
refactor: drop `fs-extra` dependency

### DIFF
--- a/packages/basic-crawler/package.json
+++ b/packages/basic-crawler/package.json
@@ -47,7 +47,6 @@
         "@crawlee/types": "workspace:*",
         "@crawlee/utils": "workspace:*",
         "csv-stringify": "^6.5.2",
-        "fs-extra": "^11.3.0",
         "ow": "^2.0.0",
         "tldts": "^7.0.6",
         "tslib": "^2.8.1",

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -1,4 +1,4 @@
-import { writeFile } from 'node:fs/promises';
+import { mkdir, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 
 import type {
@@ -85,7 +85,6 @@ import type {
 } from '@crawlee/types';
 import { isAsyncIterable, isIterable, RobotsTxtFile, ROTATE_PROXY_ERRORS } from '@crawlee/utils';
 import { stringify } from 'csv-stringify/sync';
-import { ensureDir, writeJSON } from 'fs-extra/esm';
 import ow, { ArgumentError } from 'ow';
 import { getDomain } from 'tldts';
 import type { ReadonlyDeep, SetRequired } from 'type-fest';
@@ -1988,14 +1987,14 @@ export class BasicCrawler<
                 ]);
             }
 
-            await ensureDir(dirname(path));
+            await mkdir(dirname(path), { recursive: true });
             await writeFile(path, value);
             this.log.info(`Export to ${path} finished!`);
         }
 
         if (format === 'json') {
-            await ensureDir(dirname(path));
-            await writeJSON(path, items, { spaces: 4 });
+            await mkdir(dirname(path), { recursive: true });
+            await writeFile(path, `${JSON.stringify(items, null, 4)}\n`);
             this.log.info(`Export to ${path} finished!`);
         }
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,7 +48,6 @@
         "@crawlee/templates": "workspace:*",
         "@inquirer/prompts": "^7.5.0",
         "ansi-colors": "^4.1.3",
-        "fs-extra": "^11.3.0",
         "tslib": "^2.8.1",
         "yargs": "^18.0.0"
     }

--- a/packages/cli/src/commands/CreateProjectCommand.ts
+++ b/packages/cli/src/commands/CreateProjectCommand.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'node:child_process';
 import { mkdirSync } from 'node:fs';
-import { readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { get } from 'node:https';
 import { dirname, join, resolve } from 'node:path';
 import { setTimeout } from 'node:timers/promises';
@@ -9,7 +9,6 @@ import type { Template } from '@crawlee/templates';
 import { fetchManifest } from '@crawlee/templates';
 import { input, select } from '@inquirer/prompts';
 import colors from 'ansi-colors';
-import { ensureDir } from 'fs-extra/esm';
 import type { ArgumentsCamelCase, Argv, CommandModule } from 'yargs';
 
 interface CreateProjectArgs {
@@ -76,7 +75,7 @@ async function downloadTemplateFilesToDisk(template: Template, destinationDirect
                 // Make sure the folder for the file exists
                 const fileDirName = dirname(file.path);
                 const fileFolder = resolve(destinationDirectory, fileDirName);
-                await ensureDir(fileFolder);
+                await mkdir(fileFolder, { recursive: true });
 
                 // Write the actual file
                 await writeFile(resolve(destinationDirectory, file.path), buffer);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,9 +320,6 @@ importers:
       csv-stringify:
         specifier: ^6.5.2
         version: 6.7.0
-      fs-extra:
-        specifier: ^11.3.0
-        version: 11.3.4
       ow:
         specifier: ^2.0.0
         version: 2.0.0
@@ -453,9 +450,6 @@ importers:
       ansi-colors:
         specifier: ^4.1.3
         version: 4.1.3
-      fs-extra:
-        specifier: ^11.3.0
-        version: 11.3.4
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -1312,9 +1306,6 @@ packages:
     resolution: {integrity: sha512-VHIswI7rD/R4bToeIDuJ9WJXt+qr5SdhfoZ9RzdjmCs9mgy7l0P4RugQEUCcU+WB4sfImbd4CKwzXcn0uYx1yw==}
     engines: {node: '>= 0.10'}
     hasBin: true
-
-  '@apify/pseudo_url@2.0.76':
-    resolution: {integrity: sha512-eNWHnP8CeMBgYBFko6/NJhHNKnxjy9HtbKQy0rq75LuKeibnAcT+7kkQrr6JDyDzrZL1O96yRWEy+G3lC2eIZA==}
 
   '@apify/timeout@0.3.3':
     resolution: {integrity: sha512-lyvwMXee8SJNjNyxhr+nSTNyvjyoxbxol51xikq9VytFOPNSEMz8N02mUAuLVJNqrnqCBFRybjeqZdg4Y5AZlA==}
@@ -12958,10 +12949,6 @@ snapshots:
   '@apify/ps-tree@1.2.0':
     dependencies:
       event-stream: 3.3.4
-
-  '@apify/pseudo_url@2.0.76':
-    dependencies:
-      '@apify/log': 2.5.35
 
   '@apify/timeout@0.3.3': {}
 


### PR DESCRIPTION
fs-extra was only used for `ensureDir` and `writeJSON` in `cli` and `basic-crawler`, both one-line wrappers over `node:fs/promises`. 

Swapped them for `mkdir(recursive)` and `writeFile`, dropping the dependency.

Related to #3549