### PR TITLE
fix: allow typed user data in AdaptivePlaywrightCrawler request handlers

### DIFF
--- a/docs/public-api/crawlee-playwright.api.md
+++ b/docs/public-api/crawlee-playwright.api.md
@@ -100,7 +100,7 @@ export class AdaptivePlaywrightCrawler<ContextExtension = Dictionary<never>, Ext
 }
 
 // @public (undocumented)
-export interface AdaptivePlaywrightCrawlerContext<UserData extends Dictionary = Dictionary> extends CrawlingContext_2<UserData> {
+export interface AdaptivePlaywrightCrawlerContext<UserData extends Dictionary = any> extends CrawlingContext_2<UserData> {
     // (undocumented)
     enqueueLinks(options?: EnqueueLinksOptions): Promise<unknown>;
     page: Page;

--- a/packages/playwright-crawler/src/internals/adaptive-playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/adaptive-playwright-crawler.ts
@@ -116,7 +116,7 @@ class AdaptivePlaywrightCrawlerStatistics extends Statistics {
 }
 
 export interface AdaptivePlaywrightCrawlerContext<
-    UserData extends Dictionary = Dictionary,
+    UserData extends Dictionary = any, // with default to Dictionary we cant use a typed router in untyped crawler
 > extends CrawlingContext<UserData> {
     request: LoadedRequest<Request<UserData>>;
     /**

--- a/test/core/crawlers/adaptive_playwright_types.test.ts
+++ b/test/core/crawlers/adaptive_playwright_types.test.ts
@@ -1,0 +1,22 @@
+import type { AdaptivePlaywrightCrawlerContext, AdaptivePlaywrightCrawlerOptions } from '@crawlee/playwright';
+import type { Dictionary } from '@crawlee/types';
+
+/**
+ * Type-level regression test: a request handler typed with custom user data must stay assignable
+ * to an untyped `AdaptivePlaywrightCrawlerOptions`, like in the HTTP-based crawlers (issue #2063).
+ */
+
+interface OrderUserData extends Dictionary {
+    label: string;
+}
+
+describe('AdaptivePlaywrightCrawler option types (#2063)', () => {
+    test('request handler typed with custom user data stays assignable', () => {
+        const requestHandler = async ({ request }: AdaptivePlaywrightCrawlerContext<OrderUserData>) =>
+            void request.userData.label;
+
+        const options: AdaptivePlaywrightCrawlerOptions = { requestHandler };
+
+        expect(options).toBeTruthy();
+    });
+});


### PR DESCRIPTION
A request handler typed with custom user data, e.g. `async ({ request }: AdaptivePlaywrightCrawlerContext<MyUserData>) => ...`, was not assignable to an untyped `AdaptivePlaywrightCrawlerOptions` (TS2322), because `AdaptivePlaywrightCrawlerContext` still defaulted its `UserData` generic to `Dictionary`. This is the same variance problem #2063 covers; the other crawling contexts already default `UserData` to `any` (#3970 completes the browser family), so this brings the adaptive crawler in line.

Includes a type-level regression test and the regenerated API snapshot.
