### PR TITLE
fix: don't ship `idcac-playwright` as a hard dependency

### DIFF
--- a/packages/playwright-crawler/package.json
+++ b/packages/playwright-crawler/package.json
@@ -57,7 +57,6 @@
         "@crawlee/types": "workspace:*",
         "@crawlee/utils": "workspace:*",
         "cheerio": "^1.0.0",
-        "idcac-playwright": "^0.1.3",
         "jquery": "^3.7.1",
         "ml-logistic-regression": "^2.0.0",
         "ml-matrix": "^6.12.1",

--- a/packages/puppeteer-crawler/package.json
+++ b/packages/puppeteer-crawler/package.json
@@ -55,7 +55,6 @@
         "@crawlee/utils": "workspace:*",
         "cheerio": "^1.0.0",
         "devtools-protocol": "*",
-        "idcac-playwright": "^0.2.0",
         "jquery": "^3.7.1",
         "ow": "^2.0.0",
         "tslib": "^2.8.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -781,8 +781,8 @@ importers:
         specifier: ^1.0.0
         version: 1.2.0
       idcac-playwright:
-        specifier: ^0.1.3
-        version: 0.1.3
+        specifier: ^0.2.0
+        version: 0.2.0
       jquery:
         specifier: ^3.7.1
         version: 3.7.1
@@ -7951,9 +7951,6 @@ packages:
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
-
-  idcac-playwright@0.1.3:
-    resolution: {integrity: sha512-VVYQ4sv6OrUJKVzYaIP1hq0qAHd1O22HW5LnL1Wf6zkrLStQ/QEg4iJ0rllIOEpd+Rmm+635AJD59A+Vw+2PgQ==}
 
   idcac-playwright@0.2.0:
     resolution: {integrity: sha512-qJH7vQgq3TKnhea/3Z3jlEJL7NC9vK9BkLClAzQHVRepBtq1fWfSI4fSuMKcPq7nDUTTlIEIS+vU+GRwwR1BXw==}
@@ -21220,8 +21217,6 @@ snapshots:
   icss-utils@5.1.0(postcss@8.5.9):
     dependencies:
       postcss: 8.5.9
-
-  idcac-playwright@0.1.3: {}
 
   idcac-playwright@0.2.0: {}
 

--- a/test/e2e/playwright-enqueue-links/actor/package.json
+++ b/test/e2e/playwright-enqueue-links/actor/package.json
@@ -13,6 +13,7 @@
         "@crawlee/types": "file:./packages/types",
         "@crawlee/utils": "file:./packages/utils",
         "deep-equal": "^2.0.5",
+        "idcac-playwright": "^0.2.0",
         "playwright": "1.58.2"
     },
     "overrides": {

--- a/test/e2e/puppeteer-enqueue-links/actor/package.json
+++ b/test/e2e/puppeteer-enqueue-links/actor/package.json
@@ -13,6 +13,7 @@
         "@crawlee/types": "file:./packages/types",
         "@crawlee/utils": "file:./packages/utils",
         "deep-equal": "^2.0.5",
+        "idcac-playwright": "^0.2.0",
         "puppeteer": "*"
     },
     "overrides": {


### PR DESCRIPTION
`closeCookieModals` loads `idcac-playwright` through a guarded dynamic import, and both crawler packages already declare it as an optional peer dependency — but it was also listed in `dependencies`, so it got installed for everyone anyway. The e2e actors that call `closeCookieModals` now depend on it explicitly.

`playwright-crawler` also had a `^0.1.3` dependency against a `^0.2.0` peer range.

related to #3259 