### PR TITLE
fix(browser-pool): make PlaywrightBrowser.browserType() return the browser type

### DIFF
--- a/packages/browser-pool/src/playwright/playwright-plugin.ts
+++ b/packages/browser-pool/src/playwright/playwright-plugin.ts
@@ -113,10 +113,12 @@ export class PlaywrightPlugin extends BrowserPlugin<
                     });
                 }
 
-                browser = new PlaywrightBrowserWithPersistentContext({
+                const persistentBrowser = new PlaywrightBrowserWithPersistentContext({
                     browserContext,
                     version: this._browserVersion,
-                }) as unknown as PlaywrightBrowser;
+                });
+                persistentBrowser._setBrowserType(this.library);
+                browser = persistentBrowser as unknown as PlaywrightBrowser;
             }
         } catch (error) {
             await close();

--- a/test/browser-pool/browser-plugins/plugins.test.ts
+++ b/test/browser-pool/browser-plugins/plugins.test.ts
@@ -626,6 +626,20 @@ describe('Plugins', () => {
                     expect(version1).toEqual(browser.version());
                 });
 
+                test('should return browser type', async () => {
+                    const plugin = new PlaywrightPlugin(playwright[browserName]);
+
+                    const launchContext = plugin.createLaunchContext({ useIncognitoPages: false });
+                    browser = await plugin.launch(launchContext);
+                    expect(browser.browserType()).toBe(playwright[browserName]);
+
+                    await browser.close();
+
+                    const launchContext2 = plugin.createLaunchContext({ useIncognitoPages: true });
+                    browser = await plugin.launch(launchContext2);
+                    expect(browser.browserType()).toBe(playwright[browserName]);
+                });
+
                 test('should return all contexts', async () => {
                     const plugin = new PlaywrightPlugin(playwright[browserName]);
 


### PR DESCRIPTION
`PlaywrightBrowser._setBrowserType()` has existed since the initial crawlee commit but was never called, so the `_browserType` field stayed `undefined` and `browserType()` returned `undefined` at runtime despite its non-optional `BrowserType` signature. Persistent contexts are the default (`useIncognitoPages: false`), so a call like `browser.browserType().name()` on the wrapper threw a `TypeError`. The incognito and remote-connection paths return the native Playwright `Browser` and were not affected.

This wires the existing setter in `PlaywrightPlugin._launch()` where the wrapper is created. `this.library` is the `BrowserType` that launched the context, so the wrapper now provides the consistent API with Playwright's `Browser` that its docblock describes. Also adds a test covering both the persistent-context wrapper and the native incognito browser.
