### PR TITLE
perf: lazy-load `file-type` and `csv-stringify`

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -88,7 +88,6 @@ import type {
     StorageBackend,
 } from '@crawlee/types';
 import { isAsyncIterable, isIterable, RobotsTxtFile, ROTATE_PROXY_ERRORS } from '@crawlee/utils';
-import { stringify } from 'csv-stringify/sync';
 import ow, { ArgumentError, type BasePredicate } from 'ow';
 import { getDomain } from 'tldts';
 import type { ReadonlyDeep, SetRequired } from 'type-fest';
@@ -2040,6 +2039,8 @@ export class BasicCrawler<
                 const keys = options?.collectAllKeys
                     ? Array.from(new Set(items.flatMap(Object.keys)))
                     : Object.keys(items[0]);
+
+                const { stringify } = await import('csv-stringify/sync');
 
                 value = stringify([
                     keys,

--- a/packages/core/src/storages/dataset.ts
+++ b/packages/core/src/storages/dataset.ts
@@ -1,5 +1,4 @@
 import type { Awaitable, DatasetBackend, DatasetInfo, Dictionary, PaginatedList } from '@crawlee/types';
-import { stringify } from 'csv-stringify/sync';
 import ow from 'ow';
 
 import { tryCancel } from '@apify/timeout';
@@ -409,6 +408,8 @@ export class Dataset<Data extends Dictionary = Dictionary> {
             const keys = options?.collectAllKeys
                 ? Array.from(new Set(items.flatMap(Object.keys)))
                 : Object.keys(items[0]);
+
+            const { stringify } = await import('csv-stringify/sync');
 
             const value = stringify([
                 keys,

--- a/packages/utils/src/internals/sitemap.ts
+++ b/packages/utils/src/internals/sitemap.ts
@@ -6,7 +6,6 @@ import { createGunzip } from 'node:zlib';
 
 import { FetchHttpClient } from '@crawlee/http-client';
 import type { BaseHttpClient, CrawleeLogger } from '@crawlee/types';
-import { fileTypeStream } from 'file-type';
 import sax from 'sax';
 import MIMEType from 'whatwg-mimetype';
 
@@ -297,6 +296,7 @@ export async function* parseSitemap<T extends ParseSitemapOptions>(
                         if (sitemapResponse.body === null) {
                             break;
                         }
+                        const { fileTypeStream } = await import('file-type');
                         const streamWithType = await fileTypeStream(Readable.fromWeb(sitemapResponse.body as any));
                         if (streamWithType.fileType !== undefined) {
                             contentType = streamWithType.fileType.mime;


### PR DESCRIPTION
Both are only used on specific code paths (sitemap parsing, CSV export) but were loaded eagerly by every crawler import, costing ~110ms of the ~500ms `import('@crawlee/http')` on my machine.

Related: #3549