### PR TITLE
docs(contributing): fix jest reference in vitest mock example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ vitest.mock('node:os', async (importActual) => {
     return {
         ...original,
         platform: () => 'darwin',
-        freemem: jest.fn(),
+        freemem: vitest.fn(),
     };
 });
 ```


### PR DESCRIPTION
The "Now (vitest)" example under "Mocking modules" uses `jest.fn()` instead of `vitest.fn()` when mocking `os.freemem`. This is leftover from the Jest to vitest migration.

`vitest.config.mts` sets `test.globals: true` with no jest alias, so copying this example as written would throw "ReferenceError: jest is not defined" in a real test file. Every other example in the same guide correctly uses `vitest.fn()`.