### PR TITLE
perf(utils): lazily import sax

### DIFF
--- a/packages/utils/src/internals/sitemap.ts
+++ b/packages/utils/src/internals/sitemap.ts
@@ -6,7 +6,8 @@ import { createGunzip } from 'node:zlib';
 
 import { FetchHttpClient } from '@crawlee/http-client';
 import type { BaseHttpClient, CrawleeLogger } from '@crawlee/types';
-import sax from 'sax';
+// Imported as a type only so `sax` (a fairly heavy parser) isn't loaded eagerly with @crawlee/utils.
+import type * as sax from 'sax';
 import MIMEType from 'whatwg-mimetype';
 
 import { mergeAsyncIterables } from './iterables.js';
@@ -77,13 +78,18 @@ class SitemapTxtParser extends Transform {
 
 class SitemapXmlParser extends Transform {
     #decoder: StringDecoder = new StringDecoder('utf8');
-    #parser = new sax.SAXParser(true);
+    #parser: sax.SAXParser;
 
     #rootTagName?: 'sitemapindex' | 'urlset';
     #currentTag?: 'loc' | 'lastmod' | 'changefreq' | 'priority' = undefined;
     #url: Partial<SitemapUrl> = {};
 
-    constructor() {
+    static async create(): Promise<SitemapXmlParser> {
+        const { SAXParser } = await import('sax');
+        return new SitemapXmlParser(new SAXParser(true));
+    }
+
+    private constructor(parser: sax.SAXParser) {
         super({
             readableObjectMode: true,
             transform: (chunk, _encoding, callback) => {
@@ -101,6 +107,7 @@ class SitemapXmlParser extends Transform {
             },
         });
 
+        this.#parser = parser;
         this.#parser.onopentag = this.onOpenTag.bind(this);
         this.#parser.onclosetag = this.onCloseTag.bind(this);
 
@@ -233,7 +240,7 @@ export async function* parseSitemap<T extends ParseSitemapOptions>(
     const sources = [...initialSources];
     const visitedSitemapUrls = new Set<string>();
 
-    const createParser = (contentType = '', url?: URL): Duplex => {
+    const createParser = async (contentType = '', url?: URL): Promise<Duplex> => {
         let mimeType: MIMEType | null;
 
         try {
@@ -243,7 +250,7 @@ export async function* parseSitemap<T extends ParseSitemapOptions>(
         }
 
         if (mimeType?.isXML() || url?.pathname.endsWith('.xml')) {
-            return new SitemapXmlParser();
+            return SitemapXmlParser.create();
         }
 
         if (mimeType?.essence === 'text/plain' || url?.pathname.endsWith('.txt')) {
@@ -319,7 +326,7 @@ export async function* parseSitemap<T extends ParseSitemapOptions>(
                         items = pipeline(
                             streamWithType,
                             isGzipped ? createGunzip() : new PassThrough(),
-                            createParser(contentType ?? undefined, sitemapUrl),
+                            await createParser(contentType ?? undefined, sitemapUrl),
                             (e) => {
                                 if (e !== undefined && e !== null) {
                                     error = { type: 'parser', error: e };
@@ -350,7 +357,7 @@ export async function* parseSitemap<T extends ParseSitemapOptions>(
                 }
             }
         } else if (source.type === 'raw') {
-            items = pipeline(Readable.from([source.content]), createParser('text/xml'), (error) => {
+            items = pipeline(Readable.from([source.content]), await createParser('text/xml'), (error) => {
                 if (error !== undefined) {
                     logger?.warning(`Malformed sitemap content: ${error}`);
                 }


### PR DESCRIPTION
Relates to #3549. `sax` was imported eagerly at module scope in `packages/utils/src/internals/sitemap.ts`, so every consumer of `@crawlee/utils` paid its load cost even if sitemap parsing was never used. 

`sax.SAXParser` is now loaded via a dynamic `import()` only when an XML sitemap parser is actually constructed.

No public API changes (this class is only used from the `parseSitemap` generator).