### PR TITLE
chore: fix CI failures caused by lockfile maintenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,8 @@
         "playwright-core": "1.62.1",
         "form-data": "^4.0.6",
         "tar": "^7.5.16",
-        "lerna/js-yaml": "^4.2.0"
+        "lerna/js-yaml": "^4.2.0",
+        "node-gyp": "^12.1.0"
     },
     "packageManager": "yarn@4.10.3",
     "volta": {

--- a/test/browser-pool/anonymize-proxy-sugar.test.ts
+++ b/test/browser-pool/anonymize-proxy-sugar.test.ts
@@ -20,12 +20,15 @@ describe('anonymizeProxySugar', () => {
         ['http://username:password@proxy:1000/', 'http://username:password@proxy:1000'],
         ['socks://username:password@proxy:1000', 'socks://username:password@proxy:1000'],
         ['socks://username:password@proxy:1000/', 'socks://username:password@proxy:1000'],
-    ])('should call anonymizeProxy from proxy-chain with correctly pre-processed URL: %s', async (input, expectedOutput) => {
-        const [anonymized] = await anonymizeProxySugar(input);
+    ])(
+        'should call anonymizeProxy from proxy-chain with correctly pre-processed URL: %s',
+        async (input, expectedOutput) => {
+            const [anonymized] = await anonymizeProxySugar(input);
 
-        expect(anonymizeProxy).toHaveBeenCalledWith(expect.objectContaining({ url: expectedOutput }));
-        expect(anonymized).toBeTypeOf('string');
-    });
+            expect(anonymizeProxy).toHaveBeenCalledWith(expect.objectContaining({ url: expectedOutput }));
+            expect(anonymized).toBeTypeOf('string');
+        },
+    );
 
     test('should pass ignoreProxyCertificate to anonymizeProxy', async () => {
         await anonymizeProxySugar('http://username:password@proxy:1000', undefined, undefined, {

--- a/test/core/autoscaling/snapshotter.test.ts
+++ b/test/core/autoscaling/snapshotter.test.ts
@@ -351,60 +351,62 @@ describe('Snapshotter', () => {
         expect(diffWithin).toBeLessThan(SAMPLE_SIZE_MILLIS);
     });
 
-    test.each([
-        true,
-        false,
-    ])('correctly handles dynamic vs static memory limit when total memory changes (dynamic=%s)', async (dynamic) => {
-        /**
-         * Two memory snapshots are emitted with the same process memory usage but different total memory.
-         * First snapshot is overloaded in both modes. Using 60% of total memory, while the limit is 50% in both modes.
-         * Second snapshot doubles the total memory while keeping the same usage:
-         * - Dynamic mode (availableMemoryRatio): maxMemoryBytes should update → not overloaded
-         * - Static mode (memoryMbytes): maxMemoryBytes stays fixed → still overloaded
-         */
-        const initialTotalBytes = toBytes(100);
-        const allowedMemoryUsageRatio = 0.5;
-        const actualMemoryUsage = 0.6 * initialTotalBytes;
+    test.each([true, false])(
+        'correctly handles dynamic vs static memory limit when total memory changes (dynamic=%s)',
+        async (dynamic) => {
+            /**
+             * Two memory snapshots are emitted with the same process memory usage but different total memory.
+             * First snapshot is overloaded in both modes. Using 60% of total memory, while the limit is 50% in both modes.
+             * Second snapshot doubles the total memory while keeping the same usage:
+             * - Dynamic mode (availableMemoryRatio): maxMemoryBytes should update → not overloaded
+             * - Static mode (memoryMbytes): maxMemoryBytes stays fixed → still overloaded
+             */
+            const initialTotalBytes = toBytes(100);
+            const allowedMemoryUsageRatio = 0.5;
+            const actualMemoryUsage = 0.6 * initialTotalBytes;
 
-        // Initial snapshot. Overloaded in both modes.
-        const memoryData: MemoryInfo = {
-            totalBytes: initialTotalBytes,
-            freeBytes: initialTotalBytes - actualMemoryUsage,
-            usedBytes: actualMemoryUsage,
-            mainProcessBytes: actualMemoryUsage,
-            childProcessesBytes: 0,
-        };
+            // Initial snapshot. Overloaded in both modes.
+            const memoryData: MemoryInfo = {
+                totalBytes: initialTotalBytes,
+                freeBytes: initialTotalBytes - actualMemoryUsage,
+                usedBytes: actualMemoryUsage,
+                mainProcessBytes: actualMemoryUsage,
+                childProcessesBytes: 0,
+            };
 
-        // Mock memory info to be able to inject custom memory measurement data.
-        vitest.spyOn(LocalEventManager.prototype as any, 'getMemoryInfo').mockResolvedValue(memoryData);
+            // Mock memory info to be able to inject custom memory measurement data.
+            vitest.spyOn(LocalEventManager.prototype as any, 'getMemoryInfo').mockResolvedValue(memoryData);
 
-        let config: Configuration;
-        if (dynamic) {
-            // Dynamic: Allow usage of 50 % of available memory through ratio
-            config = new Configuration({ availableMemoryRatio: allowedMemoryUsageRatio });
-        } else {
-            // Static: Allow usage of 50 % of available memory through fixed value
-            config = new Configuration({ memoryMbytes: (allowedMemoryUsageRatio * initialTotalBytes) / 1024 / 1024 });
-        }
+            let config: Configuration;
+            if (dynamic) {
+                // Dynamic: Allow usage of 50 % of available memory through ratio
+                config = new Configuration({ availableMemoryRatio: allowedMemoryUsageRatio });
+            } else {
+                // Static: Allow usage of 50 % of available memory through fixed value
+                config = new Configuration({
+                    memoryMbytes: (allowedMemoryUsageRatio * initialTotalBytes) / 1024 / 1024,
+                });
+            }
 
-        const snapshotter = new Snapshotter({ config });
-        vitest.spyOn(LocalEventManager.prototype, 'init').mockImplementation(async () => {});
-        const eventManager = config.getEventManager() as LocalEventManager;
-        await snapshotter.start();
+            const snapshotter = new Snapshotter({ config });
+            vitest.spyOn(LocalEventManager.prototype, 'init').mockImplementation(async () => {});
+            const eventManager = config.getEventManager() as LocalEventManager;
+            await snapshotter.start();
 
-        // First snapshot - full usage of the memory, should be overloaded in both modes
-        await eventManager.emitSystemInfoEvent(noop);
+            // First snapshot - full usage of the memory, should be overloaded in both modes
+            await eventManager.emitSystemInfoEvent(noop);
 
-        // Second snapshot - total memory doubled, should be overloaded only in static mode
-        memoryData.totalBytes = initialTotalBytes * 2;
-        memoryData.freeBytes = memoryData.totalBytes - actualMemoryUsage;
-        await eventManager.emitSystemInfoEvent(noop);
+            // Second snapshot - total memory doubled, should be overloaded only in static mode
+            memoryData.totalBytes = initialTotalBytes * 2;
+            memoryData.freeBytes = memoryData.totalBytes - actualMemoryUsage;
+            await eventManager.emitSystemInfoEvent(noop);
 
-        const memorySnapshots = snapshotter.getMemorySample();
-        expect(memorySnapshots).toHaveLength(2);
-        expect(memorySnapshots[0].isOverloaded).toBe(true);
-        expect(memorySnapshots[1].isOverloaded).toBe(!dynamic);
+            const memorySnapshots = snapshotter.getMemorySample();
+            expect(memorySnapshots).toHaveLength(2);
+            expect(memorySnapshots[0].isOverloaded).toBe(true);
+            expect(memorySnapshots[1].isOverloaded).toBe(!dynamic);
 
-        await snapshotter.stop();
-    });
+            await snapshotter.stop();
+        },
+    );
 });

--- a/test/core/crawlers/adaptive_playwright_crawler.test.ts
+++ b/test/core/crawlers/adaptive_playwright_crawler.test.ts
@@ -302,34 +302,34 @@ describe('AdaptivePlaywrightCrawler', () => {
         });
     });
 
-    test.each([
-        ['static'],
-        ['clientOnly'],
-    ] as const)('crawlingContext.addRequests() should add requests correctly (%s)', async (renderingType) => {
-        const renderingTypePredictor = makeRiggedRenderingTypePredictor({
-            detectionProbabilityRecommendation: 0,
-            renderingType,
-        });
-        const url = new URL(`http://${HOSTNAME}:${port}`).toString();
+    test.each([['static'], ['clientOnly']] as const)(
+        'crawlingContext.addRequests() should add requests correctly (%s)',
+        async (renderingType) => {
+            const renderingTypePredictor = makeRiggedRenderingTypePredictor({
+                detectionProbabilityRecommendation: 0,
+                renderingType,
+            });
+            const url = new URL(`http://${HOSTNAME}:${port}`).toString();
 
-        let requestContext: LoadedContext<AdaptivePlaywrightCrawlerContext> | undefined;
-        const requestHandler: AdaptivePlaywrightCrawlerOptions['requestHandler'] = async (context) => {
-            const isStartUrl = context.request.url === url;
+            let requestContext: LoadedContext<AdaptivePlaywrightCrawlerContext> | undefined;
+            const requestHandler: AdaptivePlaywrightCrawlerOptions['requestHandler'] = async (context) => {
+                const isStartUrl = context.request.url === url;
 
-            if (isStartUrl) await context.addRequests([`${url}/1`]);
-            else requestContext = context;
-        };
+                if (isStartUrl) await context.addRequests([`${url}/1`]);
+                else requestContext = context;
+            };
 
-        const crawler = await makeOneshotCrawler(
-            { requestHandler, renderingTypePredictor, maxRequestsPerCrawl: 10 },
-            [],
-        );
+            const crawler = await makeOneshotCrawler(
+                { requestHandler, renderingTypePredictor, maxRequestsPerCrawl: 10 },
+                [],
+            );
 
-        await crawler.run([{ url, crawlDepth: 2 }]);
+            await crawler.run([{ url, crawlDepth: 2 }]);
 
-        assert(requestContext);
-        expect(requestContext.request).toMatchObject({ url: `${url}/1`, crawlDepth: 3 });
-    });
+            assert(requestContext);
+            expect(requestContext.request).toMatchObject({ url: `${url}/1`, crawlDepth: 3 });
+        },
+    );
 
     describe('should enqueue links correctly', () => {
         test.each([
@@ -383,49 +383,49 @@ describe('AdaptivePlaywrightCrawler', () => {
         });
     });
 
-    test.each([
-        ['static'],
-        ['clientOnly'],
-    ] as const)('should respect the strategy option for enqueueLinks (%s)', async (renderingType) => {
-        const renderingTypePredictor = makeRiggedRenderingTypePredictor({
-            detectionProbabilityRecommendation: 0,
-            renderingType,
-        });
-        const url = new URL(`http://${HOSTNAME}:${port}/external-links`);
-        const enqueuedUrls = new Set<string>();
-        const visitedUrls = new Set<string>();
+    test.each([['static'], ['clientOnly']] as const)(
+        'should respect the strategy option for enqueueLinks (%s)',
+        async (renderingType) => {
+            const renderingTypePredictor = makeRiggedRenderingTypePredictor({
+                detectionProbabilityRecommendation: 0,
+                renderingType,
+            });
+            const url = new URL(`http://${HOSTNAME}:${port}/external-links`);
+            const enqueuedUrls = new Set<string>();
+            const visitedUrls = new Set<string>();
 
-        const requestHandler: AdaptivePlaywrightCrawlerOptions['requestHandler'] = vi.fn(
-            async ({ enqueueLinks, request }) => {
-                visitedUrls.add(request.loadedUrl);
+            const requestHandler: AdaptivePlaywrightCrawlerOptions['requestHandler'] = vi.fn(
+                async ({ enqueueLinks, request }) => {
+                    visitedUrls.add(request.loadedUrl);
 
-                if (!request.label) {
-                    const result = await enqueueLinks({
-                        label: 'enqueued-url',
-                        strategy: 'same-hostname',
-                    });
+                    if (!request.label) {
+                        const result = await enqueueLinks({
+                            label: 'enqueued-url',
+                            strategy: 'same-hostname',
+                        });
 
-                    for (const processedRequest of result.processedRequests) {
-                        enqueuedUrls.add(processedRequest.uniqueKey);
+                        for (const processedRequest of result.processedRequests) {
+                            enqueuedUrls.add(processedRequest.uniqueKey);
+                        }
                     }
-                }
-            },
-        );
+                },
+            );
 
-        const crawler = await makeOneshotCrawler(
-            {
-                requestHandler,
-                renderingTypePredictor,
-                maxRequestsPerCrawl: 10,
-            },
-            [url.toString()],
-        );
+            const crawler = await makeOneshotCrawler(
+                {
+                    requestHandler,
+                    renderingTypePredictor,
+                    maxRequestsPerCrawl: 10,
+                },
+                [url.toString()],
+            );
 
-        await crawler.run();
+            await crawler.run();
 
-        expect(new Set(visitedUrls)).toEqual(new Set([`http://${HOSTNAME}:${port}/external-links`]));
-        expect(new Set(enqueuedUrls)).toEqual(new Set([`http://${HOSTNAME}:${port}/external-redirect`]));
-    });
+            expect(new Set(visitedUrls)).toEqual(new Set([`http://${HOSTNAME}:${port}/external-links`]));
+            expect(new Set(enqueuedUrls)).toEqual(new Set([`http://${HOSTNAME}:${port}/external-redirect`]));
+        },
+    );
 
     test('should persist crawler state', async () => {
         const renderingTypePredictor = makeRiggedRenderingTypePredictor({

--- a/test/core/crawlers/basic_crawler.test.ts
+++ b/test/core/crawlers/basic_crawler.test.ts
@@ -308,24 +308,23 @@ describe('BasicCrawler', () => {
             expect(requests[0]).toMatchObject({ url: 'https://example.com/1/', crawlDepth: 3 });
         });
 
-        it.each([
-            null,
-            undefined,
-            false,
-        ] as const)('should skip requests when transformRequestFunction returns %s', async (returnValue) => {
-            const transformRequestFunction = vi.fn(() => returnValue);
-            const optionsWithTransform = { ...options, transformRequestFunction };
+        it.each([null, undefined, false] as const)(
+            'should skip requests when transformRequestFunction returns %s',
+            async (returnValue) => {
+                const transformRequestFunction = vi.fn(() => returnValue);
+                const optionsWithTransform = { ...options, transformRequestFunction };
 
-            await crawler.exposedEnqueueLinksWithCrawlDepth(optionsWithTransform, request, requestQueue);
+                await crawler.exposedEnqueueLinksWithCrawlDepth(optionsWithTransform, request, requestQueue);
 
-            const requests = addRequestsBatchedMock.mock.calls[0][0];
-            expect(requests).toHaveLength(0);
+                const requests = addRequestsBatchedMock.mock.calls[0][0];
+                expect(requests).toHaveLength(0);
 
-            const skippedRequests = onSkippedRequestMock.mock.calls.map((call) => call[0]);
-            expect(skippedRequests).toHaveLength(2);
-            expect(skippedRequests[0]).toStrictEqual({ url: 'https://example.com/1/', reason: 'filters' });
-            expect(skippedRequests[1]).toStrictEqual({ url: 'https://example.com/2/', reason: 'filters' });
-        });
+                const skippedRequests = onSkippedRequestMock.mock.calls.map((call) => call[0]);
+                expect(skippedRequests).toHaveLength(2);
+                expect(skippedRequests[0]).toStrictEqual({ url: 'https://example.com/1/', reason: 'filters' });
+                expect(skippedRequests[1]).toStrictEqual({ url: 'https://example.com/2/', reason: 'filters' });
+            },
+        );
     });
 
     it('addCrawlDepthRequestGenerator() should generate requests with maxCrawlDepth', async () => {
@@ -441,61 +440,61 @@ describe('BasicCrawler', () => {
         expect(await requestList.isEmpty()).toBe(true);
     });
 
-    test.each([
-        EventType.MIGRATING,
-        EventType.ABORTING,
-    ])('should pause on %s event and persist RequestList state', async (event) => {
-        const sources = [...Array(500).keys()].map((index) => ({ url: `https://example.com/${index + 1}` }));
+    test.each([EventType.MIGRATING, EventType.ABORTING])(
+        'should pause on %s event and persist RequestList state',
+        async (event) => {
+            const sources = [...Array(500).keys()].map((index) => ({ url: `https://example.com/${index + 1}` }));
 
-        let persistResolve!: (value?: unknown) => void;
-        const persistPromise = new Promise((res) => {
-            persistResolve = res;
-        });
+            let persistResolve!: (value?: unknown) => void;
+            const persistPromise = new Promise((res) => {
+                persistResolve = res;
+            });
 
-        // Mock the calls to persist sources.
-        const getValueSpy = vitest.spyOn(KeyValueStore.prototype, 'getValue');
-        const setValueSpy = vitest.spyOn(KeyValueStore.prototype, 'setValue');
-        getValueSpy.mockResolvedValue(null);
+            // Mock the calls to persist sources.
+            const getValueSpy = vitest.spyOn(KeyValueStore.prototype, 'getValue');
+            const setValueSpy = vitest.spyOn(KeyValueStore.prototype, 'setValue');
+            getValueSpy.mockResolvedValue(null);
 
-        const processed: { url: string }[] = [];
-        const requestList = await RequestList.open('reqList', sources);
-        const requestHandler: RequestHandler = async ({ request }) => {
-            if (request.url.endsWith('200')) events.emit(event);
-            processed.push({ url: request.url });
-        };
+            const processed: { url: string }[] = [];
+            const requestList = await RequestList.open('reqList', sources);
+            const requestHandler: RequestHandler = async ({ request }) => {
+                if (request.url.endsWith('200')) events.emit(event);
+                processed.push({ url: request.url });
+            };
 
-        const basicCrawler = new BasicCrawler({
-            requestList,
-            minConcurrency: 25,
-            maxConcurrency: 25,
-            requestHandler,
-        });
+            const basicCrawler = new BasicCrawler({
+                requestList,
+                minConcurrency: 25,
+                maxConcurrency: 25,
+                requestHandler,
+            });
 
-        let finished = false;
-        // Mock the call to persist state.
-        setValueSpy.mockImplementationOnce(persistResolve as any);
-        // The crawler will pause after 200 requests
-        const runPromise = basicCrawler.run();
-        void runPromise.then(() => {
-            finished = true;
-        });
+            let finished = false;
+            // Mock the call to persist state.
+            setValueSpy.mockImplementationOnce(persistResolve as any);
+            // The crawler will pause after 200 requests
+            const runPromise = basicCrawler.run();
+            void runPromise.then(() => {
+                finished = true;
+            });
 
-        // need to monkeypatch the stats class, otherwise it will never finish
-        basicCrawler.stats.persistState = async () => Promise.resolve();
-        await persistPromise;
+            // need to monkeypatch the stats class, otherwise it will never finish
+            basicCrawler.stats.persistState = async () => Promise.resolve();
+            await persistPromise;
 
-        expect(finished).toBe(false);
-        expect(await requestList.isFinished()).toBe(false);
-        expect(await requestList.isEmpty()).toBe(false);
-        expect(processed.length).toBe(200);
+            expect(finished).toBe(false);
+            expect(await requestList.isFinished()).toBe(false);
+            expect(await requestList.isEmpty()).toBe(false);
+            expect(processed.length).toBe(200);
 
-        expect(getValueSpy).toBeCalled();
-        expect(setValueSpy).toBeCalled();
+            expect(getValueSpy).toBeCalled();
+            expect(setValueSpy).toBeCalled();
 
-        // clean up
-        // @ts-expect-error Accessing private method
-        await basicCrawler.autoscaledPool!._destroy();
-    });
+            // clean up
+            // @ts-expect-error Accessing private method
+            await basicCrawler.autoscaledPool!._destroy();
+        },
+    );
 
     test('should retry failed requests', async () => {
         const sources = [

--- a/test/core/crawlers/playwright_crawler.test.ts
+++ b/test/core/crawlers/playwright_crawler.test.ts
@@ -209,49 +209,49 @@ describe('PlaywrightCrawler', () => {
         expect(Object.keys(options.browserPoolOptions).length).toBe(0);
     });
 
-    test.each([
-        { useIncognitoPages: true },
-        { useIncognitoPages: false },
-    ])('should apply launchOptions with useIncognitoPages: $useIncognitoPages', async ({ useIncognitoPages }) => {
-        // Some launch options apply to the browser, while some apply to the context.
-        // Here we use some context options to verify that those are actually applied.
-        const launchOptions = {
-            locale: 'cz-CZ',
-            reducedMotion: 'reduce' as const,
-            timezoneId: 'Pacific/Tahiti',
-        };
+    test.each([{ useIncognitoPages: true }, { useIncognitoPages: false }])(
+        'should apply launchOptions with useIncognitoPages: $useIncognitoPages',
+        async ({ useIncognitoPages }) => {
+            // Some launch options apply to the browser, while some apply to the context.
+            // Here we use some context options to verify that those are actually applied.
+            const launchOptions = {
+                locale: 'cz-CZ',
+                reducedMotion: 'reduce' as const,
+                timezoneId: 'Pacific/Tahiti',
+            };
 
-        let [timezone, locale, reducedMotion] = ['', '', ''];
+            let [timezone, locale, reducedMotion] = ['', '', ''];
 
-        const playwrightCrawler = new PlaywrightCrawler({
-            maxConcurrency: 1,
-            launchContext: {
-                useIncognitoPages,
-                launchOptions,
-            },
-            browserPoolOptions: {
-                // don't overwrite locale with fingerprint's locale
-                useFingerprints: false,
-            },
-            requestHandler: async ({ page }) => {
-                [timezone, locale, reducedMotion] = await Promise.all([
-                    page.evaluate(() => Intl.DateTimeFormat().resolvedOptions().timeZone),
-                    page.evaluate(() => navigator.language),
-                    page.evaluate(() => {
-                        return window.matchMedia('(prefers-reduced-motion: reduce)').matches
-                            ? 'reduce'
-                            : 'no-preference';
-                    }),
-                ]);
-            },
-        });
+            const playwrightCrawler = new PlaywrightCrawler({
+                maxConcurrency: 1,
+                launchContext: {
+                    useIncognitoPages,
+                    launchOptions,
+                },
+                browserPoolOptions: {
+                    // don't overwrite locale with fingerprint's locale
+                    useFingerprints: false,
+                },
+                requestHandler: async ({ page }) => {
+                    [timezone, locale, reducedMotion] = await Promise.all([
+                        page.evaluate(() => Intl.DateTimeFormat().resolvedOptions().timeZone),
+                        page.evaluate(() => navigator.language),
+                        page.evaluate(() => {
+                            return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+                                ? 'reduce'
+                                : 'no-preference';
+                        }),
+                    ]);
+                },
+            });
 
-        await playwrightCrawler.run([`http://${HOSTNAME}:${port}/`]);
+            await playwrightCrawler.run([`http://${HOSTNAME}:${port}/`]);
 
-        expect(timezone).toBe(launchOptions.timezoneId);
-        expect(locale).toBe(launchOptions.locale);
-        expect(reducedMotion).toBe(launchOptions.reducedMotion);
-    });
+            expect(timezone).toBe(launchOptions.timezoneId);
+            expect(locale).toBe(launchOptions.locale);
+            expect(reducedMotion).toBe(launchOptions.reducedMotion);
+        },
+    );
 
     test('exposes triggered downloads via listDownloads()', async () => {
         let countBefore = -1;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3808,13 +3808,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"abbrev@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "abbrev@npm:5.0.0"
-  checksum: 10c0/8e88f5c798ea4562d28c5a3e9ad69e3879890bc5d695d8f2dffb8609be4c890aacc8f80ef4553fdd2c6a62d70c2ce8bc57b38074e383beb7487bdafa9ed42ea5
-  languageName: node
-  linkType: hard
-
 "abort-controller@npm:^3.0.0":
   version: 3.0.0
   resolution: "abort-controller@npm:3.0.0"
@@ -10017,41 +10010,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-gyp@npm:latest":
-  version: 13.0.1
-  resolution: "node-gyp@npm:13.0.1"
-  dependencies:
-    env-paths: "npm:^2.2.0"
-    exponential-backoff: "npm:^3.1.1"
-    graceful-fs: "npm:^4.2.6"
-    nopt: "npm:^10.0.0"
-    proc-log: "npm:^7.0.0"
-    semver: "npm:^7.3.5"
-    tar: "npm:^7.5.4"
-    tinyglobby: "npm:^0.2.12"
-    undici: "npm:^8.4.1"
-    which: "npm:^7.0.0"
-  bin:
-    node-gyp: bin/node-gyp.js
-  checksum: 10c0/424077bc9e9bbe953a8e86db473ba818cbc6a121714008c977fd589e21e5f0c811fbf22faac730dc7182450b5e52df301811d01ae3373898658d999b7710f4e6
-  languageName: node
-  linkType: hard
-
 "node-releases@npm:^2.0.53":
   version: 2.0.53
   resolution: "node-releases@npm:2.0.53"
   checksum: 10c0/db9fb29b21ec12e223ead8bd9406100ff14fce01678a9a4865e288098456b84869431421a739f216aa520b6f57d9425f6537662501ae8a2d9e1771bfa87751bc
-  languageName: node
-  linkType: hard
-
-"nopt@npm:^10.0.0":
-  version: 10.0.1
-  resolution: "nopt@npm:10.0.1"
-  dependencies:
-    abbrev: "npm:^5.0.0"
-  bin:
-    nopt: bin/nopt.js
-  checksum: 10c0/980d89257f9587f3e1f77877ddbf905d6aa3b738ec33e49a4fa1a059a0dd82eb28063982b150654a7ae9de386f2ead60e56172db7d37cf56de545f7392a2a26a
   languageName: node
   linkType: hard
 
@@ -11253,13 +11215,6 @@ __metadata:
   version: 6.1.0
   resolution: "proc-log@npm:6.1.0"
   checksum: 10c0/4f178d4062733ead9d71a9b1ab24ebcecdfe2250916a5b1555f04fe2eda972a0ec76fbaa8df1ad9c02707add6749219d118a4fc46dc56bdfe4dde4b47d80bb82
-  languageName: node
-  linkType: hard
-
-"proc-log@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "proc-log@npm:7.0.0"
-  checksum: 10c0/b89c2d862604f35fec795477b0c7e376feab3ba0d4f4d291c4e959567442697cf451ac557d0623c1cc38af45a78128b983410f397a10c5d3a67f76c33de4754b
   languageName: node
   linkType: hard
 
@@ -13189,13 +13144,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^8.4.1":
-  version: 8.10.0
-  resolution: "undici@npm:8.10.0"
-  checksum: 10c0/37ae2b1db8f65c3a003504e2040e96887b99f9db16ba07dcf49c37ed8b7f8c72f4452f2d46f52f7c9e49518fe8325e3b5e7e02ac3a2424886bd67d4b62a0ecab
-  languageName: node
-  linkType: hard
-
 "unicorn-magic@npm:^0.3.0":
   version: 0.3.0
   resolution: "unicorn-magic@npm:0.3.0"
@@ -13656,17 +13604,6 @@ __metadata:
   bin:
     node-which: bin/which.js
   checksum: 10c0/7e710e54ea36d2d6183bee2f9caa27a3b47b9baf8dee55a199b736fcf85eab3b9df7556fca3d02b50af7f3dfba5ea3a45644189836df06267df457e354da66d5
-  languageName: node
-  linkType: hard
-
-"which@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "which@npm:7.0.0"
-  dependencies:
-    isexe: "npm:^4.0.0"
-  bin:
-    node-which: bin/which.js
-  checksum: 10c0/ca0b54f198f78bbc4b7c02e34bda8d335cb352e0adb4cbca1c37b1a957af3a879a82c4c27ca6525bc942f548d8b64f816ef6528360af9f3de55ffb9b979b620d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The lockfile maintenance in #3821 broke master CI in two ways:

- The Biome bump changed how a few constructs get formatted, so `yarn format:check` fails on 5 test files. Reformatted them.
- Yarn's injected `node-gyp@latest` re-resolved to v13, which only supports Node 22+ and pulls in undici 8 (needs Node >= 22.19). On the Node 20 job, native builds like `better-sqlite3` now die during `yarn install` with `webidl.util.markAsUncloneable is not a function`. Pinned `node-gyp` to `^12.1.0` via resolutions, which also brings back undici 6.
