### PR TITLE
chore: convert const enums to regular enums

### DIFF
--- a/docs/public-api/crawlee-browser-pool.api.md
+++ b/docs/public-api/crawlee-browser-pool.api.md
@@ -32,13 +32,13 @@ export interface AnonymizeProxySugarOptions {
 }
 
 // @public (undocumented)
-export const enum BROWSER_CONTROLLER_EVENTS {
+export enum BROWSER_CONTROLLER_EVENTS {
     // (undocumented)
     BROWSER_CLOSED = "browserClosed"
 }
 
 // @public (undocumented)
-export const enum BROWSER_POOL_EVENTS {
+export enum BROWSER_POOL_EVENTS {
     // (undocumented)
     BROWSER_CLOSED = "browserClosed",
     // (undocumented)
@@ -336,7 +336,7 @@ export interface CreateLaunchContextOptions<Library extends CommonLibrary, Libra
 export const DEFAULT_USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36";
 
 // @public (undocumented)
-export const enum DeviceCategory {
+export enum DeviceCategory {
     desktop = "desktop",
     mobile = "mobile"
 }
@@ -438,7 +438,7 @@ export interface LaunchContextOptions<Library extends CommonLibrary = CommonLibr
 export { NewPageOptions }
 
 // @public (undocumented)
-export const enum OperatingSystemsName {
+export enum OperatingSystemsName {
     android = "android",
     ios = "ios",
     // (undocumented)

--- a/docs/public-api/crawlee-core.api.md
+++ b/docs/public-api/crawlee-core.api.md
@@ -704,7 +704,7 @@ export interface EventStatusMessageData {
 }
 
 // @public (undocumented)
-export const enum EventType {
+export enum EventType {
     // (undocumented)
     ABORTING = "aborting",
     // (undocumented)

--- a/packages/browser-pool/src/events.ts
+++ b/packages/browser-pool/src/events.ts
@@ -1,4 +1,4 @@
-export const enum BROWSER_POOL_EVENTS {
+export enum BROWSER_POOL_EVENTS {
     BROWSER_LAUNCHED = 'browserLaunched',
     BROWSER_RETIRED = 'browserRetired',
     BROWSER_CLOSED = 'browserClosed',
@@ -7,6 +7,6 @@ export const enum BROWSER_POOL_EVENTS {
     PAGE_CLOSED = 'pageClosed',
 }
 
-export const enum BROWSER_CONTROLLER_EVENTS {
+export enum BROWSER_CONTROLLER_EVENTS {
     BROWSER_CLOSED = 'browserClosed',
 }

--- a/packages/browser-pool/src/fingerprinting/types.ts
+++ b/packages/browser-pool/src/fingerprinting/types.ts
@@ -46,7 +46,7 @@ export interface BrowserSpecification {
     httpVersion?: HttpVersion;
 }
 
-export const enum OperatingSystemsName {
+export enum OperatingSystemsName {
     linux = 'linux',
     macos = 'macos',
     windows = 'windows',
@@ -60,7 +60,7 @@ export const enum OperatingSystemsName {
     ios = 'ios',
 }
 
-export const enum DeviceCategory {
+export enum DeviceCategory {
     /**
      * Describes mobile devices (mobile phones, tablets...). These devices usually have smaller, vertical screens and load lighter versions of websites.
      * > Note: Generating `android` and `ios` devices will not work without setting the device to `mobile` first.

--- a/packages/core/src/events/event_manager.ts
+++ b/packages/core/src/events/event_manager.ts
@@ -10,7 +10,7 @@ export interface EventManagerOptions {
     persistStateIntervalMillis: number;
 }
 
-export const enum EventType {
+export enum EventType {
     PERSIST_STATE = 'persistState',
     SYSTEM_INFO = 'systemInfo',
     MIGRATING = 'migrating',


### PR DESCRIPTION
Converts all `const enum` declarations (`EventType`, `BROWSER_POOL_EVENTS`, `BROWSER_CONTROLLER_EVENTS`, `OperatingSystemsName`, `DeviceCategory`) to regular enums. `const enum` breaks downstream consumers using `isolatedModules` or transpilers that don't inline them (Babel, esbuild, vitest).

Closes #3125