### PR TITLE
chore: support RC releases in the publish workflow

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -8,7 +8,7 @@ on:
                 required: true
                 type: string
             dist-tag:
-                description: NPM dist-tag (prod or next)
+                description: NPM dist-tag (prod, next or rc)
                 required: false
                 type: string
                 default: 'prod'
@@ -19,7 +19,7 @@ on:
                 required: true
                 type: string
             dist-tag:
-                description: NPM dist-tag (prod or next)
+                description: NPM dist-tag (prod, next or rc)
                 required: false
                 type: string
                 default: 'prod'
@@ -66,7 +66,7 @@ jobs:
             - name: Bump canary versions
               if: inputs.dist-tag != 'prod'
               run: |
-                    pnpm turbo copy --force -- --canary=major --preid=beta
+                    pnpm turbo copy --force -- --canary=major --preid=${{ inputs.dist-tag == 'rc' && 'rc' || 'beta' }}
 
             - name: Commit changes
               if: inputs.dist-tag != 'prod'
@@ -75,7 +75,7 @@ jobs:
               with:
                 author_name: Apify Release Bot
                 author_email: noreply@apify.com
-                message: 'chore: bump canary versions [skip ci]'
+                message: "chore: bump ${{ inputs.dist-tag == 'rc' && 'RC' || 'canary' }} versions [skip ci]"
                 push: false
 
             - name: Publish to NPM (@latest)
@@ -90,7 +90,7 @@ jobs:
                   GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
             - name: Publish to NPM (@next)
-              if: inputs.dist-tag != 'prod'
+              if: inputs.dist-tag != 'prod' && inputs.dist-tag != 'rc'
               uses: nick-fields/retry@v4
               with:
                   timeout_minutes: 10
@@ -99,3 +99,24 @@ jobs:
                   command: git checkout . && pnpm publish:next
               env:
                   GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
+
+            - name: Publish to NPM (@rc)
+              if: inputs.dist-tag == 'rc'
+              uses: nick-fields/retry@v4
+              with:
+                  timeout_minutes: 10
+                  max_attempts: 5
+                  retry_wait_seconds: 30
+                  command: git checkout . && pnpm publish:rc
+              env:
+                  GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
+
+            # RC releases produce no changelog and no commit on the branch, only a git tag
+            # pointing at the released commit (the version bump lives only on npm).
+            - name: Create git tag
+              if: inputs.dist-tag == 'rc'
+              run: |
+                  VERSION=$(node -p "require('./packages/core/dist/package.json').version")
+                  git reset --hard HEAD~1
+                  git tag "v$VERSION"
+                  git push origin "refs/tags/v$VERSION"

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
         "coverage": "vitest --coverage",
         "publish:next": "lerna publish from-package --contents dist --dist-tag v4 --force-publish --yes",
         "release:next": "pnpm build && pnpm publish:next",
+        "publish:rc": "lerna publish from-package --contents dist --dist-tag rc --force-publish --yes",
         "publish:prod": "lerna publish from-package --contents dist --force-publish --yes",
         "release:prod": "pnpm build && pnpm publish:prod",
         "release:pin-versions": "turbo run copy -- -- --pin-versions",


### PR DESCRIPTION
Adds an `rc` dist-tag option to the `publish-to-npm.yml` workflow so we can publish v4 release candidates, same setup as in mikro-orm.

Dispatching the workflow with `dist-tag: rc` (from the `v4` branch) will:

- bump versions via `copy --canary=major --preid=rc`, resolving the next free `4.0.0-rc.N` from npm (first run produces `4.0.0-rc.0`)
- publish all packages under the `rc` dist-tag (new `publish:rc` script)
- create and push a `v4.0.0-rc.N` git tag pointing at the released commit

Unlike stable releases, no changelog is generated and no commit is pushed to the branch. The version bump lives only on npm, and the only trace in git is the tag (same as mikro-orm's RC flow).

The regular beta canary flow (`dist-tag: v4`/`next`) is unchanged. This only needs to live on the `v4` branch: `workflow_dispatch` uses the workflow file from the branch selected in the run dropdown, so `master` needs no changes.
