### PR TITLE
chore: wire the `ignoreTlsErrors` crawler option (formerly `ignoreSslErrors`) through to the HTTP client

### DIFF
--- a/docs/public-api/crawlee-http-client.api.md
+++ b/docs/public-api/crawlee-http-client.api.md
@@ -29,6 +29,9 @@ export interface CustomFetchOptions {
 
 // @public
 export class FetchHttpClient extends BaseHttpClient {
+    constructor(options?: {
+        logger?: CrawleeLogger;
+    });
     // (undocumented)
     fetch(request: Request, options?: RequestInit & CustomFetchOptions): Promise<Response>;
 }

--- a/docs/public-api/crawlee-http-client.api.md
+++ b/docs/public-api/crawlee-http-client.api.md
@@ -23,6 +23,7 @@ export abstract class BaseHttpClient implements BaseHttpClient_2 {
 export interface CustomFetchOptions {
     cookieJar?: CookieJar;
     fingerprint?: SessionFingerprint;
+    ignoreTlsErrors?: boolean;
     proxyUrl?: string;
 }
 

--- a/docs/public-api/crawlee-http.api.md
+++ b/docs/public-api/crawlee-http.api.md
@@ -117,7 +117,6 @@ export class HttpCrawler<Context extends InternalHttpCrawlingContext<any, any> =
     // (undocumented)
     protected static optionsShape: {
         navigationTimeoutSecs: NumberPredicate & BasePredicate<number | undefined>;
-        ignoreSslErrors: BooleanPredicate & BasePredicate<boolean | undefined>;
         additionalMimeTypes: ArrayPredicate<string>;
         suggestResponseEncoding: StringPredicate & BasePredicate<string | undefined>;
         forceResponseEncoding: StringPredicate & BasePredicate<string | undefined>;
@@ -168,7 +167,6 @@ export class HttpCrawler<Context extends InternalHttpCrawlingContext<any, any> =
 export interface HttpCrawlerOptions<Context extends InternalHttpCrawlingContext = InternalHttpCrawlingContext, ContextExtension = Dictionary<never>, ExtendedContext extends Context = Context & ContextExtension, Routes extends Record<keyof Routes, Dictionary> = Record<string, GetUserDataFromRequest<Context['request']>>> extends BasicCrawlerOptions<Context, ContextExtension, ExtendedContext, Routes> {
     additionalMimeTypes?: string[];
     forceResponseEncoding?: string;
-    ignoreSslErrors?: boolean;
     navigationTimeoutSecs?: number;
     postNavigationHooks?: ((crawlingContext: CrawlingContextWithResponse & ContextExtension) => Awaitable<void | Partial<CrawlingContextWithResponse>>)[];
     preNavigationHooks?: InternalHttpHook<CrawlingContext<any>, ContextExtension>[];

--- a/docs/public-api/crawlee-http.api.md
+++ b/docs/public-api/crawlee-http.api.md
@@ -117,6 +117,7 @@ export class HttpCrawler<Context extends InternalHttpCrawlingContext<any, any> =
     // (undocumented)
     protected static optionsShape: {
         navigationTimeoutSecs: NumberPredicate & BasePredicate<number | undefined>;
+        ignoreSslErrors: BooleanPredicate & BasePredicate<boolean | undefined>;
         additionalMimeTypes: ArrayPredicate<string>;
         suggestResponseEncoding: StringPredicate & BasePredicate<string | undefined>;
         forceResponseEncoding: StringPredicate & BasePredicate<string | undefined>;
@@ -167,6 +168,7 @@ export class HttpCrawler<Context extends InternalHttpCrawlingContext<any, any> =
 export interface HttpCrawlerOptions<Context extends InternalHttpCrawlingContext = InternalHttpCrawlingContext, ContextExtension = Dictionary<never>, ExtendedContext extends Context = Context & ContextExtension, Routes extends Record<keyof Routes, Dictionary> = Record<string, GetUserDataFromRequest<Context['request']>>> extends BasicCrawlerOptions<Context, ContextExtension, ExtendedContext, Routes> {
     additionalMimeTypes?: string[];
     forceResponseEncoding?: string;
+    ignoreSslErrors?: boolean;
     navigationTimeoutSecs?: number;
     postNavigationHooks?: ((crawlingContext: CrawlingContextWithResponse & ContextExtension) => Awaitable<void | Partial<CrawlingContextWithResponse>>)[];
     preNavigationHooks?: InternalHttpHook<CrawlingContext<any>, ContextExtension>[];

--- a/docs/public-api/crawlee-http.api.md
+++ b/docs/public-api/crawlee-http.api.md
@@ -118,7 +118,6 @@ export class HttpCrawler<Context extends InternalHttpCrawlingContext<any, any> =
     protected static optionsShape: {
         navigationTimeoutSecs: NumberPredicate & BasePredicate<number | undefined>;
         ignoreTlsErrors: BooleanPredicate & BasePredicate<boolean | undefined>;
-        ignoreSslErrors: BooleanPredicate & BasePredicate<boolean | undefined>;
         additionalMimeTypes: ArrayPredicate<string>;
         suggestResponseEncoding: StringPredicate & BasePredicate<string | undefined>;
         forceResponseEncoding: StringPredicate & BasePredicate<string | undefined>;
@@ -169,8 +168,6 @@ export class HttpCrawler<Context extends InternalHttpCrawlingContext<any, any> =
 export interface HttpCrawlerOptions<Context extends InternalHttpCrawlingContext = InternalHttpCrawlingContext, ContextExtension = Dictionary<never>, ExtendedContext extends Context = Context & ContextExtension, Routes extends Record<keyof Routes, Dictionary> = Record<string, GetUserDataFromRequest<Context['request']>>> extends BasicCrawlerOptions<Context, ContextExtension, ExtendedContext, Routes> {
     additionalMimeTypes?: string[];
     forceResponseEncoding?: string;
-    // @deprecated (undocumented)
-    ignoreSslErrors?: boolean;
     ignoreTlsErrors?: boolean;
     navigationTimeoutSecs?: number;
     postNavigationHooks?: ((crawlingContext: CrawlingContextWithResponse & ContextExtension) => Awaitable<void | Partial<CrawlingContextWithResponse>>)[];

--- a/docs/public-api/crawlee-http.api.md
+++ b/docs/public-api/crawlee-http.api.md
@@ -117,6 +117,7 @@ export class HttpCrawler<Context extends InternalHttpCrawlingContext<any, any> =
     // (undocumented)
     protected static optionsShape: {
         navigationTimeoutSecs: NumberPredicate & BasePredicate<number | undefined>;
+        ignoreTlsErrors: BooleanPredicate & BasePredicate<boolean | undefined>;
         ignoreSslErrors: BooleanPredicate & BasePredicate<boolean | undefined>;
         additionalMimeTypes: ArrayPredicate<string>;
         suggestResponseEncoding: StringPredicate & BasePredicate<string | undefined>;
@@ -168,7 +169,9 @@ export class HttpCrawler<Context extends InternalHttpCrawlingContext<any, any> =
 export interface HttpCrawlerOptions<Context extends InternalHttpCrawlingContext = InternalHttpCrawlingContext, ContextExtension = Dictionary<never>, ExtendedContext extends Context = Context & ContextExtension, Routes extends Record<keyof Routes, Dictionary> = Record<string, GetUserDataFromRequest<Context['request']>>> extends BasicCrawlerOptions<Context, ContextExtension, ExtendedContext, Routes> {
     additionalMimeTypes?: string[];
     forceResponseEncoding?: string;
+    // @deprecated (undocumented)
     ignoreSslErrors?: boolean;
+    ignoreTlsErrors?: boolean;
     navigationTimeoutSecs?: number;
     postNavigationHooks?: ((crawlingContext: CrawlingContextWithResponse & ContextExtension) => Awaitable<void | Partial<CrawlingContextWithResponse>>)[];
     preNavigationHooks?: InternalHttpHook<CrawlingContext<any>, ContextExtension>[];

--- a/docs/public-api/crawlee-jsdom.api.md
+++ b/docs/public-api/crawlee-jsdom.api.md
@@ -62,7 +62,6 @@ export class JSDOMCrawler<ContextExtension = Dictionary<never>, ExtendedContext 
         hideInternalConsole: BooleanPredicate & BasePredicate<boolean | undefined>;
         navigationTimeoutSecs: NumberPredicate & BasePredicate<number | undefined>;
         ignoreTlsErrors: BooleanPredicate & BasePredicate<boolean | undefined>;
-        ignoreSslErrors: BooleanPredicate & BasePredicate<boolean | undefined>;
         additionalMimeTypes: ArrayPredicate<string>;
         suggestResponseEncoding: StringPredicate & BasePredicate<string | undefined>;
         forceResponseEncoding: StringPredicate & BasePredicate<string | undefined>;

--- a/docs/public-api/crawlee-jsdom.api.md
+++ b/docs/public-api/crawlee-jsdom.api.md
@@ -61,6 +61,7 @@ export class JSDOMCrawler<ContextExtension = Dictionary<never>, ExtendedContext 
         runScripts: BooleanPredicate & BasePredicate<boolean | undefined>;
         hideInternalConsole: BooleanPredicate & BasePredicate<boolean | undefined>;
         navigationTimeoutSecs: NumberPredicate & BasePredicate<number | undefined>;
+        ignoreTlsErrors: BooleanPredicate & BasePredicate<boolean | undefined>;
         ignoreSslErrors: BooleanPredicate & BasePredicate<boolean | undefined>;
         additionalMimeTypes: ArrayPredicate<string>;
         suggestResponseEncoding: StringPredicate & BasePredicate<string | undefined>;

--- a/docs/public-api/crawlee-jsdom.api.md
+++ b/docs/public-api/crawlee-jsdom.api.md
@@ -61,7 +61,6 @@ export class JSDOMCrawler<ContextExtension = Dictionary<never>, ExtendedContext 
         runScripts: BooleanPredicate & BasePredicate<boolean | undefined>;
         hideInternalConsole: BooleanPredicate & BasePredicate<boolean | undefined>;
         navigationTimeoutSecs: NumberPredicate & BasePredicate<number | undefined>;
-        ignoreSslErrors: BooleanPredicate & BasePredicate<boolean | undefined>;
         additionalMimeTypes: ArrayPredicate<string>;
         suggestResponseEncoding: StringPredicate & BasePredicate<string | undefined>;
         forceResponseEncoding: StringPredicate & BasePredicate<string | undefined>;

--- a/docs/public-api/crawlee-jsdom.api.md
+++ b/docs/public-api/crawlee-jsdom.api.md
@@ -61,6 +61,7 @@ export class JSDOMCrawler<ContextExtension = Dictionary<never>, ExtendedContext 
         runScripts: BooleanPredicate & BasePredicate<boolean | undefined>;
         hideInternalConsole: BooleanPredicate & BasePredicate<boolean | undefined>;
         navigationTimeoutSecs: NumberPredicate & BasePredicate<number | undefined>;
+        ignoreSslErrors: BooleanPredicate & BasePredicate<boolean | undefined>;
         additionalMimeTypes: ArrayPredicate<string>;
         suggestResponseEncoding: StringPredicate & BasePredicate<string | undefined>;
         forceResponseEncoding: StringPredicate & BasePredicate<string | undefined>;

--- a/docs/public-api/crawlee-types.api.md
+++ b/docs/public-api/crawlee-types.api.md
@@ -440,6 +440,7 @@ export type SearchParams = string | URLSearchParams | Record<string, string | nu
 export interface SendRequestOptions {
     // (undocumented)
     cookieJar?: CookieJar;
+    ignoreTlsErrors?: boolean;
     proxyUrl?: string;
     // (undocumented)
     session?: ISession;

--- a/docs/upgrading/upgrading_v4.md
+++ b/docs/upgrading/upgrading_v4.md
@@ -401,6 +401,24 @@ Previously, `BrowserCrawler` with `saveResponseCookies` (formerly `persistCookie
 
 In v4, when `saveResponseCookies` is enabled (the default), browser cookies are also re-read and stored in the session cookie jar **after** `requestHandler` completes. If you relied on handler-set cookies staying page-local and not affecting later requests on the same session, set `saveResponseCookies: false` or clear/overwrite cookies on the session explicitly.
 
+### `ignoreSslErrors` is removed from `HttpCrawler`
+
+TLS behavior is now the HTTP client's responsibility, so the `ignoreSslErrors` crawler option is gone. To ignore invalid certificates, configure the client and pass it via the `httpClient` option:
+
+```ts
+import { CheerioCrawler } from '@crawlee/cheerio';
+import { ImpitHttpClient } from '@crawlee/impit-client';
+
+const crawler = new CheerioCrawler({
+    httpClient: new ImpitHttpClient({ ignoreTlsErrors: true }),
+    // ...
+});
+```
+
+Note that while the option was documented as defaulting to `true`, it had no effect in recent versions — certificates were always verified. The v4 default (verify certificates) matches that actual behavior, so dropping the option does not change what your crawler does; only re-add `ignoreTlsErrors` if you genuinely need to accept invalid certificates.
+
+MITM proxies are handled separately: when `session.proxyInfo.ignoreTlsErrors` is set, the built-in HTTP clients disable certificate verification for that session's requests automatically — same as the browser crawlers.
+
 ### `preNavigationHooks` in `HttpCrawler` no longer accepts `gotOptions` object
 
 The `preNavigationHooks` option in `HttpCrawler` subclasses no longer accepts the `gotOptions` object as a second parameter. Modify the `crawlingContext` fields (e.g. `.request`) directly instead.
@@ -685,7 +703,7 @@ This is intentional: these were never a supported API. If you relied on overridi
 The change spans, among others:
 
 - **`BasicCrawler`** — `unexpectedStop`, `requestHandlerTimeoutMillis`, `sameDomainDelayMillis`, `domainAccessedTime`, `handledRequestsCount`, `statusMessageLoggingInterval`, `statusMessageCallback`, `ignoreHttpErrorStatusCodes`, `taskLoopOptions` (was `autoscaledPoolOptions`), `autoscaledPool`, `respectRobotsTxtFile`, and the helpers `buildBasicContextPipeline`, `validateRequestUserData`, `pauseOnMigration`, `fetchNextRequest`, `delayRequest`, `handleRequest`, `timeoutAndRetry`, `isTaskReadyFunction`, `defaultIsFinishedFunction`, `requestFunctionErrorHandler`, `handleFailedRequestHandler`, `canRequestBeRetried`
-- **`HttpCrawler`** — `preNavigationHooks`, `postNavigationHooks`, `saveResponseCookies`, `navigationTimeoutMillis`, `ignoreSslErrors`, `suggestResponseEncoding`, `forceResponseEncoding`, `supportedMimeTypes`, and the helpers `requestFunction`, `parseResponse`, `getRequestOptions`, `encodeResponse`, `extendSupportedMimeTypes`, `handleRequestTimeout`
+- **`HttpCrawler`** — `preNavigationHooks`, `postNavigationHooks`, `saveResponseCookies`, `navigationTimeoutMillis`, `suggestResponseEncoding`, `forceResponseEncoding`, `supportedMimeTypes`, and the helpers `requestFunction`, `parseResponse`, `getRequestOptions`, `encodeResponse`, `extendSupportedMimeTypes`, `handleRequestTimeout`
 - **`AutoscaledPool`** — the whole class is `@internal` in v4, so its members are not enumerated here; see [`AutoscaledPool` is no longer public API](#autoscaledpool-is-no-longer-public-api)
 - **`SessionPool`** — all pool internals (`log`, `maxPoolSize`, `createSessionFunction`, `keyValueStore`, `sessions`, `sessionMap`, `sessionOptions`, `persistStateKey`, `persistStateKeyValueStoreId`, `events`, `persistenceOptions`, `sessionReuseStrategy`, and the helpers `ensureInitialized`, `maybeLoadSessionPool`, `registerSession`, `createSession`, `hasSpaceForSession`, `pickSession`, `removeRetiredSessions`, `getRandomIndex`, `defaultCreateSessionFunction`)
 - **`Session`** — `maybeSelfRetire` (`userData` is now `readonly`)

--- a/docs/upgrading/upgrading_v4.md
+++ b/docs/upgrading/upgrading_v4.md
@@ -401,9 +401,11 @@ Previously, `BrowserCrawler` with `saveResponseCookies` (formerly `persistCookie
 
 In v4, when `saveResponseCookies` is enabled (the default), browser cookies are also re-read and stored in the session cookie jar **after** `requestHandler` completes. If you relied on handler-set cookies staying page-local and not affecting later requests on the same session, set `saveResponseCookies: false` or clear/overwrite cookies on the session explicitly.
 
-### `ignoreSslErrors` is forwarded to the HTTP client
+### `ignoreSslErrors` is renamed to `ignoreTlsErrors`
 
-The `ignoreSslErrors` crawler option is unchanged for users: it still defaults to `true` and HTTP crawlers still accept invalid TLS certificates by default, same as v3. What changed is how it reaches the network layer — the crawler now forwards it to the HTTP client as `SendRequestOptions.ignoreTlsErrors` on every request, and the same flag is enabled automatically for MITM proxy sessions (`session.proxyInfo.ignoreTlsErrors`), matching the browser crawlers.
+The crawler option is renamed to `ignoreTlsErrors`, matching the naming used everywhere else in v4 (`session.proxyInfo.ignoreTlsErrors`, the browser pool, the impit client). The old `ignoreSslErrors` name still works as a deprecated alias (with a one-time warning), so existing actor input schemas and SDK forwarding are unaffected. Behavior is unchanged from v3: the option defaults to `true` and HTTP crawlers accept invalid TLS certificates by default.
+
+Under the hood the crawler now forwards the option to the HTTP client as `SendRequestOptions.ignoreTlsErrors` on every request, and the same flag is enabled automatically for MITM proxy sessions (`session.proxyInfo.ignoreTlsErrors`), matching the browser crawlers.
 
 This only affects custom `BaseHttpClient` implementations: honor `ignoreTlsErrors` (from `SendRequestOptions`, or `CustomFetchOptions` when extending the `BaseHttpClient` class from `@crawlee/http-client`) if your client can disable TLS verification. The built-in impit client does; the native fetch fallback cannot and ignores the flag.
 

--- a/docs/upgrading/upgrading_v4.md
+++ b/docs/upgrading/upgrading_v4.md
@@ -405,7 +405,7 @@ In v4, when `saveResponseCookies` is enabled (the default), browser cookies are 
 
 The crawler option is renamed to `ignoreTlsErrors`, matching the naming used everywhere else in v4 (`session.proxyInfo.ignoreTlsErrors`, the browser pool, the impit client). The old `ignoreSslErrors` name is no longer accepted — rename it in your crawler options. Behavior is unchanged from v3: the option defaults to `true` and HTTP crawlers accept invalid TLS certificates by default.
 
-Under the hood the crawler now forwards the option to the HTTP client as `SendRequestOptions.ignoreTlsErrors` on every request, and the same flag is enabled automatically for MITM proxy sessions (`session.proxyInfo.ignoreTlsErrors`), matching the browser crawlers.
+Under the hood the crawler now forwards the option to the HTTP client as `SendRequestOptions.ignoreTlsErrors` on every navigation request, and the same flag is enabled automatically for MITM proxy sessions (`session.proxyInfo.ignoreTlsErrors`), matching the browser crawlers.
 
 This only affects custom `BaseHttpClient` implementations: honor `ignoreTlsErrors` (from `SendRequestOptions`, or `CustomFetchOptions` when extending the `BaseHttpClient` class from `@crawlee/http-client`) if your client can disable TLS verification. The built-in impit client does; the native fetch fallback cannot and ignores the flag.
 

--- a/docs/upgrading/upgrading_v4.md
+++ b/docs/upgrading/upgrading_v4.md
@@ -403,7 +403,7 @@ In v4, when `saveResponseCookies` is enabled (the default), browser cookies are 
 
 ### `ignoreSslErrors` is removed from `HttpCrawler`
 
-TLS behavior is now the HTTP client's responsibility, so the `ignoreSslErrors` crawler option is gone. To ignore invalid certificates, configure the client and pass it via the `httpClient` option:
+TLS behavior is now the HTTP client's responsibility, so the `ignoreSslErrors` crawler option is gone. **This is also a behavior change:** in v3 the option defaulted to `true`, so HTTP crawlers accepted invalid TLS certificates by default. In v4, certificates are always verified unless you configure the client otherwise. If you crawl sites with invalid, expired, or self-signed certificates (or relied on the old default), configure the client and pass it via the `httpClient` option:
 
 ```ts
 import { CheerioCrawler } from '@crawlee/cheerio';
@@ -414,8 +414,6 @@ const crawler = new CheerioCrawler({
     // ...
 });
 ```
-
-Note that while the option was documented as defaulting to `true`, it had no effect in recent versions — certificates were always verified. The v4 default (verify certificates) matches that actual behavior, so dropping the option does not change what your crawler does; only re-add `ignoreTlsErrors` if you genuinely need to accept invalid certificates.
 
 MITM proxies are handled separately: when `session.proxyInfo.ignoreTlsErrors` is set, the built-in HTTP clients disable certificate verification for that session's requests automatically — same as the browser crawlers.
 

--- a/docs/upgrading/upgrading_v4.md
+++ b/docs/upgrading/upgrading_v4.md
@@ -407,7 +407,7 @@ The crawler option is renamed to `ignoreTlsErrors`, matching the naming used eve
 
 Under the hood the crawler now forwards the option to the HTTP client as `SendRequestOptions.ignoreTlsErrors` on every navigation request, and the same flag is enabled automatically for MITM proxy sessions (`session.proxyInfo.ignoreTlsErrors`), matching the browser crawlers.
 
-This only affects custom `BaseHttpClient` implementations: honor `ignoreTlsErrors` (from `SendRequestOptions`, or `CustomFetchOptions` when extending the `BaseHttpClient` class from `@crawlee/http-client`) if your client can disable TLS verification. The built-in impit client does; the native fetch fallback cannot and ignores the flag.
+This only affects custom `BaseHttpClient` implementations: honor `ignoreTlsErrors` (from `SendRequestOptions`, or `CustomFetchOptions` when extending the `BaseHttpClient` class from `@crawlee/http-client`) if your client can disable TLS verification. The built-in impit and got-scraping clients do; the native fetch fallback cannot, so it warns and ignores the flag.
 
 ### `preNavigationHooks` in `HttpCrawler` no longer accepts `gotOptions` object
 

--- a/docs/upgrading/upgrading_v4.md
+++ b/docs/upgrading/upgrading_v4.md
@@ -401,21 +401,11 @@ Previously, `BrowserCrawler` with `saveResponseCookies` (formerly `persistCookie
 
 In v4, when `saveResponseCookies` is enabled (the default), browser cookies are also re-read and stored in the session cookie jar **after** `requestHandler` completes. If you relied on handler-set cookies staying page-local and not affecting later requests on the same session, set `saveResponseCookies: false` or clear/overwrite cookies on the session explicitly.
 
-### `ignoreSslErrors` is removed from `HttpCrawler`
+### `ignoreSslErrors` is forwarded to the HTTP client
 
-TLS behavior is now the HTTP client's responsibility, so the `ignoreSslErrors` crawler option is gone. **This is also a behavior change:** in v3 the option defaulted to `true`, so HTTP crawlers accepted invalid TLS certificates by default. In v4, certificates are always verified unless you configure the client otherwise. If you crawl sites with invalid, expired, or self-signed certificates (or relied on the old default), configure the client and pass it via the `httpClient` option:
+The `ignoreSslErrors` crawler option is unchanged for users: it still defaults to `true` and HTTP crawlers still accept invalid TLS certificates by default, same as v3. What changed is how it reaches the network layer — the crawler now forwards it to the HTTP client as `SendRequestOptions.ignoreTlsErrors` on every request, and the same flag is enabled automatically for MITM proxy sessions (`session.proxyInfo.ignoreTlsErrors`), matching the browser crawlers.
 
-```ts
-import { CheerioCrawler } from '@crawlee/cheerio';
-import { ImpitHttpClient } from '@crawlee/impit-client';
-
-const crawler = new CheerioCrawler({
-    httpClient: new ImpitHttpClient({ ignoreTlsErrors: true }),
-    // ...
-});
-```
-
-MITM proxies are handled separately: when `session.proxyInfo.ignoreTlsErrors` is set, the built-in HTTP clients disable certificate verification for that session's requests automatically — same as the browser crawlers.
+This only affects custom `BaseHttpClient` implementations: honor `ignoreTlsErrors` (from `SendRequestOptions`, or `CustomFetchOptions` when extending the `BaseHttpClient` class from `@crawlee/http-client`) if your client can disable TLS verification. The built-in impit client does; the native fetch fallback cannot and ignores the flag.
 
 ### `preNavigationHooks` in `HttpCrawler` no longer accepts `gotOptions` object
 

--- a/docs/upgrading/upgrading_v4.md
+++ b/docs/upgrading/upgrading_v4.md
@@ -403,7 +403,7 @@ In v4, when `saveResponseCookies` is enabled (the default), browser cookies are 
 
 ### `ignoreSslErrors` is renamed to `ignoreTlsErrors`
 
-The crawler option is renamed to `ignoreTlsErrors`, matching the naming used everywhere else in v4 (`session.proxyInfo.ignoreTlsErrors`, the browser pool, the impit client). The old `ignoreSslErrors` name still works as a deprecated alias (with a one-time warning), so existing actor input schemas and SDK forwarding are unaffected. Behavior is unchanged from v3: the option defaults to `true` and HTTP crawlers accept invalid TLS certificates by default.
+The crawler option is renamed to `ignoreTlsErrors`, matching the naming used everywhere else in v4 (`session.proxyInfo.ignoreTlsErrors`, the browser pool, the impit client). The old `ignoreSslErrors` name is no longer accepted — rename it in your crawler options. Behavior is unchanged from v3: the option defaults to `true` and HTTP crawlers accept invalid TLS certificates by default.
 
 Under the hood the crawler now forwards the option to the HTTP client as `SendRequestOptions.ignoreTlsErrors` on every request, and the same flag is enabled automatically for MITM proxy sessions (`session.proxyInfo.ignoreTlsErrors`), matching the browser crawlers.
 

--- a/packages/basic-crawler/src/internals/send-request.ts
+++ b/packages/basic-crawler/src/internals/send-request.ts
@@ -36,6 +36,7 @@ export function createSendRequest(httpClient: BaseHttpClient, originRequest: Cra
             cookieJar: overrideOptions?.cookieJar ?? session.cookieJar,
             timeoutMillis: overrideOptions.timeoutMillis,
             signal: overrideOptions.signal,
+            ignoreTlsErrors: overrideOptions.ignoreTlsErrors,
         });
     };
 }

--- a/packages/got-scraping-client/src/index.ts
+++ b/packages/got-scraping-client/src/index.ts
@@ -35,7 +35,7 @@ export class GotScrapingHttpClient extends BaseHttpClient {
     }
 
     override async fetch(request: Request, options?: RequestInit & CustomFetchOptions): Promise<Response> {
-        const { proxyUrl, redirect } = options ?? {};
+        const { proxyUrl, redirect, ignoreTlsErrors } = options ?? {};
 
         if (!this.validateRequest(request)) {
             throw new Error(`The HTTP method CONNECT is not supported by the GotScrapingHttpClient.`);
@@ -49,6 +49,7 @@ export class GotScrapingHttpClient extends BaseHttpClient {
             proxyUrl,
             signal: options?.signal ?? undefined,
             followRedirect: redirect === 'follow',
+            ...(ignoreTlsErrors ? { https: { rejectUnauthorized: false } } : {}),
         });
 
         const responseHeaders = this.parseHeaders(gotResult.headers);

--- a/packages/http-client/src/base-http-client.ts
+++ b/packages/http-client/src/base-http-client.ts
@@ -37,7 +37,7 @@ export interface CustomFetchOptions {
     /**
      * When `true`, TLS certificate errors should be ignored for this request.
      * Set when `SendRequestOptions.ignoreTlsErrors` is passed (e.g. from the
-     * `ignoreSslErrors` crawler option) or when the session's proxy is a MITM
+     * `ignoreTlsErrors` crawler option) or when the session's proxy is a MITM
      * proxy (`session.proxyInfo.ignoreTlsErrors`). Best-effort: clients that
      * cannot disable TLS verification ignore it.
      */

--- a/packages/http-client/src/base-http-client.ts
+++ b/packages/http-client/src/base-http-client.ts
@@ -36,9 +36,10 @@ export interface CustomFetchOptions {
 
     /**
      * When `true`, TLS certificate errors should be ignored for this request.
-     * Sourced from `SendRequestOptions.session.proxyInfo.ignoreTlsErrors` —
-     * set for MITM proxies whose certificates cannot be verified. Best-effort:
-     * clients that cannot disable TLS verification ignore it.
+     * Set when `SendRequestOptions.ignoreTlsErrors` is passed (e.g. from the
+     * `ignoreSslErrors` crawler option) or when the session's proxy is a MITM
+     * proxy (`session.proxyInfo.ignoreTlsErrors`). Best-effort: clients that
+     * cannot disable TLS verification ignore it.
      */
     ignoreTlsErrors?: boolean;
 }
@@ -123,7 +124,7 @@ export abstract class BaseHttpClient implements BaseHttpClientInterface {
             cookieJar,
             signal,
             fingerprint: options?.session?.fingerprint,
-            ignoreTlsErrors: options?.session?.proxyInfo?.ignoreTlsErrors,
+            ignoreTlsErrors: options?.ignoreTlsErrors || options?.session?.proxyInfo?.ignoreTlsErrors,
         };
     }
 

--- a/packages/http-client/src/base-http-client.ts
+++ b/packages/http-client/src/base-http-client.ts
@@ -33,6 +33,14 @@ export interface CustomFetchOptions {
      * rest on a best-effort basis. Sourced from `SendRequestOptions.session.fingerprint`.
      */
     fingerprint?: SessionFingerprint;
+
+    /**
+     * When `true`, TLS certificate errors should be ignored for this request.
+     * Sourced from `SendRequestOptions.session.proxyInfo.ignoreTlsErrors` —
+     * set for MITM proxies whose certificates cannot be verified. Best-effort:
+     * clients that cannot disable TLS verification ignore it.
+     */
+    ignoreTlsErrors?: boolean;
 }
 
 /**
@@ -105,6 +113,7 @@ export abstract class BaseHttpClient implements BaseHttpClientInterface {
         cookieJar: CookieJar;
         signal?: AbortSignal;
         fingerprint?: SessionFingerprint;
+        ignoreTlsErrors?: boolean;
     }> {
         const proxyUrl = options?.proxyUrl ?? options?.session?.proxyInfo?.url;
         const cookieJar = options?.cookieJar ?? options?.session?.cookieJar ?? (await this.#createDefaultCookieJar());
@@ -114,6 +123,7 @@ export abstract class BaseHttpClient implements BaseHttpClientInterface {
             cookieJar,
             signal,
             fingerprint: options?.session?.fingerprint,
+            ignoreTlsErrors: options?.session?.proxyInfo?.ignoreTlsErrors,
         };
     }
 
@@ -176,7 +186,7 @@ export abstract class BaseHttpClient implements BaseHttpClientInterface {
         let currentRequest = initialRequest;
         let redirectCount = 0;
 
-        const { proxyUrl, cookieJar, signal, fingerprint } = await this.resolveRequestContext(options);
+        const { proxyUrl, cookieJar, signal, fingerprint, ignoreTlsErrors } = await this.resolveRequestContext(options);
         currentRequest = initialRequest.clone();
 
         while (true) {
@@ -187,6 +197,7 @@ export abstract class BaseHttpClient implements BaseHttpClientInterface {
                 proxyUrl,
                 cookieJar,
                 fingerprint,
+                ignoreTlsErrors,
                 redirect: 'manual',
             });
 

--- a/packages/http-client/src/fetch-http-client.ts
+++ b/packages/http-client/src/fetch-http-client.ts
@@ -1,3 +1,5 @@
+import type { CrawleeLogger } from '@crawlee/types';
+
 import { BaseHttpClient, type CustomFetchOptions } from './base-http-client.js';
 
 /**
@@ -6,7 +8,23 @@ import { BaseHttpClient, type CustomFetchOptions } from './base-http-client.js';
  * This implementation does not support proxying.
  */
 export class FetchHttpClient extends BaseHttpClient {
+    #logger?: CrawleeLogger;
+    #warnedIgnoreTlsErrors = false;
+
+    constructor(options?: { logger?: CrawleeLogger }) {
+        super(options);
+        this.#logger = options?.logger;
+    }
+
     override async fetch(request: Request, options?: RequestInit & CustomFetchOptions): Promise<Response> {
+        if (options?.ignoreTlsErrors && !this.#warnedIgnoreTlsErrors) {
+            this.#warnedIgnoreTlsErrors = true;
+            this.#logger?.warning(
+                'FetchHttpClient cannot disable TLS certificate verification, the `ignoreTlsErrors` option is ignored. ' +
+                    'Install the optional @crawlee/impit-client dependency to make it work.',
+            );
+        }
+
         return fetch(request, options);
     }
 }

--- a/packages/http-client/src/fetch-http-client.ts
+++ b/packages/http-client/src/fetch-http-client.ts
@@ -9,7 +9,6 @@ import { BaseHttpClient, type CustomFetchOptions } from './base-http-client.js';
  */
 export class FetchHttpClient extends BaseHttpClient {
     #logger?: CrawleeLogger;
-    #warnedIgnoreTlsErrors = false;
 
     constructor(options?: { logger?: CrawleeLogger }) {
         super(options);
@@ -17,9 +16,8 @@ export class FetchHttpClient extends BaseHttpClient {
     }
 
     override async fetch(request: Request, options?: RequestInit & CustomFetchOptions): Promise<Response> {
-        if (options?.ignoreTlsErrors && !this.#warnedIgnoreTlsErrors) {
-            this.#warnedIgnoreTlsErrors = true;
-            this.#logger?.warning(
+        if (options?.ignoreTlsErrors) {
+            this.#logger?.warningOnce(
                 'FetchHttpClient cannot disable TLS certificate verification, the `ignoreTlsErrors` option is ignored. ' +
                     'Install the optional @crawlee/impit-client dependency to make it work.',
             );

--- a/packages/http-crawler/src/internals/http-crawler.ts
+++ b/packages/http-crawler/src/internals/http-crawler.ts
@@ -91,8 +91,8 @@ export interface HttpCrawlerOptions<
     /**
      * If set to `true`, TLS/SSL certificate errors are ignored. Forwarded to the HTTP client as
      * {@apilink SendRequestOptions.ignoreTlsErrors|`ignoreTlsErrors`} on every navigation request, so custom
-     * {@apilink BaseHttpClient} implementations should honor that flag (the built-in impit client does;
-     * the native fetch fallback cannot disable TLS verification).
+     * {@apilink BaseHttpClient} implementations should honor that flag (the built-in impit and got-scraping
+     * clients do; the native fetch fallback cannot disable TLS verification and warns instead).
      *
      * @default true
      */

--- a/packages/http-crawler/src/internals/http-crawler.ts
+++ b/packages/http-crawler/src/internals/http-crawler.ts
@@ -99,11 +99,6 @@ export interface HttpCrawlerOptions<
     ignoreTlsErrors?: boolean;
 
     /**
-     * @deprecated Use {@apilink HttpCrawlerOptions.ignoreTlsErrors|`ignoreTlsErrors`} instead.
-     */
-    ignoreSslErrors?: boolean;
-
-    /**
      * Async functions that are sequentially evaluated before the navigation. Good for setting additional cookies
      * or browser properties before navigation. The function accepts one parameter `crawlingContext`,
      * which is passed to the `requestAsBrowser()` function the crawler calls to navigate.
@@ -368,7 +363,6 @@ export class HttpCrawler<
 
         navigationTimeoutSecs: ow.optional.number,
         ignoreTlsErrors: ow.optional.boolean,
-        ignoreSslErrors: ow.optional.boolean,
         additionalMimeTypes: ow.optional.array.ofType(ow.string),
         suggestResponseEncoding: ow.optional.string,
         forceResponseEncoding: ow.optional.string,
@@ -389,9 +383,7 @@ export class HttpCrawler<
 
         const {
             navigationTimeoutSecs = 30,
-            // oxlint-disable-next-line typescript/no-deprecated -- still accepted and folded into `ignoreTlsErrors` for back-compat
-            ignoreSslErrors,
-            ignoreTlsErrors = ignoreSslErrors ?? true,
+            ignoreTlsErrors = true,
             additionalMimeTypes = [],
             suggestResponseEncoding,
             forceResponseEncoding,
@@ -418,10 +410,6 @@ export class HttpCrawler<
             this.log.warning(
                 'Both forceResponseEncoding and suggestResponseEncoding options are set. Using forceResponseEncoding.',
             );
-        }
-
-        if (ignoreSslErrors !== undefined) {
-            this.log.deprecated('The `ignoreSslErrors` option is deprecated, use `ignoreTlsErrors` instead.');
         }
 
         this.#navigationTimeoutMillis = navigationTimeoutSecs * 1000;

--- a/packages/http-crawler/src/internals/http-crawler.ts
+++ b/packages/http-crawler/src/internals/http-crawler.ts
@@ -96,6 +96,11 @@ export interface HttpCrawlerOptions<
      *
      * @default true
      */
+    ignoreTlsErrors?: boolean;
+
+    /**
+     * @deprecated Use {@apilink HttpCrawlerOptions.ignoreTlsErrors|`ignoreTlsErrors`} instead.
+     */
     ignoreSslErrors?: boolean;
 
     /**
@@ -353,7 +358,7 @@ export class HttpCrawler<
     #postNavigationHooks: InternalHttpPostNavigationHook[];
     #saveResponseCookies: boolean;
     #navigationTimeoutMillis: number;
-    #ignoreSslErrors: boolean;
+    #ignoreTlsErrors: boolean;
     #suggestResponseEncoding?: string;
     #forceResponseEncoding?: string;
     readonly #supportedMimeTypes: Set<string>;
@@ -362,6 +367,7 @@ export class HttpCrawler<
         ...BasicCrawler.optionsShape,
 
         navigationTimeoutSecs: ow.optional.number,
+        ignoreTlsErrors: ow.optional.boolean,
         ignoreSslErrors: ow.optional.boolean,
         additionalMimeTypes: ow.optional.array.ofType(ow.string),
         suggestResponseEncoding: ow.optional.string,
@@ -383,7 +389,9 @@ export class HttpCrawler<
 
         const {
             navigationTimeoutSecs = 30,
-            ignoreSslErrors = true,
+            // oxlint-disable-next-line typescript/no-deprecated -- still accepted and folded into `ignoreTlsErrors` for back-compat
+            ignoreSslErrors,
+            ignoreTlsErrors = ignoreSslErrors ?? true,
             additionalMimeTypes = [],
             suggestResponseEncoding,
             forceResponseEncoding,
@@ -412,8 +420,12 @@ export class HttpCrawler<
             );
         }
 
+        if (ignoreSslErrors !== undefined) {
+            this.log.deprecated('The `ignoreSslErrors` option is deprecated, use `ignoreTlsErrors` instead.');
+        }
+
         this.#navigationTimeoutMillis = navigationTimeoutSecs * 1000;
-        this.#ignoreSslErrors = ignoreSslErrors;
+        this.#ignoreTlsErrors = ignoreTlsErrors;
         this.#suggestResponseEncoding = suggestResponseEncoding;
         this.#forceResponseEncoding = forceResponseEncoding;
         // Cast away the extension-aware option types to the base internal storage types (see the field
@@ -904,7 +916,7 @@ export class HttpCrawler<
                 cookieJar,
                 signal: cancelSignal,
                 timeoutMillis: cancelSignal ? undefined : opts.timeout,
-                ignoreTlsErrors: this.#ignoreSslErrors,
+                ignoreTlsErrors: this.#ignoreTlsErrors,
             },
         );
 

--- a/packages/http-crawler/src/internals/http-crawler.ts
+++ b/packages/http-crawler/src/internals/http-crawler.ts
@@ -89,11 +89,6 @@ export interface HttpCrawlerOptions<
     navigationTimeoutSecs?: number;
 
     /**
-     * If set to true, SSL certificate errors will be ignored.
-     */
-    ignoreSslErrors?: boolean;
-
-    /**
      * Async functions that are sequentially evaluated before the navigation. Good for setting additional cookies
      * or browser properties before navigation. The function accepts one parameter `crawlingContext`,
      * which is passed to the `requestAsBrowser()` function the crawler calls to navigate.
@@ -348,8 +343,6 @@ export class HttpCrawler<
     #postNavigationHooks: InternalHttpPostNavigationHook[];
     #saveResponseCookies: boolean;
     #navigationTimeoutMillis: number;
-    // kept as TS-private: tests read it at runtime
-    private ignoreSslErrors: boolean;
     #suggestResponseEncoding?: string;
     #forceResponseEncoding?: string;
     readonly #supportedMimeTypes: Set<string>;
@@ -358,7 +351,6 @@ export class HttpCrawler<
         ...BasicCrawler.optionsShape,
 
         navigationTimeoutSecs: ow.optional.number,
-        ignoreSslErrors: ow.optional.boolean,
         additionalMimeTypes: ow.optional.array.ofType(ow.string),
         suggestResponseEncoding: ow.optional.string,
         forceResponseEncoding: ow.optional.string,
@@ -379,7 +371,6 @@ export class HttpCrawler<
 
         const {
             navigationTimeoutSecs = 30,
-            ignoreSslErrors = true,
             additionalMimeTypes = [],
             suggestResponseEncoding,
             forceResponseEncoding,
@@ -409,7 +400,6 @@ export class HttpCrawler<
         }
 
         this.#navigationTimeoutMillis = navigationTimeoutSecs * 1000;
-        this.ignoreSslErrors = ignoreSslErrors;
         this.#suggestResponseEncoding = suggestResponseEncoding;
         this.#forceResponseEncoding = forceResponseEncoding;
         // Cast away the extension-aware option types to the base internal storage types (see the field
@@ -764,23 +754,12 @@ export class HttpCrawler<
             timeout: this.#navigationTimeoutMillis,
             sessionToken: session,
             headers: request.headers,
-            https: {
-                rejectUnauthorized: !this.ignoreSslErrors,
-            },
             body: undefined as string | undefined,
         };
 
         if (requestOptions.headers?.cookie || requestOptions.headers?.Cookie) {
             requestOptions.headers!.Cookie = this.getCookieHeaderFromRequest(request);
             delete requestOptions.headers!.cookie;
-        }
-
-        // Disable SSL verification for MITM proxies
-        if (session.proxyInfo?.ignoreTlsErrors) {
-            requestOptions.https = {
-                ...requestOptions.https,
-                rejectUnauthorized: false,
-            };
         }
 
         if (/PATCH|POST|PUT/.test(request.method)) requestOptions.body = request.payload ?? '';

--- a/packages/http-crawler/src/internals/http-crawler.ts
+++ b/packages/http-crawler/src/internals/http-crawler.ts
@@ -90,7 +90,7 @@ export interface HttpCrawlerOptions<
 
     /**
      * If set to `true`, TLS/SSL certificate errors are ignored. Forwarded to the HTTP client as
-     * {@apilink SendRequestOptions.ignoreTlsErrors|`ignoreTlsErrors`} on every request, so custom
+     * {@apilink SendRequestOptions.ignoreTlsErrors|`ignoreTlsErrors`} on every navigation request, so custom
      * {@apilink BaseHttpClient} implementations should honor that flag (the built-in impit client does;
      * the native fetch fallback cannot disable TLS verification).
      *

--- a/packages/http-crawler/src/internals/http-crawler.ts
+++ b/packages/http-crawler/src/internals/http-crawler.ts
@@ -89,6 +89,16 @@ export interface HttpCrawlerOptions<
     navigationTimeoutSecs?: number;
 
     /**
+     * If set to `true`, TLS/SSL certificate errors are ignored. Forwarded to the HTTP client as
+     * {@apilink SendRequestOptions.ignoreTlsErrors|`ignoreTlsErrors`} on every request, so custom
+     * {@apilink BaseHttpClient} implementations should honor that flag (the built-in impit client does;
+     * the native fetch fallback cannot disable TLS verification).
+     *
+     * @default true
+     */
+    ignoreSslErrors?: boolean;
+
+    /**
      * Async functions that are sequentially evaluated before the navigation. Good for setting additional cookies
      * or browser properties before navigation. The function accepts one parameter `crawlingContext`,
      * which is passed to the `requestAsBrowser()` function the crawler calls to navigate.
@@ -343,6 +353,7 @@ export class HttpCrawler<
     #postNavigationHooks: InternalHttpPostNavigationHook[];
     #saveResponseCookies: boolean;
     #navigationTimeoutMillis: number;
+    #ignoreSslErrors: boolean;
     #suggestResponseEncoding?: string;
     #forceResponseEncoding?: string;
     readonly #supportedMimeTypes: Set<string>;
@@ -351,6 +362,7 @@ export class HttpCrawler<
         ...BasicCrawler.optionsShape,
 
         navigationTimeoutSecs: ow.optional.number,
+        ignoreSslErrors: ow.optional.boolean,
         additionalMimeTypes: ow.optional.array.ofType(ow.string),
         suggestResponseEncoding: ow.optional.string,
         forceResponseEncoding: ow.optional.string,
@@ -371,6 +383,7 @@ export class HttpCrawler<
 
         const {
             navigationTimeoutSecs = 30,
+            ignoreSslErrors = true,
             additionalMimeTypes = [],
             suggestResponseEncoding,
             forceResponseEncoding,
@@ -400,6 +413,7 @@ export class HttpCrawler<
         }
 
         this.#navigationTimeoutMillis = navigationTimeoutSecs * 1000;
+        this.#ignoreSslErrors = ignoreSslErrors;
         this.#suggestResponseEncoding = suggestResponseEncoding;
         this.#forceResponseEncoding = forceResponseEncoding;
         // Cast away the extension-aware option types to the base internal storage types (see the field
@@ -890,6 +904,7 @@ export class HttpCrawler<
                 cookieJar,
                 signal: cancelSignal,
                 timeoutMillis: cancelSignal ? undefined : opts.timeout,
+                ignoreTlsErrors: this.#ignoreSslErrors,
             },
         );
 

--- a/packages/impit-client/src/index.ts
+++ b/packages/impit-client/src/index.ts
@@ -91,13 +91,16 @@ export class ImpitHttpClient extends BaseHttpClient {
      * @inheritDoc
      */
     async fetch(request: Request, options?: RequestInit & CustomFetchOptions): Promise<Response> {
-        const { proxyUrl, redirect, signal, fingerprint } = options ?? {};
+        const { proxyUrl, redirect, signal, fingerprint, ignoreTlsErrors } = options ?? {};
 
         const impitBrowser = this.resolveImpitBrowser(fingerprint);
 
         const impit = this.getClient({
             ...this.#impitOptions,
             ...(impitBrowser ? { browser: impitBrowser } : {}),
+            // Per-request flag (from `session.proxyInfo.ignoreTlsErrors`, i.e. MITM proxies)
+            // can only enable ignoring, never override a constructor-level `true`.
+            ...(ignoreTlsErrors ? { ignoreTlsErrors: true } : {}),
             proxyUrl,
             followRedirects: redirect === 'follow',
         });

--- a/packages/impit-client/src/index.ts
+++ b/packages/impit-client/src/index.ts
@@ -98,7 +98,7 @@ export class ImpitHttpClient extends BaseHttpClient {
         const impit = this.getClient({
             ...this.#impitOptions,
             ...(impitBrowser ? { browser: impitBrowser } : {}),
-            // Per-request flag (from `session.proxyInfo.ignoreTlsErrors`, i.e. MITM proxies)
+            // The per-request flag (from the crawler option or a MITM proxy session)
             // can only enable ignoring, never override a constructor-level `true`.
             ...(ignoreTlsErrors ? { ignoreTlsErrors: true } : {}),
             proxyUrl,

--- a/packages/types/src/http-client.ts
+++ b/packages/types/src/http-client.ts
@@ -75,6 +75,13 @@ export interface SendRequestOptions {
      * Note that setting this manually can interfere with session proxy rotation.
      */
     proxyUrl?: string;
+
+    /**
+     * When `true`, TLS certificate errors are ignored for this request. Also enabled by
+     * `session.proxyInfo.ignoreTlsErrors` (MITM proxies). Best-effort: clients that cannot
+     * disable TLS verification (e.g. the native fetch fallback) ignore it.
+     */
+    ignoreTlsErrors?: boolean;
 }
 
 export interface StreamOptions extends SendRequestOptions {

--- a/packages/types/src/session.ts
+++ b/packages/types/src/session.ts
@@ -55,6 +55,8 @@ export interface ProxyInfo {
 
     /**
      * When `true`, the proxy is likely intercepting HTTPS traffic and is able to view and modify its content.
+     * The built-in HTTP clients and the browser pool disable TLS certificate verification for the session's
+     * requests when this is set.
      *
      * @default false
      */

--- a/test/core/base-http-client.test.ts
+++ b/test/core/base-http-client.test.ts
@@ -188,17 +188,15 @@ describe('BaseHttpClient TLS error handling', () => {
         expect(client.lastFetchOptions?.ignoreTlsErrors).toBeUndefined();
     });
 
-    test('FetchHttpClient warns once when ignoreTlsErrors is requested', async () => {
-        const warning = vitest.fn();
-        const client = new FetchHttpClient({ logger: { warning } as any });
+    test('FetchHttpClient warns when ignoreTlsErrors is requested', async () => {
+        const warningOnce = vitest.fn();
+        const client = new FetchHttpClient({ logger: { warningOnce } as any });
 
         await client.sendRequest(new Request(url), { ignoreTlsErrors: true });
-        await client.sendRequest(new Request(url), { ignoreTlsErrors: true });
-        expect(warning).toHaveBeenCalledTimes(1);
-        expect(warning).toHaveBeenCalledWith(expect.stringContaining('ignoreTlsErrors'));
+        expect(warningOnce).toHaveBeenCalledWith(expect.stringContaining('ignoreTlsErrors'));
 
-        const quietClient = new FetchHttpClient({ logger: { warning } as any });
-        await quietClient.sendRequest(new Request(url));
-        expect(warning).toHaveBeenCalledTimes(1);
+        warningOnce.mockClear();
+        await client.sendRequest(new Request(url));
+        expect(warningOnce).not.toHaveBeenCalled();
     });
 });

--- a/test/core/base-http-client.test.ts
+++ b/test/core/base-http-client.test.ts
@@ -1,7 +1,8 @@
 import http from 'node:http';
 import type { AddressInfo } from 'node:net';
 
-import { FetchHttpClient } from '@crawlee/http-client';
+import type { CustomFetchOptions } from '@crawlee/http-client';
+import { BaseHttpClient, FetchHttpClient } from '@crawlee/http-client';
 import { CookieJar } from 'tough-cookie';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
@@ -140,5 +141,33 @@ describe('BaseHttpClient cookie handling', () => {
         const body = (await response.json()) as { cookie: string };
 
         expect(body.cookie).toBe('header_only=value');
+    });
+});
+
+describe('BaseHttpClient TLS error handling', () => {
+    class CapturingHttpClient extends BaseHttpClient {
+        lastFetchOptions?: RequestInit & CustomFetchOptions;
+
+        override async fetch(request: Request, options?: RequestInit & CustomFetchOptions): Promise<Response> {
+            this.lastFetchOptions = options;
+            return fetch(request, options);
+        }
+    }
+
+    test('passes ignoreTlsErrors from session.proxyInfo to fetch', async () => {
+        const client = new CapturingHttpClient();
+        const session = { proxyInfo: { ignoreTlsErrors: true } } as any;
+
+        await client.sendRequest(new Request(url), { session });
+
+        expect(client.lastFetchOptions?.ignoreTlsErrors).toBe(true);
+    });
+
+    test('leaves ignoreTlsErrors unset without a session proxy', async () => {
+        const client = new CapturingHttpClient();
+
+        await client.sendRequest(new Request(url));
+
+        expect(client.lastFetchOptions?.ignoreTlsErrors).toBeUndefined();
     });
 });

--- a/test/core/base-http-client.test.ts
+++ b/test/core/base-http-client.test.ts
@@ -4,7 +4,7 @@ import type { AddressInfo } from 'node:net';
 import type { CustomFetchOptions } from '@crawlee/http-client';
 import { BaseHttpClient, FetchHttpClient } from '@crawlee/http-client';
 import { CookieJar } from 'tough-cookie';
-import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { afterAll, beforeAll, describe, expect, test, vitest } from 'vitest';
 
 let server: http.Server;
 let url: string;
@@ -186,5 +186,19 @@ describe('BaseHttpClient TLS error handling', () => {
         await client.sendRequest(new Request(url));
 
         expect(client.lastFetchOptions?.ignoreTlsErrors).toBeUndefined();
+    });
+
+    test('FetchHttpClient warns once when ignoreTlsErrors is requested', async () => {
+        const warning = vitest.fn();
+        const client = new FetchHttpClient({ logger: { warning } as any });
+
+        await client.sendRequest(new Request(url), { ignoreTlsErrors: true });
+        await client.sendRequest(new Request(url), { ignoreTlsErrors: true });
+        expect(warning).toHaveBeenCalledTimes(1);
+        expect(warning).toHaveBeenCalledWith(expect.stringContaining('ignoreTlsErrors'));
+
+        const quietClient = new FetchHttpClient({ logger: { warning } as any });
+        await quietClient.sendRequest(new Request(url));
+        expect(warning).toHaveBeenCalledTimes(1);
     });
 });

--- a/test/core/base-http-client.test.ts
+++ b/test/core/base-http-client.test.ts
@@ -163,6 +163,14 @@ describe('BaseHttpClient TLS error handling', () => {
         expect(client.lastFetchOptions?.ignoreTlsErrors).toBe(true);
     });
 
+    test('passes an explicit ignoreTlsErrors option to fetch', async () => {
+        const client = new CapturingHttpClient();
+
+        await client.sendRequest(new Request(url), { ignoreTlsErrors: true });
+
+        expect(client.lastFetchOptions?.ignoreTlsErrors).toBe(true);
+    });
+
     test('leaves ignoreTlsErrors unset without a session proxy', async () => {
         const client = new CapturingHttpClient();
 

--- a/test/core/base-http-client.test.ts
+++ b/test/core/base-http-client.test.ts
@@ -171,6 +171,15 @@ describe('BaseHttpClient TLS error handling', () => {
         expect(client.lastFetchOptions?.ignoreTlsErrors).toBe(true);
     });
 
+    test('session proxyInfo.ignoreTlsErrors wins over an explicit false option', async () => {
+        const client = new CapturingHttpClient();
+        const session = { proxyInfo: { ignoreTlsErrors: true } } as any;
+
+        await client.sendRequest(new Request(url), { session, ignoreTlsErrors: false });
+
+        expect(client.lastFetchOptions?.ignoreTlsErrors).toBe(true);
+    });
+
     test('leaves ignoreTlsErrors unset without a session proxy', async () => {
         const client = new CapturingHttpClient();
 

--- a/test/core/crawlers/basic_crawler.test.ts
+++ b/test/core/crawlers/basic_crawler.test.ts
@@ -2272,6 +2272,26 @@ describe('BasicCrawler', () => {
             ]);
         });
 
+        test('forwards ignoreTlsErrors to the http client', async () => {
+            const captured: (boolean | undefined)[] = [];
+
+            const crawler = new BasicCrawler({
+                httpClient: {
+                    async sendRequest(request, options) {
+                        captured.push(options?.ignoreTlsErrors);
+                        return new Response('ok');
+                    },
+                },
+                async requestHandler({ sendRequest }) {
+                    await sendRequest({}, { ignoreTlsErrors: true });
+                },
+            });
+
+            await crawler.run([url]);
+
+            expect(captured).toEqual([true]);
+        });
+
         test('proxyUrl TypeScript support', async () => {
             const crawler = new BasicCrawler({
                 async requestHandler({ sendRequest }) {

--- a/test/core/crawlers/cheerio_crawler.test.ts
+++ b/test/core/crawlers/cheerio_crawler.test.ts
@@ -201,23 +201,6 @@ describe('CheerioCrawler', () => {
         );
     });
 
-    test('should ignore ssl by default', async () => {
-        const sources = [{ url: 'http://example.com/?q=1' }];
-        const requestList = await RequestList.open(null, sources);
-        const requestHandler = () => {};
-
-        const cheerioCrawler = new CheerioCrawler({
-            requestList,
-            maxConcurrency: 1,
-            requestHandler,
-        });
-
-        await cheerioCrawler.run();
-
-        // @ts-expect-error Accessing private prop
-        expect(cheerioCrawler.ignoreSslErrors).toBeTruthy();
-    });
-
     test('should work with skipNavigation', async () => {
         const processed: Request[] = [];
         const failed: Request[] = [];

--- a/test/core/crawlers/cheerio_crawler.test.ts
+++ b/test/core/crawlers/cheerio_crawler.test.ts
@@ -201,6 +201,34 @@ describe('CheerioCrawler', () => {
         );
     });
 
+    test('forwards ignoreSslErrors to the http client as ignoreTlsErrors', async () => {
+        const captured: (boolean | undefined)[] = [];
+        const fetchClient = new FetchHttpClient();
+        const capturingClient = {
+            sendRequest: async (request: globalThis.Request, options?: { ignoreTlsErrors?: boolean }) => {
+                captured.push(options?.ignoreTlsErrors);
+                return fetchClient.sendRequest(request, options);
+            },
+        };
+
+        const defaultCrawler = new CheerioCrawler({
+            httpClient: capturingClient,
+            maxConcurrency: 1,
+            requestHandler: () => {},
+        });
+        await defaultCrawler.run([`${serverAddress}/?tls=default`]);
+
+        const strictCrawler = new CheerioCrawler({
+            httpClient: capturingClient,
+            ignoreSslErrors: false,
+            maxConcurrency: 1,
+            requestHandler: () => {},
+        });
+        await strictCrawler.run([`${serverAddress}/?tls=strict`]);
+
+        expect(captured).toEqual([true, false]);
+    });
+
     test('should work with skipNavigation', async () => {
         const processed: Request[] = [];
         const failed: Request[] = [];

--- a/test/core/crawlers/cheerio_crawler.test.ts
+++ b/test/core/crawlers/cheerio_crawler.test.ts
@@ -226,15 +226,7 @@ describe('CheerioCrawler', () => {
         });
         await strictCrawler.run([`${serverAddress}/?tls=strict`]);
 
-        const legacyCrawler = new CheerioCrawler({
-            httpClient: capturingClient,
-            ignoreSslErrors: false,
-            maxConcurrency: 1,
-            requestHandler: () => {},
-        });
-        await legacyCrawler.run([`${serverAddress}/?tls=legacy`]);
-
-        expect(captured).toEqual([true, false, false]);
+        expect(captured).toEqual([true, false]);
     });
 
     test('should work with skipNavigation', async () => {

--- a/test/core/crawlers/cheerio_crawler.test.ts
+++ b/test/core/crawlers/cheerio_crawler.test.ts
@@ -201,7 +201,7 @@ describe('CheerioCrawler', () => {
         );
     });
 
-    test('forwards ignoreSslErrors to the http client as ignoreTlsErrors', async () => {
+    test('forwards ignoreTlsErrors to the http client', async () => {
         const captured: (boolean | undefined)[] = [];
         const fetchClient = new FetchHttpClient();
         const capturingClient = {
@@ -220,13 +220,21 @@ describe('CheerioCrawler', () => {
 
         const strictCrawler = new CheerioCrawler({
             httpClient: capturingClient,
-            ignoreSslErrors: false,
+            ignoreTlsErrors: false,
             maxConcurrency: 1,
             requestHandler: () => {},
         });
         await strictCrawler.run([`${serverAddress}/?tls=strict`]);
 
-        expect(captured).toEqual([true, false]);
+        const legacyCrawler = new CheerioCrawler({
+            httpClient: capturingClient,
+            ignoreSslErrors: false,
+            maxConcurrency: 1,
+            requestHandler: () => {},
+        });
+        await legacyCrawler.run([`${serverAddress}/?tls=legacy`]);
+
+        expect(captured).toEqual([true, false, false]);
     });
 
     test('should work with skipNavigation', async () => {

--- a/test/core/got_scraping_http_client.test.ts
+++ b/test/core/got_scraping_http_client.test.ts
@@ -1,0 +1,34 @@
+import { GotScrapingHttpClient } from '@crawlee/got-scraping-client';
+import { gotScraping } from 'got-scraping';
+
+vi.mock('got-scraping', () => ({
+    gotScraping: vi.fn(async () => ({
+        rawBody: Buffer.from('ok'),
+        headers: { 'content-type': 'text/plain' },
+        statusCode: 200,
+        statusMessage: 'OK',
+        url: 'http://example.com/',
+    })),
+}));
+
+describe('GotScrapingHttpClient', () => {
+    beforeEach(() => {
+        vi.mocked(gotScraping).mockClear();
+    });
+
+    test('disables certificate verification when ignoreTlsErrors is set', async () => {
+        const httpClient = new GotScrapingHttpClient();
+
+        await httpClient.fetch(new Request('http://example.com'), { ignoreTlsErrors: true });
+
+        expect(gotScraping).toHaveBeenCalledWith(expect.objectContaining({ https: { rejectUnauthorized: false } }));
+    });
+
+    test('leaves certificate verification enabled without the flag', async () => {
+        const httpClient = new GotScrapingHttpClient();
+
+        await httpClient.fetch(new Request('http://example.com'), {});
+
+        expect(gotScraping).toHaveBeenCalledWith(expect.not.objectContaining({ https: expect.anything() }));
+    });
+});

--- a/test/core/impit_http_client.test.ts
+++ b/test/core/impit_http_client.test.ts
@@ -4,7 +4,7 @@ import { Impit } from 'impit';
 vi.mock('impit', () => ({
     Impit: vi.fn(
         class {
-            fetch = vi.fn();
+            fetch = vi.fn(async () => new Response('ok'));
         },
     ),
 }));
@@ -30,5 +30,21 @@ describe('ImpitHttpClient', () => {
         (httpClient as any).getClient({ proxyUrl: 'http://proxy.example' });
 
         expect(Impit).toHaveBeenCalledTimes(2);
+    });
+
+    test('forwards the per-request ignoreTlsErrors flag to the impit client', async () => {
+        const httpClient = new ImpitHttpClient();
+
+        await (httpClient as any).fetch(new Request('http://example.com'), { ignoreTlsErrors: true });
+
+        expect(Impit).toHaveBeenCalledWith(expect.objectContaining({ ignoreTlsErrors: true }));
+    });
+
+    test('keeps constructor-level ignoreTlsErrors when the per-request flag is absent', async () => {
+        const httpClient = new ImpitHttpClient({ ignoreTlsErrors: true });
+
+        await (httpClient as any).fetch(new Request('http://example.com'), {});
+
+        expect(Impit).toHaveBeenCalledWith(expect.objectContaining({ ignoreTlsErrors: true }));
     });
 });

--- a/test/core/impit_http_client.test.ts
+++ b/test/core/impit_http_client.test.ts
@@ -35,7 +35,7 @@ describe('ImpitHttpClient', () => {
     test('forwards the per-request ignoreTlsErrors flag to the impit client', async () => {
         const httpClient = new ImpitHttpClient();
 
-        await (httpClient as any).fetch(new Request('http://example.com'), { ignoreTlsErrors: true });
+        await httpClient.fetch(new Request('http://example.com'), { ignoreTlsErrors: true });
 
         expect(Impit).toHaveBeenCalledWith(expect.objectContaining({ ignoreTlsErrors: true }));
     });
@@ -43,7 +43,7 @@ describe('ImpitHttpClient', () => {
     test('keeps constructor-level ignoreTlsErrors when the per-request flag is absent', async () => {
         const httpClient = new ImpitHttpClient({ ignoreTlsErrors: true });
 
-        await (httpClient as any).fetch(new Request('http://example.com'), {});
+        await httpClient.fetch(new Request('http://example.com'), {});
 
         expect(Impit).toHaveBeenCalledWith(expect.objectContaining({ ignoreTlsErrors: true }));
     });

--- a/test/e2e/cheerio-ignore-ssl-errors/actor/main.js
+++ b/test/e2e/cheerio-ignore-ssl-errors/actor/main.js
@@ -1,6 +1,5 @@
 import { Actor } from 'apify';
 import { CheerioCrawler, Dataset } from '@crawlee/cheerio';
-import { ImpitHttpClient } from '@crawlee/impit-client';
 
 const mainOptions = {
     exit: Actor.isAtHome(),
@@ -12,7 +11,7 @@ const mainOptions = {
 
 await Actor.main(async () => {
     const crawler = new CheerioCrawler({
-        httpClient: new ImpitHttpClient({ ignoreTlsErrors: true }),
+        ignoreSslErrors: true,
         async requestHandler({ $, enqueueLinks, request, log }) {
             const {
                 url,

--- a/test/e2e/cheerio-ignore-ssl-errors/actor/main.js
+++ b/test/e2e/cheerio-ignore-ssl-errors/actor/main.js
@@ -1,5 +1,6 @@
 import { Actor } from 'apify';
 import { CheerioCrawler, Dataset } from '@crawlee/cheerio';
+import { ImpitHttpClient } from '@crawlee/impit-client';
 
 const mainOptions = {
     exit: Actor.isAtHome(),
@@ -11,7 +12,7 @@ const mainOptions = {
 
 await Actor.main(async () => {
     const crawler = new CheerioCrawler({
-        ignoreSslErrors: true,
+        httpClient: new ImpitHttpClient({ ignoreTlsErrors: true }),
         async requestHandler({ $, enqueueLinks, request, log }) {
             const {
                 url,

--- a/test/e2e/cheerio-ignore-ssl-errors/actor/main.js
+++ b/test/e2e/cheerio-ignore-ssl-errors/actor/main.js
@@ -11,7 +11,7 @@ const mainOptions = {
 
 await Actor.main(async () => {
     const crawler = new CheerioCrawler({
-        ignoreSslErrors: true,
+        ignoreTlsErrors: true,
         async requestHandler({ $, enqueueLinks, request, log }) {
             const {
                 url,

--- a/test/e2e/cheerio-ignore-ssl-errors/actor/package.json
+++ b/test/e2e/cheerio-ignore-ssl-errors/actor/package.json
@@ -9,7 +9,6 @@
         "@crawlee/browser-pool": "file:./packages/browser-pool",
         "@crawlee/http": "file:./packages/http-crawler",
         "@crawlee/cheerio": "file:./packages/cheerio-crawler",
-        "@crawlee/impit-client": "file:./packages/impit-client",
         "@crawlee/core": "file:./packages/core",
         "@crawlee/types": "file:./packages/types",
         "@crawlee/utils": "file:./packages/utils"

--- a/test/e2e/cheerio-ignore-ssl-errors/actor/package.json
+++ b/test/e2e/cheerio-ignore-ssl-errors/actor/package.json
@@ -9,6 +9,7 @@
         "@crawlee/browser-pool": "file:./packages/browser-pool",
         "@crawlee/http": "file:./packages/http-crawler",
         "@crawlee/cheerio": "file:./packages/cheerio-crawler",
+        "@crawlee/impit-client": "file:./packages/impit-client",
         "@crawlee/core": "file:./packages/core",
         "@crawlee/types": "file:./packages/types",
         "@crawlee/utils": "file:./packages/utils"

--- a/test/e2e/cheerio-throw-on-ssl-errors/actor/main.js
+++ b/test/e2e/cheerio-throw-on-ssl-errors/actor/main.js
@@ -11,7 +11,6 @@ const mainOptions = {
 
 await Actor.main(async () => {
     const crawler = new CheerioCrawler({
-        ignoreSslErrors: false,
         async requestHandler({ $, enqueueLinks, request, log }) {
             const {
                 userData: { label },

--- a/test/e2e/cheerio-throw-on-ssl-errors/actor/main.js
+++ b/test/e2e/cheerio-throw-on-ssl-errors/actor/main.js
@@ -11,7 +11,7 @@ const mainOptions = {
 
 await Actor.main(async () => {
     const crawler = new CheerioCrawler({
-        ignoreSslErrors: false,
+        ignoreTlsErrors: false,
         async requestHandler({ $, enqueueLinks, request, log }) {
             const {
                 userData: { label },

--- a/test/e2e/cheerio-throw-on-ssl-errors/actor/main.js
+++ b/test/e2e/cheerio-throw-on-ssl-errors/actor/main.js
@@ -11,6 +11,7 @@ const mainOptions = {
 
 await Actor.main(async () => {
     const crawler = new CheerioCrawler({
+        ignoreSslErrors: false,
         async requestHandler({ $, enqueueLinks, request, log }) {
             const {
                 userData: { label },


### PR DESCRIPTION
The `ignoreSslErrors` option stopped working during the v4 HTTP client interface rework: it was still folded into got-style request options, but those never reach `httpClient.sendRequest()`. In v3 the option works, and actors commonly expose it in their input schemas and pass it into crawler options (e.g. actor-scraper), so this keeps it working instead of removing it.

The option is renamed to `ignoreTlsErrors`, matching `session.proxyInfo.ignoreTlsErrors`, the browser pool, and the impit client (the old name is dropped, documented in the upgrading guide; actors migrating to v4 rename it in their own code, the SDK does not touch this option). The crawler forwards it (still defaulting to `true`, same as v3) as a new `SendRequestOptions.ignoreTlsErrors` flag, which `BaseHttpClient` also enables for MITM proxy sessions (previously equally dead). The impit client honors the flag; for custom clients it is best effort, and `FetchHttpClient` cannot disable TLS verification at all. The dead plumbing in `getRequestOptions()` is removed and unit tests cover the forwarding chain.
