### PR TITLE
feat: Improve sameDomainDelaySecs implementation via ThrottlingRequestManager

### DIFF
--- a/docs/guides/request_loaders.mdx
+++ b/docs/guides/request_loaders.mdx
@@ -191,7 +191,7 @@ const crawler = new CheerioCrawler({
 
 This is what the crawler's own <ApiLink to="basic-crawler/interface/BasicCrawlerOptions#sameDomainDelaySecs">`sameDomainDelaySecs`</ApiLink> option is built on — it wraps the crawler's request manager in a `ThrottlingRequestManager` configured exactly like the above. Dropping `minCrawlDelaySecs` is just as useful: 429 backoff and robots.txt `Crawl-delay` then apply to every domain, with no pacing of your own on top.
 
-A queue per domain is not free, so a run may only throttle `maxThrottledDomains` of them (1000 by default) before it throws. If you are crawling more domains than that, pace the crawl with `maxRequestsPerMinute` instead. The list of domains discovered so far is kept in the default key-value store, under `persistStateKey`, so that a restart reopens their queues rather than leaving whatever they still hold uncrawled.
+A queue per domain is not free, so a run may only throttle `maxThrottledDomains` of them (100 by default) before it throws. If you are crawling more domains than that, pace the crawl with `maxRequestsPerMinute` instead. The list of domains discovered so far is kept in the default key-value store, under `persistStateKey`, so that a restart reopens their queues rather than leaving whatever they still hold uncrawled.
 
 ## Request manager tandem
 

--- a/docs/guides/request_loaders.mdx
+++ b/docs/guides/request_loaders.mdx
@@ -162,13 +162,36 @@ Requests for a listed domain are routed into their own queue as they are added. 
 
 Because a throttled request costs no retries, a domain that never stops rate-limiting would otherwise keep the crawl alive forever. If one goes `maxDomainStallSecs` without letting a single request through, the crawl shuts down with a `PersistentRateLimitError` — at that point the concurrency is too high for that domain, or it has blocked you outright, and waiting longer will not help. Its requests are left in their queue on purpose, so re-running the crawl with `purgeOnStart` disabled resumes them if the rate limit lifts. A crawler running with `keepAlive` is exempt, since staying up regardless is what it was asked to do.
 
-This is opt-in and exact: only the domains you list are throttled, and matching is case-insensitive with no wildcard support, so list each subdomain you care about.
+Matching is exact and case-insensitive, with no wildcard support, so list each subdomain you care about — or set `throttleBy: 'registrableDomain'`, which groups a site and all of its subdomains under a single set of clocks.
 
-:::note robots.txt crawl-delay
+### The two clocks
 
-`ThrottlingRequestManager` is also what enforces `Crawl-delay` directives when `respectRobotsTxtFile` is enabled. Without it, or for a domain missing from `domains`, the directive is ignored and the crawler warns you about it.
+Every throttled domain runs two of them, and is dispatched to once both have run out:
 
-:::
+- **Backoff** — reactive and temporary, set by HTTP 429 responses and decaying once the domain stops turning you away.
+- **Crawl delay** — proactive and constant, a minimum interval between two dispatches, armed after each one. It is whatever the domain's robots.txt asks for (with `respectRobotsTxtFile` enabled), floored by `minCrawlDelaySecs`. A domain asking for longer gets longer.
+
+### Throttling every domain
+
+`domains: 'all'` gives a clock to each domain the crawl encounters instead of a fixed list, and a queue of its own the first time it is seen — so a domain that is waiting out a delay is skipped rather than repeatedly fetched and put back:
+
+```ts
+const crawler = new CheerioCrawler({
+    requestManager: new ThrottlingRequestManager({
+        inner: await RequestQueue.open(),
+        domains: 'all',
+        minCrawlDelaySecs: 1,
+        throttleBy: 'registrableDomain',
+    }),
+    requestHandler: async ({ request }) => {
+        // ...
+    },
+});
+```
+
+This is what the crawler's own <ApiLink to="basic-crawler/interface/BasicCrawlerOptions#sameDomainDelaySecs">`sameDomainDelaySecs`</ApiLink> option is built on — it wraps the crawler's request manager in a `ThrottlingRequestManager` configured exactly like the above. Dropping `minCrawlDelaySecs` is just as useful: 429 backoff and robots.txt `Crawl-delay` then apply to every domain, with no pacing of your own on top.
+
+A queue per domain is not free, so a run may only throttle `maxThrottledDomains` of them (1000 by default) before it throws. If you are crawling more domains than that, pace the crawl with `maxRequestsPerMinute` instead. The list of domains discovered so far is kept in the default key-value store, under `persistStateKey`, so that a restart reopens their queues rather than leaving whatever they still hold uncrawled.
 
 ## Request manager tandem
 

--- a/docs/public-api/crawlee-core.api.md
+++ b/docs/public-api/crawlee-core.api.md
@@ -2193,6 +2193,7 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
     // (undocumented)
     persistState(): Promise<void>;
     purge(): Promise<void>;
+    purgeDomainQueues(): Promise<void>;
     // (undocumented)
     reclaimRequest(request: Request_2, options?: RequestQueueOperationOptions): Promise<RequestQueueOperationInfo | null>;
     recordDomainDelay(url: string, retryAfterMs?: number | null): boolean;
@@ -2204,11 +2205,15 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
 // @public
 export interface ThrottlingRequestManagerOptions<T extends IRequestManager = IRequestManager> {
     baseDelaySecs?: number;
-    domains: string[];
+    domains: string[] | 'all';
     inner: T;
     maxDelaySecs?: number;
     maxDomainStallSecs?: number;
+    maxThrottledDomains?: number;
+    minCrawlDelaySecs?: number;
+    persistStateKey?: string;
     requestManagerOpener?: RequestManagerOpener<T>;
+    throttleBy?: 'hostname' | 'registrableDomain';
 }
 
 export { tryAbsoluteURL }

--- a/docs/upgrading/upgrading_v4.md
+++ b/docs/upgrading/upgrading_v4.md
@@ -1369,6 +1369,14 @@ For the domains you list, a 429 is treated as a rate limit before `blockedStatus
 
 It is also what enforces robots.txt `Crawl-delay` directives — with `respectRobotsTxtFile` enabled and no throttling manager covering the domain, the directive is ignored and the crawler warns about it. See the [request loaders guide](../guides/request-loaders#per-domain-throttling).
 
+#### `sameDomainDelaySecs` is now backed by `ThrottlingRequestManager`
+
+The option means the same thing as in v3 — subdomains included, it still paces a whole site rather than a single host — but it no longer holds delayed requests in memory and re-enqueues them. The crawler now wraps its request manager in a `ThrottlingRequestManager`, which gives every domain a request queue of its own so a delayed request waits in storage. Consequences worth knowing about:
+
+- A crawl that discovers more than `maxThrottledDomains` domains (1000 by default) throws instead of quietly running out of steam. Pass your own `ThrottlingRequestManager` as `requestManager` to raise the ceiling — or crawl fewer sites.
+- Combining `sameDomainDelaySecs` with a `requestManager` that throttles per domain on its own now throws. Configure the delay on that manager instead, via its `domains: 'all'` and `minCrawlDelaySecs` options.
+- Requests that never pass through the request manager — those from the deprecated `requestList` option, or from a `requestsFromUrl` list — are not paced, and the crawler warns when it hands one out.
+
 #### `BasicCrawler.requestList` and `BasicCrawler.requestQueue` fields removed
 
 The public `requestList` and `requestQueue` instance fields are gone. The crawler exposes a single `protected requestManager?: IRequestManager` instead. Access the active manager via the new async `getRequestManager()` method.

--- a/docs/upgrading/upgrading_v4.md
+++ b/docs/upgrading/upgrading_v4.md
@@ -1373,7 +1373,7 @@ It is also what enforces robots.txt `Crawl-delay` directives — with `respectRo
 
 The option means the same thing as in v3 — subdomains included, it still paces a whole site rather than a single host — but it no longer holds delayed requests in memory and re-enqueues them. The crawler now wraps its request manager in a `ThrottlingRequestManager`, which gives every domain a request queue of its own so a delayed request waits in storage. Consequences worth knowing about:
 
-- A crawl that discovers more than `maxThrottledDomains` domains (1000 by default) throws instead of quietly running out of steam. Pass your own `ThrottlingRequestManager` as `requestManager` to raise the ceiling — or crawl fewer sites.
+- A crawl that discovers more than `maxThrottledDomains` domains (100 by default) throws instead of quietly running out of steam. Pass your own `ThrottlingRequestManager` as `requestManager` to raise the ceiling — or crawl fewer sites.
 - Combining `sameDomainDelaySecs` with a `requestManager` that throttles per domain on its own now throws. Configure the delay on that manager instead, via its `domains: 'all'` and `minCrawlDelaySecs` options.
 - Requests that never pass through the request manager — those from the deprecated `requestList` option, or from a `requestsFromUrl` list — are not paced, and the crawler warns when it hands one out.
 

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -76,6 +76,7 @@ import {
     SessionError,
     SessionPool,
     Statistics,
+    ThrottlingRequestManager,
     validateUserData,
     validators,
     withDirectStorageAccess,
@@ -316,7 +317,11 @@ export interface BasicCrawlerOptions<
     maxRequestRetries?: number;
 
     /**
-     * Indicates how much time (in seconds) to wait before crawling another same domain request.
+     * Indicates how much time (in seconds) to wait before crawling another same domain request. Subdomains are
+     * paced together with the site they belong to.
+     *
+     * Wraps the crawler's request manager in a {@apilink ThrottlingRequestManager}; pass one as `requestManager`
+     * yourself to configure it further.
      * @default 0
      */
     sameDomainDelaySecs?: number;
@@ -796,8 +801,7 @@ export class BasicCrawler<
     protected readonly internalTimeoutMillis: number;
     protected readonly maxRequestRetries: number;
     protected readonly maxCrawlDepth?: number;
-    #sameDomainDelayMillis: number;
-    #domainAccessedTime: Map<string, number>;
+    #sameDomainDelaySecs: number;
     protected readonly maxRequestsPerCrawl?: number;
 
     private get handledRequestsCount(): number {
@@ -1011,6 +1015,16 @@ export class BasicCrawler<
                         'The `requestManager` option cannot be used in conjunction with `requestList` and/or `requestQueue`',
                     );
                 }
+                // Both would pace the same domains, from different keys and with no idea of one another.
+                if (sameDomainDelaySecs > 0 && supportsDomainThrottling(requestManager)) {
+                    throw new ArgumentError(
+                        'The `sameDomainDelaySecs` option cannot be combined with a `requestManager` that throttles ' +
+                            'per domain on its own. Configure the delay on the manager instead, via the ' +
+                            '`sameDomainDelaySecs` option of `ThrottlingRequestManager`.',
+                        this.constructor,
+                    );
+                }
+
                 this.requestManager = requestManager;
             } else if (requestList !== undefined && requestQueue !== undefined) {
                 // Combine the read-only list with the writable queue into a tandem.
@@ -1029,7 +1043,6 @@ export class BasicCrawler<
             this.proxyConfiguration = proxyConfiguration;
             this.#statusMessageLoggingInterval = statusMessageLoggingInterval;
             this.#statusMessageCallback = statusMessageCallback as StatusMessageCallback;
-            this.#domainAccessedTime = new Map();
             this.#robotsTxtFileCache = new LruCache({ maxLength: 1000 });
             this.handleSkippedRequest = this.handleSkippedRequest.bind(this);
 
@@ -1064,7 +1077,7 @@ export class BasicCrawler<
 
             this.maxRequestRetries = maxRequestRetries;
             this.maxCrawlDepth = maxCrawlDepth;
-            this.#sameDomainDelayMillis = sameDomainDelaySecs * 1000;
+            this.#sameDomainDelaySecs = sameDomainDelaySecs;
             this.#statsDep = OwnedOrInjected.resolve<IStatistics, Statistics>(
                 statistics,
                 () =>
@@ -1130,7 +1143,7 @@ export class BasicCrawler<
                     if (!source) throw new Error('Request provider is not initialized!');
 
                     const request = await this.resolveRequest();
-                    if (!request || this.delayRequest(request, source)) {
+                    if (!request) {
                         return;
                     }
 
@@ -1595,8 +1608,15 @@ export class BasicCrawler<
             const managerToPurge =
                 this.#ownedRequestQueue.maybeValue ?? (purgeRequestQueue === true ? this.requestManager : undefined);
 
-            if (managerToPurge?.purge && shouldPurge) {
-                await managerToPurge.purge();
+            if (shouldPurge) {
+                await managerToPurge?.purge?.();
+
+                // The per-domain queues a `sameDomainDelaySecs` wrapper created are the crawler's own, whatever
+                // sits underneath them - so they are emptied even when the manager they wrap is spared. Purging
+                // the wrapper itself has already covered them.
+                if (this.requestManager instanceof ThrottlingRequestManager && managerToPurge !== this.requestManager) {
+                    await this.requestManager.purgeDomainQueues();
+                }
             }
 
             // A supplied statistics instance keeps whatever state it was handed - only wipe a default we built.
@@ -1765,6 +1785,20 @@ export class BasicCrawler<
     async getRequestManager(): Promise<IRequestManager> {
         if (!this.requestManager) {
             this.requestManager = await this.openOwnedRequestQueue();
+        }
+
+        // Wrapped here rather than in the constructor, because the manager being wrapped may only be opened at
+        // this point - and because everything that enqueues goes through here first, so nothing slips past the
+        // wrapper into the queue it hides.
+        if (this.#sameDomainDelaySecs > 0 && !supportsDomainThrottling(this.requestManager)) {
+            this.requestManager = new ThrottlingRequestManager({
+                inner: this.requestManager,
+                domains: 'all',
+                minCrawlDelaySecs: this.#sameDomainDelaySecs,
+                // What `sameDomainDelaySecs` has always meant: one clock for a site, subdomains included.
+                throttleBy: 'registrableDomain',
+                persistStateKey: `CRAWLEE_THROTTLED_DOMAINS_${this.identity.id}`,
+            });
         }
 
         // Apply the processing-time hint here (an async lifecycle point) rather than in the constructor,
@@ -2386,39 +2420,6 @@ export class BasicCrawler<
         }
 
         return this.requestManager.fetchNextRequest();
-    }
-
-    /**
-     * Delays processing of the request based on the `sameDomainDelaySecs` option,
-     * adding it back to the queue after the timeout passes. Returns `true` if the request
-     * should be ignored and will be reclaimed to the queue once ready.
-     */
-    private delayRequest(request: Request, source: IRequestManager) {
-        const domain = getDomain(request.url);
-
-        if (!domain || !request) {
-            return false;
-        }
-
-        const now = Date.now();
-        const lastAccessTime = this.#domainAccessedTime.get(domain);
-
-        if (!lastAccessTime || now - lastAccessTime >= this.#sameDomainDelayMillis) {
-            this.#domainAccessedTime.set(domain, now);
-            return false;
-        }
-
-        const delay = lastAccessTime + this.#sameDomainDelayMillis - now;
-        this.log.debug(
-            `Request ${request.url} (${request.id}) will be reclaimed after ${delay} milliseconds due to same domain delay`,
-        );
-        setTimeout(async () => {
-            this.log.debug(`Adding request ${request.url} (${request.id}) back to the queue`);
-
-            await source.reclaimRequest(request, { forefront: request.userData?.__crawlee?.forefront });
-        }, delay);
-
-        return true;
     }
 
     /** Handles a single request - runs the request handler with retries, error handling, and lifecycle management. */

--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -1017,11 +1017,10 @@ export class BasicCrawler<
                 }
                 // Both would pace the same domains, from different keys and with no idea of one another.
                 if (sameDomainDelaySecs > 0 && supportsDomainThrottling(requestManager)) {
-                    throw new ArgumentError(
+                    throw new Error(
                         'The `sameDomainDelaySecs` option cannot be combined with a `requestManager` that throttles ' +
                             'per domain on its own. Configure the delay on the manager instead, via the ' +
-                            '`sameDomainDelaySecs` option of `ThrottlingRequestManager`.',
-                        this.constructor,
+                            '`minCrawlDelaySecs` option of `ThrottlingRequestManager`.',
                     );
                 }
 

--- a/packages/core/src/events/event_manager.ts
+++ b/packages/core/src/events/event_manager.ts
@@ -66,7 +66,8 @@ export abstract class EventManager {
 
     constructor(options: EventManagerOptions) {
         this.#persistStateIntervalMillis = options.persistStateIntervalMillis;
-        this.events.setMaxListeners(50);
+        // One MIGRATING listener per RequestQueue, and ThrottlingRequestManager opens one per domain.
+        this.events.setMaxListeners(150);
     }
 
     /**

--- a/packages/core/src/storages/throttling_request_manager.ts
+++ b/packages/core/src/storages/throttling_request_manager.ts
@@ -35,9 +35,7 @@ const throttlingRequestManagerOptionsSchema = z.strictObject({
         .refine((value) => value >= 0, 'Expected a number greater than or equal to 0')
         .optional(),
     throttleBy: z.enum(['hostname', 'registrableDomain']).optional(),
-    maxThrottledDomains: schemas.anyNumber
-        .refine((value) => value > 0, 'Expected a number greater than 0')
-        .optional(),
+    maxThrottledDomains: schemas.anyNumber.refine((value) => value > 0, 'Expected a number greater than 0').optional(),
     persistStateKey: z.string().nonempty().optional(),
 });
 

--- a/packages/core/src/storages/throttling_request_manager.ts
+++ b/packages/core/src/storages/throttling_request_manager.ts
@@ -129,7 +129,7 @@ export interface ThrottlingRequestManagerOptions<T extends IRequestManager = IRe
      * bound would drown the storage backend in them.
      *
      * Only domains discovered under `domains: 'all'` count against this; an explicit list is taken at face value.
-     * @default 1000
+     * @default 100
      */
     maxThrottledDomains?: number;
 
@@ -271,56 +271,58 @@ const DEFAULT_PERSIST_STATE_KEY = 'CRAWLEE_THROTTLED_DOMAINS';
 export class ThrottlingRequestManager<T extends IRequestManager = IRequestManager>
     implements IRequestManager, SupportsDomainThrottling
 {
-    private readonly inner: T;
-    private readonly requestManagerOpener: RequestManagerOpener<T>;
-    private readonly baseDelayMs: number;
-    private readonly maxDelayMs: number;
-    private readonly maxDomainStallMs: number;
-    private readonly minCrawlDelayMs: number;
-    private readonly throttlesEveryDomain: boolean;
-    private readonly throttleBy: 'hostname' | 'registrableDomain';
-    private readonly maxThrottledDomains: number;
-    private readonly persistStateKey: string;
+    readonly #inner: T;
+    readonly #requestManagerOpener: RequestManagerOpener<T>;
+    readonly #baseDelayMs: number;
+    readonly #maxDelayMs: number;
+    readonly #maxDomainStallMs: number;
+    readonly #minCrawlDelayMs: number;
+    readonly #throttlesEveryDomain: boolean;
+    readonly #throttleBy: 'hostname' | 'registrableDomain';
+    readonly #maxThrottledDomains: number;
+    readonly #persistStateKey: string;
 
+    readonly #subManagers = new Map<string, Promise<T>>();
+
+    // Not `#private`, unlike the rest: the tests reach for these two.
     private readonly domainStates = new Map<string, DomainState>();
-    private readonly subManagers = new Map<string, Promise<T>>();
     private readonly log: CrawleeLogger;
 
     /** Domains from the `domains` option, which are throttled whether or not the crawl ever visits them. */
-    private readonly listedDomains = new Set<string>();
+    readonly #listedDomains = new Set<string>();
 
     /**
      * Domains picked up at runtime under `domains: 'all'`. Persisted, because unlike the listed ones there
      * is nothing to rediscover them from at startup - and a sub-queue nobody reopens is a sub-queue whose
      * requests are never crawled.
      */
-    private readonly discoveredDomains = new Set<string>();
+    readonly #discoveredDomains = new Set<string>();
 
     /**
      * Requests currently held by the consumer that came out of the wrapped manager rather than a sub-queue.
      * They have to go back where they came from: routing them by domain would mark them handled in a queue
      * that has never heard of them, leaving the wrapped manager to hand them out over and over.
      */
-    private readonly inFlightFromInner = new Set<string>();
-    private domainListStore?: KeyValueStore;
-    private lastDomainListWrite: Promise<unknown> = Promise.resolve();
-    private queuedDomainListWrite?: Promise<void>;
+    readonly #inFlightFromInner = new Set<string>();
+    #domainListStore?: KeyValueStore;
+    #lastDomainListWrite: Promise<unknown> = Promise.resolve();
+    #queuedDomainListWrite?: Promise<void>;
 
     /**
      * Sub-managers are keyed by a stable alias, so with `purgeOnStart` disabled they outlive the process. They
      * must therefore be reopened for every known domain rather than created on first insert - otherwise a
      * restart sees an empty map, reports the crawl finished, and strands whatever the previous run left in them.
      */
-    private subManagersReady?: Promise<void>;
+    #subManagersReady?: Promise<void>;
 
     /** Batches still being added in the background; keeps {@apilink ThrottlingRequestManager.isFinished} honest. */
-    private inProgressBatchCount = 0;
+    #inProgressBatchCount = 0;
 
-    private readonly warnedAbout = new Set<string>();
+    readonly #warnedAbout = new Set<string>();
 
     /** Whether any domain at all may end up throttled - listed up front, or discovered as the crawl runs. */
-    private get throttlingEnabled(): boolean {
-        return this.listedDomains.size > 0 || this.throttlesEveryDomain;
+    get #throttlingEnabled(): boolean {
+        return this.#listedDomains.size > 0 || this.#throttlesEveryDomain;
     }
 
     constructor(
@@ -329,18 +331,18 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
     ) {
         parseArgument(options, throttlingRequestManagerOptionsSchema, 'ThrottlingRequestManagerOptions');
 
-        this.inner = options.inner;
-        this.requestManagerOpener =
+        this.#inner = options.inner;
+        this.#requestManagerOpener =
             options.requestManagerOpener ??
             ((idOrAlias, opts) => RequestQueue.open(idOrAlias, opts) as unknown as Promise<T>);
-        this.baseDelayMs = (options.baseDelaySecs ?? 2) * 1000;
-        this.maxDelayMs = (options.maxDelaySecs ?? 60) * 1000;
-        this.maxDomainStallMs = (options.maxDomainStallSecs ?? 900) * 1000;
-        this.minCrawlDelayMs = (options.minCrawlDelaySecs ?? 0) * 1000;
-        this.throttlesEveryDomain = options.domains === 'all';
-        this.throttleBy = options.throttleBy ?? 'hostname';
-        this.maxThrottledDomains = options.maxThrottledDomains ?? 1000;
-        this.persistStateKey = options.persistStateKey ?? DEFAULT_PERSIST_STATE_KEY;
+        this.#baseDelayMs = (options.baseDelaySecs ?? 2) * 1000;
+        this.#maxDelayMs = (options.maxDelaySecs ?? 60) * 1000;
+        this.#maxDomainStallMs = (options.maxDomainStallSecs ?? 900) * 1000;
+        this.#minCrawlDelayMs = (options.minCrawlDelaySecs ?? 0) * 1000;
+        this.#throttlesEveryDomain = options.domains === 'all';
+        this.#throttleBy = options.throttleBy ?? 'hostname';
+        this.#maxThrottledDomains = options.maxThrottledDomains ?? 100;
+        this.#persistStateKey = options.persistStateKey ?? DEFAULT_PERSIST_STATE_KEY;
         this.log = serviceLocator.getLogger().child({ prefix: 'ThrottlingRequestManager' });
 
         for (const domain of Array.isArray(options.domains) ? options.domains : []) {
@@ -355,8 +357,8 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
                 );
             }
 
-            const key = this.domainKey(hostname);
-            this.listedDomains.add(key);
+            const key = this.#domainKey(hostname);
+            this.#listedDomains.add(key);
             this.domainStates.set(key, newDomainState(key));
         }
     }
@@ -366,10 +368,10 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
      *
      * @param hostname A hostname as `URL` reports it, so in punycode and possibly with a root dot.
      */
-    private domainKey(hostname: string): string {
+    #domainKey(hostname: string): string {
         const normalized = normalizeHostname(hostname);
 
-        if (this.throttleBy === 'hostname') {
+        if (this.#throttleBy === 'hostname') {
             return normalized;
         }
 
@@ -380,15 +382,15 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
 
     /** The wrapped manager, holding every request whose domain is not throttled. */
     get innerManager(): T {
-        return this.inner;
+        return this.#inner;
     }
 
     /** Warns once about sources that cannot be routed by domain, because their URLs are not known yet. */
-    private warnIfNotRoutable(requestLike: Source): void {
-        if ('requestsFromUrl' in requestLike && requestLike.requestsFromUrl !== undefined && this.throttlingEnabled) {
+    #warnIfNotRoutable(requestLike: Source): void {
+        if ('requestsFromUrl' in requestLike && requestLike.requestsFromUrl !== undefined && this.#throttlingEnabled) {
             // The URL list is only fetched once the owning manager expands it, so we cannot know which domains
             // it covers and cannot route it. Warn instead of silently exempting those URLs from throttling.
-            this.warnOnce(
+            this.#warnOnce(
                 'urlListNotRouted',
                 `Requests loaded via \`requestsFromUrl\` cannot be routed to a per-domain queue, because their URLs ` +
                     `are not known at insertion time. They will be added to the inner request manager and will not ` +
@@ -397,84 +399,100 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
         }
     }
 
-    private warnOnce(key: string, message: string): void {
-        if (this.warnedAbout.has(key)) {
+    #warnOnce(key: string, message: string): void {
+        if (this.#warnedAbout.has(key)) {
             return;
         }
-        this.warnedAbout.add(key);
+        this.#warnedAbout.add(key);
         this.log.warning(message);
     }
 
-    private extractDomain(url: string): string {
+    #extractDomain(url: string): string {
         try {
-            return this.domainKey(new URL(url).hostname);
+            return this.#domainKey(new URL(url).hostname);
         } catch {
             return '';
         }
     }
 
-    private getDomainState(url: string): DomainState | null {
-        const domain = this.extractDomain(url);
+    #getDomainState(url: string): DomainState | null {
+        const domain = this.#extractDomain(url);
         return this.domainStates.get(domain) ?? null;
     }
 
     /**
      * The manager that owns a URL's requests, opening a sub-queue for its domain if this is the first time we
-     * have seen it and every domain is throttled.
+     * have seen it and every domain is throttled. `null` means the domain is new and `maxThrottledDomains`
+     * leaves no room for it.
      */
-    private async selectManager(url: string): Promise<T> {
-        await this.ensureSubManagers();
+    async #selectManager(url: string): Promise<T | null> {
+        await this.#ensureSubManagers();
 
-        const domain = this.extractDomain(url);
+        const domain = this.#extractDomain(url);
 
-        if (!domain || !(this.listedDomains.has(domain) || this.throttlesEveryDomain)) {
-            return this.inner;
+        if (!domain || !(this.#listedDomains.has(domain) || this.#throttlesEveryDomain)) {
+            return this.#inner;
         }
 
-        if (!this.listedDomains.has(domain) && !this.discoveredDomains.has(domain)) {
-            this.assertRoomForDomain(domain);
-            this.discoveredDomains.add(domain);
+        if (!this.#listedDomains.has(domain) && !this.#discoveredDomains.has(domain)) {
+            if (this.#discoveredDomains.size >= this.#maxThrottledDomains) {
+                return null;
+            }
+
+            this.#discoveredDomains.add(domain);
             // Written before the request lands in the sub-queue: a crash in between would leave that queue
             // with nothing to reopen it, and the crawl would silently drop everything in it.
-            await this.persistDiscoveredDomains();
+            await this.#persistDiscoveredDomains();
         }
 
-        return this.subManagerFor(domain);
+        return this.#subManagerFor(domain);
     }
 
-    private assertRoomForDomain(domain: string): void {
-        if (this.discoveredDomains.size < this.maxThrottledDomains) {
-            return;
+    async #selectManagerOrThrow(url: string): Promise<T> {
+        const manager = await this.#selectManager(url);
+
+        if (!manager) {
+            throw this.#throttledDomainLimitError([this.#extractDomain(url)]);
         }
 
-        throw new Error(
-            `Refusing to throttle "${domain}": ${this.maxThrottledDomains} domains are already being throttled ` +
-                `(\`maxThrottledDomains\`). Each of them holds a request queue of its own, so a crawl that keeps ` +
-                `discovering new domains will bury the storage backend in them. Narrow the crawl down, pace it ` +
-                `with \`maxRequestsPerMinute\` instead, or raise \`maxThrottledDomains\` if you are prepared to ` +
-                `pay for it.`,
+        return manager;
+    }
+
+    #throttledDomainLimitError(domains: string[]): Error {
+        const [first, ...rest] = domains;
+        const named = rest.slice(0, 10);
+        const ellipsis = rest.length > named.length ? ', ...' : '';
+        const others =
+            rest.length > 0 ? ` (and ${rest.length} other new domain(s): ${named.join(', ')}${ellipsis})` : '';
+
+        return new Error(
+            `Refusing to throttle "${first}"${others}: ${this.#maxThrottledDomains} domains are already being ` +
+                `throttled (\`maxThrottledDomains\`). Each of them holds a request queue of its own, so a crawl ` +
+                `that keeps discovering new domains will bury the storage backend in them. Narrow the crawl down, ` +
+                `pace it with \`maxRequestsPerMinute\` instead, or raise \`maxThrottledDomains\` if you are ` +
+                `prepared to pay for it.`,
         );
     }
 
     /** Opens the domain's sub-queue, or returns the one already opened (or being opened) for it. */
-    private subManagerFor(domain: string): Promise<T> {
-        let subManager = this.subManagers.get(domain);
+    #subManagerFor(domain: string): Promise<T> {
+        let subManager = this.#subManagers.get(domain);
 
         if (!subManager) {
-            subManager = this.requestManagerOpener(
+            subManager = this.#requestManagerOpener(
                 // Backends use the alias as a directory name, and an IPv6 literal is full of characters
                 // Windows will not accept. Ordinary hostnames survive this untouched.
                 { alias: `throttled-${encodeURIComponent(domain)}` },
                 { configuration: this.config },
             );
-            this.subManagers.set(domain, subManager);
-            this.ensureDomainState(domain);
+            this.#subManagers.set(domain, subManager);
+            this.#ensureDomainState(domain);
         }
 
         return subManager;
     }
 
-    private ensureDomainState(domain: string): DomainState {
+    #ensureDomainState(domain: string): DomainState {
         let state = this.domainStates.get(domain);
 
         if (!state) {
@@ -489,42 +507,42 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
      * Coalesces the writes of the discovered domain list: callers that arrive while one is in flight share the
      * single write queued behind it, which snapshots the set once it starts and so covers all of them.
      */
-    private async persistDiscoveredDomains(): Promise<void> {
-        this.queuedDomainListWrite ??= this.lastDomainListWrite
+    async #persistDiscoveredDomains(): Promise<void> {
+        this.#queuedDomainListWrite ??= this.#lastDomainListWrite
             // A failed write must not poison the ones behind it - they will rewrite the whole set anyway.
             .catch(() => {})
             .then(async () => {
-                this.queuedDomainListWrite = undefined;
-                await this.domainListStore!.setValue(this.persistStateKey, Array.from(this.discoveredDomains));
+                this.#queuedDomainListWrite = undefined;
+                await this.#domainListStore!.setValue(this.#persistStateKey, Array.from(this.#discoveredDomains));
             });
-        this.lastDomainListWrite = this.queuedDomainListWrite;
+        this.#lastDomainListWrite = this.#queuedDomainListWrite;
 
-        await this.queuedDomainListWrite;
+        await this.#queuedDomainListWrite;
     }
 
-    private async ensureSubManagers(): Promise<void> {
-        this.subManagersReady ??= (async () => {
-            if (this.throttlesEveryDomain) {
-                this.domainListStore = await KeyValueStore.open(null, { configuration: this.config });
+    async #ensureSubManagers(): Promise<void> {
+        this.#subManagersReady ??= (async () => {
+            if (this.#throttlesEveryDomain) {
+                this.#domainListStore = await KeyValueStore.open(null, { configuration: this.config });
 
-                for (const domain of (await this.domainListStore.getValue<string[]>(this.persistStateKey)) ?? []) {
-                    this.discoveredDomains.add(domain);
+                for (const domain of (await this.#domainListStore.getValue<string[]>(this.#persistStateKey)) ?? []) {
+                    this.#discoveredDomains.add(domain);
                 }
             }
 
             await Promise.all(
-                Array.from([...this.listedDomains, ...this.discoveredDomains], async (domain) =>
-                    this.subManagerFor(domain),
+                Array.from([...this.#listedDomains, ...this.#discoveredDomains], async (domain) =>
+                    this.#subManagerFor(domain),
                 ),
             );
         })();
 
-        await this.subManagersReady;
+        await this.#subManagersReady;
     }
 
-    private async getSubManagers(): Promise<T[]> {
-        await this.ensureSubManagers();
-        return Promise.all(this.subManagers.values());
+    async #getSubManagers(): Promise<T[]> {
+        await this.#ensureSubManagers();
+        return Promise.all(this.#subManagers.values());
     }
 
     /**
@@ -533,10 +551,10 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
      * A domain whose sub-queue has not been opened yet is skipped - a robots.txt `Crawl-delay` gives a domain a
      * clock before its first request gives it a queue, and there is nothing to fetch from until then.
      */
-    private fetchableDomains(): string[] {
+    #fetchableDomains(): string[] {
         const now = Date.now();
         return Array.from(this.domainStates.values())
-            .filter((state) => now >= throttledUntil(state) && this.subManagers.has(state.domain))
+            .filter((state) => now >= throttledUntil(state) && this.#subManagers.has(state.domain))
             .sort((a, b) => throttledUntil(a) - throttledUntil(b))
             .map((state) => state.domain);
     }
@@ -547,7 +565,7 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
      * @returns `false` if the domain is not configured for throttling, in which case this is a no-op.
      */
     recordDomainDelay(url: string, retryAfterMs?: number | null): boolean {
-        const state = this.getDomainState(url);
+        const state = this.#getDomainState(url);
         if (!state) {
             return false;
         }
@@ -578,16 +596,16 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
         state.consecutive429Count += 1;
 
         const retryAfterGiven = retryAfterMs !== undefined && retryAfterMs !== null;
-        let delayMs = retryAfterGiven ? retryAfterMs : this.baseDelayMs * Math.pow(2, state.consecutive429Count - 1);
+        let delayMs = retryAfterGiven ? retryAfterMs : this.#baseDelayMs * Math.pow(2, state.consecutive429Count - 1);
 
-        if (delayMs > this.maxDelayMs) {
+        if (delayMs > this.#maxDelayMs) {
             const source = retryAfterGiven ? 'Retry-After header' : 'exponential backoff';
             this.log.warning(
                 `Capping ${source} delay of ${(delayMs / 1000).toFixed(1)}s for domain "${state.domain}" ` +
-                    `to maxDelaySecs (${(this.maxDelayMs / 1000).toFixed(1)}s); the domain may continue to rate-limit. ` +
+                    `to maxDelaySecs (${(this.#maxDelayMs / 1000).toFixed(1)}s); the domain may continue to rate-limit. ` +
                     `Consider increasing maxDelaySecs if this recurs.`,
             );
-            delayMs = this.maxDelayMs;
+            delayMs = this.#maxDelayMs;
         }
 
         state.backoffUntil = now + delayMs;
@@ -610,15 +628,15 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
      * @returns `false` if the domain is not throttled, in which case this is a no-op.
      */
     setCrawlDelay(url: string, delaySeconds: number): boolean {
-        const domain = this.extractDomain(url);
+        const domain = this.#extractDomain(url);
 
-        if (!domain || !(this.listedDomains.has(domain) || this.throttlesEveryDomain)) {
+        if (!domain || !(this.#listedDomains.has(domain) || this.#throttlesEveryDomain)) {
             return false;
         }
 
         // The crawler reads robots.txt before it enqueues a domain's first request, so the clock can predate
         // the sub-queue it will end up pacing.
-        const state = this.ensureDomainState(domain);
+        const state = this.#ensureDomainState(domain);
 
         if (state.declaredCrawlDelayMs === null) {
             state.declaredCrawlDelayMs = delaySeconds * 1000;
@@ -638,7 +656,7 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
      * `Crawl-delay` is being obeyed, not stonewalled.
      */
     async assertNoStalledDomains(): Promise<void> {
-        await this.ensureSubManagers();
+        await this.#ensureSubManagers();
 
         const now = Date.now();
         const candidates = Array.from(this.domainStates.values()).filter(
@@ -647,14 +665,14 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
             // arriving with the idle time already on it.
             (state) =>
                 state.rateLimitedSince !== 0 &&
-                now - state.lastRateLimitedAt <= this.maxDomainStallMs &&
-                now - state.rateLimitedSince > this.maxDomainStallMs,
+                now - state.lastRateLimitedAt <= this.#maxDomainStallMs &&
+                now - state.rateLimitedSince > this.#maxDomainStallMs,
         );
 
         const stalled = (
             await Promise.all(
                 candidates.map(async (state) => {
-                    const subManager = await this.subManagers.get(state.domain);
+                    const subManager = await this.#subManagers.get(state.domain);
                     return subManager && !(await subManager.isEmpty()) ? state : null;
                 }),
             )
@@ -670,15 +688,15 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
 
         throw new PersistentRateLimitError(
             `Giving up: ${summary} rate-limited every request for longer than maxDomainStallSecs ` +
-                `(${(this.maxDomainStallMs / 1000).toFixed(0)}s). Waiting longer will not help - lower the ` +
+                `(${(this.#maxDomainStallMs / 1000).toFixed(0)}s). Waiting longer will not help - lower the ` +
                 `crawler's concurrency, or drop these domains. Their requests are still queued, so re-running ` +
                 `with \`purgeOnStart\` disabled will resume them if the rate limit lifts.`,
         );
     }
 
     /** Records that a domain let a request through, which ends any rate-limit run stall detection was timing. */
-    private recordProgress(url: string): void {
-        const state = this.getDomainState(url);
+    #recordProgress(url: string): void {
+        const state = this.#getDomainState(url);
         if (state) {
             state.rateLimitedSince = 0;
         }
@@ -687,9 +705,9 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
     // --- IRequestManager Implementation ---
 
     async addRequest(requestLike: Source, options?: RequestQueueOperationOptions): Promise<RequestQueueOperationInfo> {
-        this.warnIfNotRoutable(requestLike);
+        this.#warnIfNotRoutable(requestLike);
 
-        const manager = await this.selectManager(requestLike.url ?? '');
+        const manager = await this.#selectManagerOrThrow(requestLike.url ?? '');
         return manager.addRequest(requestLike, options);
     }
 
@@ -704,7 +722,7 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
         requests: RequestsLike,
         options: AddRequestsBatchedOptions = {},
     ): Promise<AddRequestsBatchedResult> {
-        await this.ensureSubManagers();
+        await this.#ensureSubManagers();
 
         // Normalized up front so the shared batching helper - and `requestsOverLimit` - only ever see `Source`.
         async function* iterateRequests(): AsyncGenerator<Source> {
@@ -724,10 +742,20 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
             // deduplication themselves.
             processChunk: async (chunk) => {
                 const byManager = new Map<T, Source[]>();
-                for (const request of chunk) {
-                    this.warnIfNotRoutable(request);
+                // Collected, not thrown on sight, so an overflow does not discard the requests that fit.
+                const overflowing = new Set<string>();
 
-                    const manager = await this.selectManager(request.url ?? '');
+                for (const request of chunk) {
+                    this.#warnIfNotRoutable(request);
+
+                    const url = request.url ?? '';
+                    const manager = await this.#selectManager(url);
+
+                    if (!manager) {
+                        overflowing.add(this.#extractDomain(url));
+                        continue;
+                    }
+
                     const bucket = byManager.get(manager);
                     if (bucket) {
                         bucket.push(request);
@@ -747,14 +775,18 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
                     ),
                 );
 
+                if (overflowing.size > 0) {
+                    throw this.#throttledDomainLimitError(Array.from(overflowing));
+                }
+
                 return results.flatMap((result) => result.addedRequests);
             },
 
             // Keeps the crawler from concluding it is finished while batches are still landing.
             trackBackgroundBatches: (batches) => {
-                this.inProgressBatchCount += 1;
+                this.#inProgressBatchCount += 1;
                 void batches.finally(() => {
-                    this.inProgressBatchCount -= 1;
+                    this.#inProgressBatchCount -= 1;
                 });
             },
         });
@@ -764,14 +796,14 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
         request: Request,
         options?: RequestQueueOperationOptions,
     ): Promise<RequestQueueOperationInfo | null> {
-        const manager = await this.managerHolding(request);
+        const manager = await this.#managerHolding(request);
         return manager.reclaimRequest(request, options);
     }
 
     async markRequestAsHandled(request: Request): Promise<RequestQueueOperationInfo | void | null> {
-        const manager = await this.managerHolding(request);
+        const manager = await this.#managerHolding(request);
         // Reached whether the request succeeded or ran out of retries; either way the domain answered us.
-        this.recordProgress(request.url);
+        this.#recordProgress(request.url);
         return manager.markRequestAsHandled(request);
     }
 
@@ -779,26 +811,26 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
      * The manager a request in the consumer's hands has to be given back to - the one it was fetched from,
      * which is only the same as the one its domain routes to if it was routed in the first place.
      */
-    private async managerHolding(request: Request): Promise<T> {
+    async #managerHolding(request: Request): Promise<T> {
         const key = request.id ?? request.uniqueKey;
 
-        if (this.inFlightFromInner.delete(key)) {
-            return this.inner;
+        if (this.#inFlightFromInner.delete(key)) {
+            return this.#inner;
         }
 
-        return this.selectManager(request.url);
+        return this.#selectManagerOrThrow(request.url);
     }
 
     async getTotalCount(): Promise<number> {
-        return this.sumOverManagers((manager) => manager.getTotalCount());
+        return this.#sumOverManagers((manager) => manager.getTotalCount());
     }
 
     async getPendingCount(): Promise<number> {
-        return this.sumOverManagers((manager) => manager.getPendingCount());
+        return this.#sumOverManagers((manager) => manager.getPendingCount());
     }
 
     async getHandledCount(): Promise<number> {
-        return this.sumOverManagers((manager) => manager.getHandledCount());
+        return this.#sumOverManagers((manager) => manager.getHandledCount());
     }
 
     /**
@@ -808,23 +840,23 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
      * this idles for the backoff instead of spinning on a fetch that cannot succeed yet.
      */
     async isEmpty(): Promise<boolean> {
-        await this.ensureSubManagers();
+        await this.#ensureSubManagers();
 
         const fetchable = await Promise.all(
-            this.fetchableDomains().map(async (domain) => this.subManagers.get(domain)!),
+            this.#fetchableDomains().map(async (domain) => this.#subManagers.get(domain)!),
         );
-        const results = await Promise.all([this.inner, ...fetchable].map(async (manager) => manager.isEmpty()));
+        const results = await Promise.all([this.#inner, ...fetchable].map(async (manager) => manager.isEmpty()));
 
         return results.every(Boolean);
     }
 
     /** Unlike {@apilink ThrottlingRequestManager.isEmpty}, throttled requests still count as outstanding work. */
     async isFinished(): Promise<boolean> {
-        if (this.inProgressBatchCount > 0) {
+        if (this.#inProgressBatchCount > 0) {
             return false;
         }
 
-        return this.everyManager((manager) => manager.isFinished());
+        return this.#everyManager((manager) => manager.isFinished());
     }
 
     /**
@@ -832,7 +864,7 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
      * site rather than of the run, so it survives.
      */
     async purge(): Promise<void> {
-        await this.inner.purge?.();
+        await this.#inner.purge?.();
         await this.purgeDomainQueues();
     }
 
@@ -843,7 +875,7 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
      * call where a full {@apilink ThrottlingRequestManager.purge|`purge()`} would not be.
      */
     async purgeDomainQueues(): Promise<void> {
-        const subManagers = await this.getSubManagers();
+        const subManagers = await this.#getSubManagers();
         await Promise.all(subManagers.map(async (manager) => manager.purge?.()));
 
         for (const state of this.domainStates.values()) {
@@ -857,21 +889,21 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
     }
 
     async setExpectedRequestProcessingTimeSecs(secs: number): Promise<void> {
-        await this.forEachManager((manager) => manager.setExpectedRequestProcessingTimeSecs?.(secs));
+        await this.#forEachManager((manager) => manager.setExpectedRequestProcessingTimeSecs?.(secs));
     }
 
-    private async forEachManager(fn: (manager: T) => Promise<unknown> | undefined): Promise<void> {
+    async #forEachManager(fn: (manager: T) => Promise<unknown> | undefined): Promise<void> {
         // `fn` targets optional members, so it may return nothing - the wrapper normalizes that for `Promise.all`.
-        await Promise.all([this.inner, ...(await this.getSubManagers())].map(async (manager) => fn(manager)));
+        await Promise.all([this.#inner, ...(await this.#getSubManagers())].map(async (manager) => fn(manager)));
     }
 
-    private async sumOverManagers(fn: (manager: T) => Promise<number>): Promise<number> {
-        const counts = await Promise.all([this.inner, ...(await this.getSubManagers())].map(fn));
+    async #sumOverManagers(fn: (manager: T) => Promise<number>): Promise<number> {
+        const counts = await Promise.all([this.#inner, ...(await this.#getSubManagers())].map(fn));
         return counts.reduce((a, b) => a + b, 0);
     }
 
-    private async everyManager(fn: (manager: T) => Promise<boolean>): Promise<boolean> {
-        const results = await Promise.all([this.inner, ...(await this.getSubManagers())].map(fn));
+    async #everyManager(fn: (manager: T) => Promise<boolean>): Promise<boolean> {
+        const results = await Promise.all([this.#inner, ...(await this.#getSubManagers())].map(fn));
         return results.every(Boolean);
     }
 
@@ -884,21 +916,21 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
      * reports `true` meanwhile so the crawler's task loop idles rather than spins.
      */
     async fetchNextRequest<R extends Dictionary = Dictionary>(): Promise<Request<R> | null> {
-        await this.ensureSubManagers();
+        await this.#ensureSubManagers();
 
-        for (const domain of this.fetchableDomains()) {
+        for (const domain of this.#fetchableDomains()) {
             const state = this.domainStates.get(domain)!;
 
             // Armed while the fetch below is still suspended, so that a concurrent `fetchNextRequest` cannot
             // find the domain fetchable and dispatch into the same window - which would pace each task
             // rather than the domain.
             const crawlDelayUntilBefore = state.crawlDelayUntil;
-            const delayMs = crawlDelayMs(state, this.minCrawlDelayMs);
+            const delayMs = crawlDelayMs(state, this.#minCrawlDelayMs);
             if (delayMs > 0) {
                 state.crawlDelayUntil = Date.now() + delayMs;
             }
 
-            const request = await (await this.subManagers.get(domain)!).fetchNextRequest<R>();
+            const request = await (await this.#subManagers.get(domain)!).fetchNextRequest<R>();
             if (request) {
                 return request;
             }
@@ -907,17 +939,17 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
             state.crawlDelayUntil = crawlDelayUntilBefore;
         }
 
-        const request = await this.inner.fetchNextRequest<R>();
+        const request = await this.#inner.fetchNextRequest<R>();
 
         if (request !== null) {
-            this.inFlightFromInner.add(request.id ?? request.uniqueKey);
+            this.#inFlightFromInner.add(request.id ?? request.uniqueKey);
         }
 
-        if (request !== null && this.throttlesEveryDomain) {
+        if (request !== null && this.#throttlesEveryDomain) {
             // Requests that were never routed by domain - a `RequestList`, a `requestsFromUrl` expansion - are
             // handed out as fast as the crawler asks for them, because there is no per-domain queue to hold
             // them back in.
-            this.warnOnce(
+            this.#warnOnce(
                 'innerNotThrottled',
                 `Requests read directly from the wrapped request manager (for instance from a \`RequestList\` or a ` +
                     `\`requestsFromUrl\` list) are not throttled, because they are not stored per domain. Enqueue ` +
@@ -938,12 +970,12 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
     }
 
     async persistState(): Promise<void> {
-        await this.forEachManager((manager) => manager.persistState?.());
+        await this.#forEachManager((manager) => manager.persistState?.());
     }
 
     async drop(): Promise<void> {
-        await this.forEachManager((manager) => (manager as { drop?(): Promise<void> }).drop?.());
-        this.subManagers.clear();
-        this.subManagersReady = undefined;
+        await this.#forEachManager((manager) => (manager as { drop?(): Promise<void> }).drop?.());
+        this.#subManagers.clear();
+        this.#subManagersReady = undefined;
     }
 }

--- a/packages/core/src/storages/throttling_request_manager.ts
+++ b/packages/core/src/storages/throttling_request_manager.ts
@@ -1,5 +1,6 @@
 import { URL } from 'node:url';
 import type { Dictionary } from '@crawlee/types';
+import { getDomain } from 'tldts';
 import { z } from 'zod';
 
 import type { Configuration } from '../configuration.js';
@@ -11,6 +12,7 @@ import { serviceLocator } from '../service_locator.js';
 import { normalizeHostname } from '../url.js';
 import { parseArgument, schemas } from '../validators.js';
 import { drainRequestBatches } from './batched_adds.js';
+import { KeyValueStore } from './key_value_store.js';
 import type { IRequestManager, RequestsLike } from './request_manager.js';
 import type {
     AddRequestsBatchedOptions,
@@ -24,11 +26,19 @@ import type { StorageOpenOptions } from './utils.js';
 
 const throttlingRequestManagerOptionsSchema = z.strictObject({
     inner: schemas.anyObject,
-    domains: schemas.arrayOf(z.string().nonempty(), 'non-empty strings'),
+    domains: z.union([schemas.arrayOf(z.string().nonempty(), 'non-empty strings'), z.literal('all')]),
     requestManagerOpener: schemas.anyFunction.optional(),
     baseDelaySecs: schemas.anyNumber.refine((value) => value > 0, 'Expected a number greater than 0').optional(),
     maxDelaySecs: schemas.anyNumber.refine((value) => value > 0, 'Expected a number greater than 0').optional(),
     maxDomainStallSecs: schemas.anyNumber.refine((value) => value > 0, 'Expected a number greater than 0').optional(),
+    minCrawlDelaySecs: schemas.anyNumber
+        .refine((value) => value >= 0, 'Expected a number greater than or equal to 0')
+        .optional(),
+    throttleBy: z.enum(['hostname', 'registrableDomain']).optional(),
+    maxThrottledDomains: schemas.anyNumber
+        .refine((value) => value > 0, 'Expected a number greater than 0')
+        .optional(),
+    persistStateKey: z.string().nonempty().optional(),
 });
 
 /**
@@ -78,16 +88,63 @@ export interface ThrottlingRequestManagerOptions<T extends IRequestManager = IRe
     inner: T;
 
     /**
-     * Hostnames to throttle. Matching is case-insensitive and exact - wildcards such as `*.example.com` are not
-     * supported, so list each subdomain you care about. Requests for any other domain bypass throttling entirely.
+     * Which domains to throttle: a list of hostnames, or `'all'` for every domain the crawl encounters.
      *
-     * An internationalized domain may be given in either its unicode or its punycode form, and an IPv6 address
-     * has to be bracketed (`[::1]`).
+     * Matching a listed hostname is case-insensitive and exact - wildcards such as `*.example.com` are not
+     * supported, so list each subdomain you care about (or set
+     * {@apilink ThrottlingRequestManagerOptions.throttleBy|`throttleBy: 'registrableDomain'`}). An
+     * internationalized domain may be given in either its unicode or its punycode form, and an IPv6 address has
+     * to be bracketed (`[::1]`). Requests for any other domain bypass throttling entirely.
+     *
+     * `'all'` gives each domain a queue of its own the first time it is seen, so that it can be held back
+     * without its requests being repeatedly popped and re-enqueued. One request queue per domain is not free,
+     * which is what {@apilink ThrottlingRequestManagerOptions.maxThrottledDomains|`maxThrottledDomains`} is
+     * there to bound.
      */
-    domains: string[];
+    domains: string[] | 'all';
 
     /**
-     * Opens the per-domain queues, one per entry in `domains`, each under the alias `throttled-<domain>`.
+     * A floor under the crawl delay of every throttled domain, in seconds - the proactive clock described on
+     * {@apilink ThrottlingRequestManager}. A domain whose robots.txt asks for a longer `Crawl-delay` gets the
+     * longer one; this is a minimum, not an override.
+     * @default 0
+     */
+    minCrawlDelaySecs?: number;
+
+    /**
+     * What counts as "the same domain": the exact hostname, or the registrable domain it belongs to
+     * (`example.com` for `www.example.com`, `a.example.co.uk` and so on). Hosts with no registrable domain -
+     * IP addresses, `localhost` - are always throttled per hostname.
+     *
+     * Grouping by registrable domain gives subdomains a single pair of clocks and a single queue, which is what
+     * you want when the pacing is there to be polite to one server rather than to satisfy a specific host's
+     * rate limit.
+     * @default 'hostname'
+     */
+    throttleBy?: 'hostname' | 'registrableDomain';
+
+    /**
+     * The most domains a run may throttle at once. Exceeding it throws, rather than silently letting the
+     * throttling lapse - one request queue per domain is not free, and a crawl that discovers domains without
+     * bound would drown the storage backend in them.
+     *
+     * Only domains discovered under `domains: 'all'` count against this; an explicit list is taken at face value.
+     * @default 1000
+     */
+    maxThrottledDomains?: number;
+
+    /**
+     * The key under which the discovered domain list is kept in the default key-value store, so that a restart
+     * with `purgeOnStart` disabled reopens their queues instead of stranding whatever they still hold. Only
+     * written under `domains: 'all'`.
+     *
+     * Give each manager its own key when running several of them against the same storage.
+     * @default 'CRAWLEE_THROTTLED_DOMAINS'
+     */
+    persistStateKey?: string;
+
+    /**
+     * Opens the per-domain queues, one per throttled domain, each under the alias `throttled-<domain>`.
      * @default RequestQueue.open
      */
     requestManagerOpener?: RequestManagerOpener<T>;
@@ -124,17 +181,17 @@ interface DomainState {
     domain: string;
     /**
      * Earliest dispatch time imposed by 429 backoff, as a `Date.now()` timestamp. Kept apart from
-     * `crawlDelayUntil` so that a crawl-delay, which is armed on every single dispatch, cannot pass for an
+     * `crawlDelayUntil` so that the crawl delay, which is armed on every single dispatch, cannot pass for an
      * active backoff and swallow the 429s it is supposed to be tracking.
      */
     backoffUntil: number;
-    /** Earliest dispatch time imposed by the robots.txt `Crawl-delay`, as a `Date.now()` timestamp. */
+    /** Earliest dispatch time imposed by the domain's crawl delay, as a `Date.now()` timestamp. */
     crawlDelayUntil: number;
     /** Time after which an incoming 429 is treated as a fresh burst rather than a continuation. */
     backoffDecaysAt: number;
     consecutive429Count: number;
-    /** Minimum interval between dispatches, from a robots.txt `Crawl-delay` directive. */
-    crawlDelayMs: number | null;
+    /** The `Crawl-delay` this domain's robots.txt asked for, if any - a floor, not the whole story. */
+    declaredCrawlDelayMs: number | null;
     /**
      * When the current unbroken run of 429s began, as a `Date.now()` timestamp, or `0` if the domain is not
      * currently rate-limiting us. Cleared the moment a request gets through, so it measures how long we have
@@ -153,25 +210,49 @@ function throttledUntil(state: DomainState): number {
     return Math.max(state.backoffUntil, state.crawlDelayUntil);
 }
 
+/** How long a domain must be left alone after a dispatch: what it asked for, or our floor, whichever is longer. */
+function crawlDelayMs(state: DomainState, minCrawlDelayMs: number): number {
+    return Math.max(state.declaredCrawlDelayMs ?? 0, minCrawlDelayMs);
+}
+
+function newDomainState(domain: string): DomainState {
+    return {
+        domain,
+        backoffUntil: 0,
+        crawlDelayUntil: 0,
+        backoffDecaysAt: 0,
+        consecutive429Count: 0,
+        declaredCrawlDelayMs: null,
+        rateLimitedSince: 0,
+        lastRateLimitedAt: 0,
+    };
+}
+
+const DEFAULT_PERSIST_STATE_KEY = 'CRAWLEE_THROTTLED_DOMAINS';
+
 /**
  * A request manager that wraps another one and paces requests per domain.
  *
- * Requests for the configured {@apilink ThrottlingRequestManagerOptions.domains|`domains`} are routed into their own
- * queue when they are added, so each request lives in exactly one place and deduplication keeps working. Everything
- * else goes to the wrapped manager untouched.
+ * Requests for a throttled domain are routed into their own queue when they are added, so each request lives in
+ * exactly one place and deduplication keeps working. Everything else goes to the wrapped manager untouched.
  *
  * {@apilink ThrottlingRequestManager.fetchNextRequest|`fetchNextRequest()`} serves the domain that has been waiting
  * longest and skips any that are backing off, falling back to the wrapped manager. It never blocks: while every
  * remaining request belongs to a throttled domain it returns `null` and {@apilink ThrottlingRequestManager.isEmpty}
  * reports `true`, so the crawler idles instead of holding a concurrency slot open.
  *
- * Delays come from two places:
- * - HTTP 429 responses, honouring `Retry-After` and otherwise backing off exponentially. The crawlers report these
- *   automatically; a request that is throttled is retried later without counting against `maxRequestRetries` and
+ * Each throttled domain runs two independent clocks, and may be dispatched to once **both** have run out:
+ * - **Backoff**, set by HTTP 429 responses - honouring `Retry-After`, and otherwise doubling from `baseDelaySecs`.
+ *   Reactive and temporary: it decays once the domain stops turning us away. The crawlers report the 429s
+ *   themselves; a request held back this way is retried later without counting against `maxRequestRetries` and
  *   without penalising its session.
- * - robots.txt `Crawl-delay` directives, when `respectRobotsTxtFile` is enabled.
+ * - **Crawl delay**, the minimum interval between two dispatches to the domain, armed after each one. Proactive
+ *   and constant: whatever the domain's robots.txt asks for, floored by
+ *   {@apilink ThrottlingRequestManagerOptions.minCrawlDelaySecs|`minCrawlDelaySecs`}. Either may be absent, in
+ *   which case the other one is the delay.
  *
- * This is opt-in: throttling only happens for a domain you list explicitly.
+ * Which domains get those clocks is {@apilink ThrottlingRequestManagerOptions.domains|`domains`} - a list, or
+ * `'all'` for every domain the crawl encounters.
  *
  * **Example usage:**
  *
@@ -195,14 +276,39 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
     private readonly baseDelayMs: number;
     private readonly maxDelayMs: number;
     private readonly maxDomainStallMs: number;
+    private readonly minCrawlDelayMs: number;
+    private readonly throttlesEveryDomain: boolean;
+    private readonly throttleBy: 'hostname' | 'registrableDomain';
+    private readonly maxThrottledDomains: number;
+    private readonly persistStateKey: string;
 
     private readonly domainStates = new Map<string, DomainState>();
-    private readonly subManagers = new Map<string, T>();
+    private readonly subManagers = new Map<string, Promise<T>>();
     private readonly log: CrawleeLogger;
+
+    /** Domains from the `domains` option, which are throttled whether or not the crawl ever visits them. */
+    private readonly listedDomains = new Set<string>();
+
+    /**
+     * Domains picked up at runtime under `domains: 'all'`. Persisted, because unlike the listed ones there
+     * is nothing to rediscover them from at startup - and a sub-queue nobody reopens is a sub-queue whose
+     * requests are never crawled.
+     */
+    private readonly discoveredDomains = new Set<string>();
+
+    /**
+     * Requests currently held by the consumer that came out of the wrapped manager rather than a sub-queue.
+     * They have to go back where they came from: routing them by domain would mark them handled in a queue
+     * that has never heard of them, leaving the wrapped manager to hand them out over and over.
+     */
+    private readonly inFlightFromInner = new Set<string>();
+    private domainListStore?: KeyValueStore;
+    private lastDomainListWrite: Promise<unknown> = Promise.resolve();
+    private queuedDomainListWrite?: Promise<void>;
 
     /**
      * Sub-managers are keyed by a stable alias, so with `purgeOnStart` disabled they outlive the process. They
-     * must therefore be reopened for every configured domain rather than created on first insert - otherwise a
+     * must therefore be reopened for every known domain rather than created on first insert - otherwise a
      * restart sees an empty map, reports the crawl finished, and strands whatever the previous run left in them.
      */
     private subManagersReady?: Promise<void>;
@@ -212,8 +318,9 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
 
     private readonly warnedAbout = new Set<string>();
 
-    private get hasThrottledDomains(): boolean {
-        return this.domainStates.size > 0;
+    /** Whether any domain at all may end up throttled - listed up front, or discovered as the crawl runs. */
+    private get throttlingEnabled(): boolean {
+        return this.listedDomains.size > 0 || this.throttlesEveryDomain;
     }
 
     constructor(
@@ -229,13 +336,18 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
         this.baseDelayMs = (options.baseDelaySecs ?? 2) * 1000;
         this.maxDelayMs = (options.maxDelaySecs ?? 60) * 1000;
         this.maxDomainStallMs = (options.maxDomainStallSecs ?? 900) * 1000;
+        this.minCrawlDelayMs = (options.minCrawlDelaySecs ?? 0) * 1000;
+        this.throttlesEveryDomain = options.domains === 'all';
+        this.throttleBy = options.throttleBy ?? 'hostname';
+        this.maxThrottledDomains = options.maxThrottledDomains ?? 1000;
+        this.persistStateKey = options.persistStateKey ?? DEFAULT_PERSIST_STATE_KEY;
         this.log = serviceLocator.getLogger().child({ prefix: 'ThrottlingRequestManager' });
 
-        for (const domain of options.domains) {
+        for (const domain of Array.isArray(options.domains) ? options.domains : []) {
             let hostname: string;
             try {
                 // These are bare hostnames, so they only reach `URL` - and with it IDNA - via a synthetic URL.
-                hostname = normalizeHostname(new URL(`http://${domain}`).hostname);
+                hostname = new URL(`http://${domain}`).hostname;
             } catch {
                 throw new Error(
                     `"${domain}" is not a valid hostname. The \`domains\` option takes bare hostnames such as ` +
@@ -243,17 +355,27 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
                 );
             }
 
-            this.domainStates.set(hostname, {
-                domain: hostname,
-                backoffUntil: 0,
-                crawlDelayUntil: 0,
-                backoffDecaysAt: 0,
-                consecutive429Count: 0,
-                crawlDelayMs: null,
-                rateLimitedSince: 0,
-                lastRateLimitedAt: 0,
-            });
+            const key = this.domainKey(hostname);
+            this.listedDomains.add(key);
+            this.domainStates.set(key, newDomainState(key));
         }
+    }
+
+    /**
+     * The key a URL's requests are grouped under - one delay clock and one sub-queue per key.
+     *
+     * @param hostname A hostname as `URL` reports it, so in punycode and possibly with a root dot.
+     */
+    private domainKey(hostname: string): string {
+        const normalized = normalizeHostname(hostname);
+
+        if (this.throttleBy === 'hostname') {
+            return normalized;
+        }
+
+        // No registrable domain to group by for an IP address or a single-label host such as `localhost`,
+        // so those stay paced per hostname.
+        return getDomain(normalized, { mixedInputs: false }) ?? normalized;
     }
 
     /** The wrapped manager, holding every request whose domain is not throttled. */
@@ -263,7 +385,7 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
 
     /** Warns once about sources that cannot be routed by domain, because their URLs are not known yet. */
     private warnIfNotRoutable(requestLike: Source): void {
-        if ('requestsFromUrl' in requestLike && requestLike.requestsFromUrl !== undefined && this.hasThrottledDomains) {
+        if ('requestsFromUrl' in requestLike && requestLike.requestsFromUrl !== undefined && this.throttlingEnabled) {
             // The URL list is only fetched once the owning manager expands it, so we cannot know which domains
             // it covers and cannot route it. Warn instead of silently exempting those URLs from throttling.
             this.warnOnce(
@@ -285,7 +407,7 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
 
     private extractDomain(url: string): string {
         try {
-            return normalizeHostname(new URL(url).hostname);
+            return this.domainKey(new URL(url).hostname);
         } catch {
             return '';
         }
@@ -296,28 +418,104 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
         return this.domainStates.get(domain) ?? null;
     }
 
+    /**
+     * The manager that owns a URL's requests, opening a sub-queue for its domain if this is the first time we
+     * have seen it and every domain is throttled.
+     */
     private async selectManager(url: string): Promise<T> {
         await this.ensureSubManagers();
-        return this.managerForUrl(url);
+
+        const domain = this.extractDomain(url);
+
+        if (!domain || !(this.listedDomains.has(domain) || this.throttlesEveryDomain)) {
+            return this.inner;
+        }
+
+        if (!this.listedDomains.has(domain) && !this.discoveredDomains.has(domain)) {
+            this.assertRoomForDomain(domain);
+            this.discoveredDomains.add(domain);
+            // Written before the request lands in the sub-queue: a crash in between would leave that queue
+            // with nothing to reopen it, and the crawl would silently drop everything in it.
+            await this.persistDiscoveredDomains();
+        }
+
+        return this.subManagerFor(domain);
     }
 
-    /** Only valid once {@apilink ThrottlingRequestManager.ensureSubManagers} has resolved. */
-    private managerForUrl(url: string): T {
-        return this.subManagers.get(this.extractDomain(url)) ?? this.inner;
+    private assertRoomForDomain(domain: string): void {
+        if (this.discoveredDomains.size < this.maxThrottledDomains) {
+            return;
+        }
+
+        throw new Error(
+            `Refusing to throttle "${domain}": ${this.maxThrottledDomains} domains are already being throttled ` +
+                `(\`maxThrottledDomains\`). Each of them holds a request queue of its own, so a crawl that keeps ` +
+                `discovering new domains will bury the storage backend in them. Narrow the crawl down, pace it ` +
+                `with \`maxRequestsPerMinute\` instead, or raise \`maxThrottledDomains\` if you are prepared to ` +
+                `pay for it.`,
+        );
+    }
+
+    /** Opens the domain's sub-queue, or returns the one already opened (or being opened) for it. */
+    private subManagerFor(domain: string): Promise<T> {
+        let subManager = this.subManagers.get(domain);
+
+        if (!subManager) {
+            subManager = this.requestManagerOpener(
+                // Backends use the alias as a directory name, and an IPv6 literal is full of characters
+                // Windows will not accept. Ordinary hostnames survive this untouched.
+                { alias: `throttled-${encodeURIComponent(domain)}` },
+                { configuration: this.config },
+            );
+            this.subManagers.set(domain, subManager);
+            this.ensureDomainState(domain);
+        }
+
+        return subManager;
+    }
+
+    private ensureDomainState(domain: string): DomainState {
+        let state = this.domainStates.get(domain);
+
+        if (!state) {
+            state = newDomainState(domain);
+            this.domainStates.set(domain, state);
+        }
+
+        return state;
+    }
+
+    /**
+     * Coalesces the writes of the discovered domain list: callers that arrive while one is in flight share the
+     * single write queued behind it, which snapshots the set once it starts and so covers all of them.
+     */
+    private async persistDiscoveredDomains(): Promise<void> {
+        this.queuedDomainListWrite ??= this.lastDomainListWrite
+            // A failed write must not poison the ones behind it - they will rewrite the whole set anyway.
+            .catch(() => {})
+            .then(async () => {
+                this.queuedDomainListWrite = undefined;
+                await this.domainListStore!.setValue(this.persistStateKey, Array.from(this.discoveredDomains));
+            });
+        this.lastDomainListWrite = this.queuedDomainListWrite;
+
+        await this.queuedDomainListWrite;
     }
 
     private async ensureSubManagers(): Promise<void> {
         this.subManagersReady ??= (async () => {
+            if (this.throttlesEveryDomain) {
+                this.domainListStore = await KeyValueStore.open(null, { configuration: this.config });
+
+                for (const domain of (await this.domainListStore.getValue<string[]>(this.persistStateKey)) ?? []) {
+                    this.discoveredDomains.add(domain);
+                }
+            }
+
             await Promise.all(
-                Array.from(this.domainStates.keys(), async (domain) => {
-                    const subManager = await this.requestManagerOpener(
-                        // Backends use the alias as a directory name, and an IPv6 literal is full of characters
-                        // Windows will not accept. Ordinary hostnames survive this untouched.
-                        { alias: `throttled-${encodeURIComponent(domain)}` },
-                        { configuration: this.config },
-                    );
-                    this.subManagers.set(domain, subManager);
-                }),
+                Array.from([...this.listedDomains, ...this.discoveredDomains], async (domain) =>
+                    this.subManagerFor(domain),
+                ),
             );
         })();
 
@@ -326,14 +524,19 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
 
     private async getSubManagers(): Promise<T[]> {
         await this.ensureSubManagers();
-        return Array.from(this.subManagers.values());
+        return Promise.all(this.subManagers.values());
     }
 
-    /** Configured domains that are not currently backing off, longest-overdue first. */
+    /**
+     * Throttled domains that are not currently backing off, longest-overdue first.
+     *
+     * A domain whose sub-queue has not been opened yet is skipped - a robots.txt `Crawl-delay` gives a domain a
+     * clock before its first request gives it a queue, and there is nothing to fetch from until then.
+     */
     private fetchableDomains(): string[] {
         const now = Date.now();
         return Array.from(this.domainStates.values())
-            .filter((state) => now >= throttledUntil(state))
+            .filter((state) => now >= throttledUntil(state) && this.subManagers.has(state.domain))
             .sort((a, b) => throttledUntil(a) - throttledUntil(b))
             .map((state) => state.domain);
     }
@@ -399,20 +602,26 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
     }
 
     /**
-     * Applies a robots.txt `Crawl-delay` to the URL's domain, as a minimum interval between dispatches.
+     * Records the `Crawl-delay` a domain's robots.txt asked for, which becomes its crawl delay unless
+     * {@apilink ThrottlingRequestManagerOptions.minCrawlDelaySecs|`minCrawlDelaySecs`} asks for longer.
      *
      * The first value wins, so a robots.txt re-fetch cannot change the cadence mid-crawl.
      *
-     * @returns `false` if the domain is not configured for throttling, in which case this is a no-op.
+     * @returns `false` if the domain is not throttled, in which case this is a no-op.
      */
     setCrawlDelay(url: string, delaySeconds: number): boolean {
-        const state = this.getDomainState(url);
-        if (!state) {
+        const domain = this.extractDomain(url);
+
+        if (!domain || !(this.listedDomains.has(domain) || this.throttlesEveryDomain)) {
             return false;
         }
 
-        if (state.crawlDelayMs === null) {
-            state.crawlDelayMs = delaySeconds * 1000;
+        // The crawler reads robots.txt before it enqueues a domain's first request, so the clock can predate
+        // the sub-queue it will end up pacing.
+        const state = this.ensureDomainState(domain);
+
+        if (state.declaredCrawlDelayMs === null) {
+            state.declaredCrawlDelayMs = delaySeconds * 1000;
             this.log.debug(`Set crawl-delay for domain "${state.domain}" to ${delaySeconds}s`);
         }
 
@@ -444,7 +653,10 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
 
         const stalled = (
             await Promise.all(
-                candidates.map(async (state) => ((await this.subManagers.get(state.domain)!.isEmpty()) ? null : state)),
+                candidates.map(async (state) => {
+                    const subManager = await this.subManagers.get(state.domain);
+                    return subManager && !(await subManager.isEmpty()) ? state : null;
+                }),
             )
         ).filter((state) => state !== null);
 
@@ -460,7 +672,7 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
             `Giving up: ${summary} rate-limited every request for longer than maxDomainStallSecs ` +
                 `(${(this.maxDomainStallMs / 1000).toFixed(0)}s). Waiting longer will not help - lower the ` +
                 `crawler's concurrency, or drop these domains. Their requests are still queued, so re-running ` +
-                `without purging storages will resume them if the rate limit lifts.`,
+                `with \`purgeOnStart\` disabled will resume them if the rate limit lifts.`,
         );
     }
 
@@ -515,7 +727,7 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
                 for (const request of chunk) {
                     this.warnIfNotRoutable(request);
 
-                    const manager = this.managerForUrl(request.url ?? '');
+                    const manager = await this.selectManager(request.url ?? '');
                     const bucket = byManager.get(manager);
                     if (bucket) {
                         bucket.push(request);
@@ -552,15 +764,29 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
         request: Request,
         options?: RequestQueueOperationOptions,
     ): Promise<RequestQueueOperationInfo | null> {
-        const manager = await this.selectManager(request.url);
+        const manager = await this.managerHolding(request);
         return manager.reclaimRequest(request, options);
     }
 
     async markRequestAsHandled(request: Request): Promise<RequestQueueOperationInfo | void | null> {
-        const manager = await this.selectManager(request.url);
+        const manager = await this.managerHolding(request);
         // Reached whether the request succeeded or ran out of retries; either way the domain answered us.
         this.recordProgress(request.url);
         return manager.markRequestAsHandled(request);
+    }
+
+    /**
+     * The manager a request in the consumer's hands has to be given back to - the one it was fetched from,
+     * which is only the same as the one its domain routes to if it was routed in the first place.
+     */
+    private async managerHolding(request: Request): Promise<T> {
+        const key = request.id ?? request.uniqueKey;
+
+        if (this.inFlightFromInner.delete(key)) {
+            return this.inner;
+        }
+
+        return this.selectManager(request.url);
     }
 
     async getTotalCount(): Promise<number> {
@@ -584,8 +810,10 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
     async isEmpty(): Promise<boolean> {
         await this.ensureSubManagers();
 
-        const fetchable = [this.inner, ...this.fetchableDomains().map((domain) => this.subManagers.get(domain)!)];
-        const results = await Promise.all(fetchable.map((manager) => manager.isEmpty()));
+        const fetchable = await Promise.all(
+            this.fetchableDomains().map(async (domain) => this.subManagers.get(domain)!),
+        );
+        const results = await Promise.all([this.inner, ...fetchable].map(async (manager) => manager.isEmpty()));
 
         return results.every(Boolean);
     }
@@ -604,7 +832,20 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
      * site rather than of the run, so it survives.
      */
     async purge(): Promise<void> {
-        await this.forEachManager((manager) => manager.purge?.());
+        await this.inner.purge?.();
+        await this.purgeDomainQueues();
+    }
+
+    /**
+     * Empties the per-domain queues, leaving the wrapped manager alone.
+     *
+     * Those queues are this manager's own no matter who owns the one it wraps, which is what makes this safe to
+     * call where a full {@apilink ThrottlingRequestManager.purge|`purge()`} would not be.
+     */
+    async purgeDomainQueues(): Promise<void> {
+        const subManagers = await this.getSubManagers();
+        await Promise.all(subManagers.map(async (manager) => manager.purge?.()));
+
         for (const state of this.domainStates.values()) {
             state.consecutive429Count = 0;
             state.backoffUntil = 0;
@@ -651,21 +892,41 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
             // Armed while the fetch below is still suspended, so that a concurrent `fetchNextRequest` cannot
             // find the domain fetchable and dispatch into the same window - which would pace each task
             // rather than the domain.
-            const crawlDelayBefore = state.crawlDelayUntil;
-            if (state.crawlDelayMs !== null) {
-                state.crawlDelayUntil = Date.now() + state.crawlDelayMs;
+            const crawlDelayUntilBefore = state.crawlDelayUntil;
+            const delayMs = crawlDelayMs(state, this.minCrawlDelayMs);
+            if (delayMs > 0) {
+                state.crawlDelayUntil = Date.now() + delayMs;
             }
 
-            const request = await this.subManagers.get(domain)!.fetchNextRequest<R>();
+            const request = await (await this.subManagers.get(domain)!).fetchNextRequest<R>();
             if (request) {
                 return request;
             }
 
             // No dispatch to pace, so the domain keeps its slot.
-            state.crawlDelayUntil = crawlDelayBefore;
+            state.crawlDelayUntil = crawlDelayUntilBefore;
         }
 
-        return this.inner.fetchNextRequest<R>();
+        const request = await this.inner.fetchNextRequest<R>();
+
+        if (request !== null) {
+            this.inFlightFromInner.add(request.id ?? request.uniqueKey);
+        }
+
+        if (request !== null && this.throttlesEveryDomain) {
+            // Requests that were never routed by domain - a `RequestList`, a `requestsFromUrl` expansion - are
+            // handed out as fast as the crawler asks for them, because there is no per-domain queue to hold
+            // them back in.
+            this.warnOnce(
+                'innerNotThrottled',
+                `Requests read directly from the wrapped request manager (for instance from a \`RequestList\` or a ` +
+                    `\`requestsFromUrl\` list) are not throttled, because they are not stored per domain. Enqueue ` +
+                    `them through the crawler - \`crawler.run(requests)\` or \`crawler.addRequests()\` - to have ` +
+                    `their domains paced.`,
+            );
+        }
+
+        return request;
     }
 
     async *[Symbol.asyncIterator]() {

--- a/test/core/crawlers/basic_crawler.test.ts
+++ b/test/core/crawlers/basic_crawler.test.ts
@@ -2523,7 +2523,7 @@ describe('BasicCrawler', () => {
                 // The robots.txt `Crawl-delay: 5` must have reached the manager, not merely been survivable.
                 await requestManager.fetchNextRequest();
                 const state = (requestManager as any).domainStates.get('example.com');
-                expect(state.crawlDelayMs).toBe(5_000);
+                expect(state.declaredCrawlDelayMs).toBe(5_000);
 
                 // ...and it paces dispatch: the next request is held back rather than served immediately.
                 expect(state.crawlDelayUntil).toBeGreaterThan(Date.now() + 4_000);
@@ -2552,6 +2552,98 @@ describe('BasicCrawler', () => {
 
                 expect(warning).toHaveBeenCalledTimes(1);
                 expect(warning.mock.calls[0][0]).toMatch(/example\.com/);
+            });
+        });
+
+        describe('sameDomainDelaySecs', () => {
+            const crawlerVisiting = async (urls: string[], options: Partial<BasicCrawlerOptions> = {}) => {
+                const visits: { url: string; at: number }[] = [];
+                const crawler = new BasicCrawler({
+                    sameDomainDelaySecs: 0.5,
+                    requestHandler: async ({ request }) => {
+                        visits.push({ url: request.url, at: Date.now() });
+                    },
+                    ...options,
+                });
+
+                await crawler.run(urls);
+                return { crawler, visits };
+            };
+
+            test('spaces out requests to one site, subdomains included', async () => {
+                const { visits } = await crawlerVisiting(
+                    ['http://a.example.com/1', 'http://b.example.com/2', 'http://other.com/1'],
+                    { sameDomainDelaySecs: 1 },
+                );
+
+                expect(visits).toHaveLength(3);
+
+                const [sameSite, elsewhere] = [
+                    visits.filter(({ url }) => url.includes('example.com')),
+                    visits.filter(({ url }) => url.includes('other.com')),
+                ];
+
+                // The two hosts belong to the same site, so the delay applies across them...
+                expect(sameSite[1].at - sameSite[0].at).toBeGreaterThanOrEqual(700);
+                // ...while an unrelated domain is served in the meantime rather than queued behind it.
+                expect(elsewhere[0].at - sameSite[0].at).toBeLessThan(700);
+            });
+
+            test('does not re-enqueue the requests it delays', async () => {
+                const reclaimed: string[] = [];
+                const requestQueue = await RequestQueue.open();
+                const reclaimRequest = requestQueue.reclaimRequest.bind(requestQueue);
+                requestQueue.reclaimRequest = async (request, options) => {
+                    reclaimed.push(request.url);
+                    return reclaimRequest(request, options);
+                };
+
+                const { visits } = await crawlerVisiting(['http://example.com/1', 'http://example.com/2'], {
+                    requestQueue,
+                    sameDomainDelaySecs: 0.2,
+                });
+
+                // The point of the exercise: a delayed request waits in its domain's queue instead of being
+                // handed out, put back, and handed out again.
+                expect(visits).toHaveLength(2);
+                expect(reclaimed).toEqual([]);
+            });
+
+            test('a crawl fed by a requestList still finishes', async () => {
+                // Those requests are transferred straight into the wrapped manager, so they are never routed by
+                // domain - and have to be handed back to it rather than to the queue their domain would own.
+                const requestList = await RequestList.open(null, ['http://example.com/1', 'http://example.com/2']);
+                const { visits } = await crawlerVisiting([], { requestList, sameDomainDelaySecs: 0.1 });
+
+                expect(visits.map(({ url }) => url).sort()).toEqual(['http://example.com/1', 'http://example.com/2']);
+            });
+
+            test('a second run() crawls the same requests again', async () => {
+                const crawler = new BasicCrawler({
+                    sameDomainDelaySecs: 0.05,
+                    requestHandler: async () => {},
+                });
+
+                await crawler.run(['http://example.com/1']);
+                await crawler.run(['http://example.com/1']);
+
+                expect(crawler.stats.state.requestsFinished).toBe(1);
+            });
+
+            test('refuses to be combined with a request manager that throttles on its own', async () => {
+                const requestManager = new ThrottlingRequestManager({
+                    inner: await RequestQueue.open(),
+                    domains: ['example.com'],
+                });
+
+                expect(
+                    () =>
+                        new BasicCrawler({
+                            requestManager,
+                            sameDomainDelaySecs: 1,
+                            requestHandler: async () => {},
+                        }),
+                ).toThrow(/ThrottlingRequestManager/);
             });
         });
 

--- a/test/core/storages/throttling_request_manager.test.ts
+++ b/test/core/storages/throttling_request_manager.test.ts
@@ -1,5 +1,6 @@
 import type { AddRequestsBatchedResult } from '@crawlee/core';
 import {
+    KeyValueStore,
     MemoryStorageBackend,
     PersistentRateLimitError,
     RequestQueue,
@@ -228,6 +229,22 @@ describe('ThrottlingRequestManager', () => {
 
         expect(warning).toHaveBeenCalledTimes(1);
         expect(warning.mock.calls[0][0]).toMatch(/requestsFromUrl/);
+    });
+
+    test('a request fetched from the inner manager is handed back to it', async () => {
+        const inner = await createQueue();
+        const manager = new ThrottlingRequestManager({ inner, domains: ['example.com'] });
+
+        // Bypasses routing, exactly as a `RequestList` transfer or a `requestsFromUrl` expansion does - so the
+        // request sits in the inner manager despite belonging to a throttled domain.
+        await inner.addRequest({ url: 'https://example.com/1' });
+
+        const request = (await manager.fetchNextRequest())!;
+        await manager.markRequestAsHandled(request);
+
+        // Marking it handled in its domain's sub-queue instead would leave the inner manager serving it forever.
+        expect(await manager.isFinished()).toBe(true);
+        expect(await inner.getPendingCount()).toBe(0);
     });
 
     test('recordDomainDelay enforces throttling and fair scheduling', async () => {
@@ -516,6 +533,159 @@ describe('ThrottlingRequestManager', () => {
 
         await manager.addRequest({ url: 'https://example.com/1' });
         expect((await manager.fetchNextRequest())!.url).toBe('https://example.com/1');
+    });
+
+    describe("domains: 'all'", () => {
+        test('gives every domain a queue of its own, the first time it is seen', async () => {
+            const inner = await createQueue();
+            const manager = new ThrottlingRequestManager({ inner, domains: 'all' });
+
+            await manager.addRequest({ url: 'https://example.com/1' });
+            await manager.addRequestsBatched([{ url: 'https://other.com/1' }]);
+
+            // Nothing was left unrouted, and no domain had to be named up front for that.
+            expect(await inner.getTotalCount()).toBe(0);
+            expect(await manager.getTotalCount()).toBe(2);
+        });
+
+        test('backs off a domain nobody listed', async () => {
+            // No delay configured at all: the point is that an unlisted domain still gets a clock, which is
+            // what makes its 429s actionable.
+            const manager = new ThrottlingRequestManager({ inner: await createQueue(), domains: 'all' });
+
+            await manager.addRequest({ url: 'https://example.com/1' });
+
+            expect(manager.recordDomainDelay('https://example.com/1', 60_000)).toBe(true);
+            expect(await manager.fetchNextRequest()).toBeNull();
+        });
+
+        test('paces one domain without holding back the others', async () => {
+            const manager = new ThrottlingRequestManager({
+                inner: await createQueue(),
+                domains: 'all',
+                minCrawlDelaySecs: 0.5,
+            });
+
+            await manager.addRequest({ url: 'https://example.com/1' });
+            await manager.addRequest({ url: 'https://example.com/2' });
+            await manager.addRequest({ url: 'https://other.com/1' });
+
+            expect((await manager.fetchNextRequest())!.url).toBe('https://example.com/1');
+            // example.com is spending its delay, so the unrelated domain goes first...
+            expect((await manager.fetchNextRequest())!.url).toBe('https://other.com/1');
+            // ...and until the delay is up there is nothing else to hand out.
+            expect(await manager.fetchNextRequest()).toBeNull();
+
+            const start = Date.now();
+            const next = await pollForNextRequest(manager);
+
+            expect(Date.now() - start).toBeGreaterThanOrEqual(250);
+            expect(next.url).toBe('https://example.com/2');
+        });
+
+        test('a longer robots.txt crawl-delay wins over the floor', async () => {
+            const manager = new ThrottlingRequestManager({
+                inner: await createQueue(),
+                domains: 'all',
+                minCrawlDelaySecs: 0.01,
+            });
+
+            // Robots.txt is read before the domain's first request is enqueued, so the delay lands on a domain
+            // the manager has never seen.
+            expect(manager.setCrawlDelay('https://example.com/robots.txt', 60)).toBe(true);
+
+            await manager.addRequest({ url: 'https://example.com/1' });
+            await manager.addRequest({ url: 'https://example.com/2' });
+
+            expect((await manager.fetchNextRequest())!.url).toBe('https://example.com/1');
+            await sleep(50);
+            expect(await manager.fetchNextRequest()).toBeNull();
+        });
+
+        test('throttleBy: registrableDomain gives a site and its subdomains one clock', async () => {
+            const manager = new ThrottlingRequestManager({
+                inner: await createQueue(),
+                domains: 'all',
+                minCrawlDelaySecs: 60,
+                throttleBy: 'registrableDomain',
+            });
+
+            await manager.addRequest({ url: 'https://a.example.com/1' });
+            await manager.addRequest({ url: 'https://b.example.com/1' });
+
+            expect((await manager.fetchNextRequest())!.url).toBe('https://a.example.com/1');
+            // A different host, but the same site - so it waits out the delay rather than doubling the rate.
+            expect(await manager.fetchNextRequest()).toBeNull();
+            expect(domainState(manager, 'example.com')).toBeDefined();
+        });
+
+        test('hosts with no registrable domain are still paced per hostname', async () => {
+            const manager = new ThrottlingRequestManager({
+                inner: await createQueue(),
+                domains: 'all',
+                minCrawlDelaySecs: 60,
+                throttleBy: 'registrableDomain',
+            });
+
+            await manager.addRequest({ url: 'http://127.0.0.1:8080/1' });
+            await manager.addRequest({ url: 'http://localhost:8080/1' });
+
+            expect(await manager.fetchNextRequest()).not.toBeNull();
+            // Two hosts that tldts cannot reduce to a common site, so they do not share a queue either.
+            expect(await manager.fetchNextRequest()).not.toBeNull();
+        });
+
+        test('refuses to throttle more domains than maxThrottledDomains', async () => {
+            const manager = new ThrottlingRequestManager({
+                inner: await createQueue(),
+                domains: 'all',
+                maxThrottledDomains: 2,
+            });
+
+            await manager.addRequest({ url: 'https://one.com/1' });
+            await manager.addRequest({ url: 'https://two.com/1' });
+
+            await expect(manager.addRequest({ url: 'https://three.com/1' })).rejects.toThrow(/maxThrottledDomains/);
+        });
+
+        test('a restart reopens the queues of domains the previous run discovered', async () => {
+            const firstRun = new ThrottlingRequestManager({ inner: await createQueue(), domains: 'all' });
+            await firstRun.addRequest({ url: 'https://example.com/left-behind' });
+
+            // A restart builds a brand new manager over the same storage backend, with nothing but the
+            // persisted domain list to tell it that queue exists.
+            const secondRun = new ThrottlingRequestManager({ inner: await createQueue(), domains: 'all' });
+
+            expect(await secondRun.getPendingCount()).toBe(1);
+            expect((await pollForNextRequest(secondRun)).url).toBe('https://example.com/left-behind');
+        });
+
+        test('a domain is recorded before its first request lands in the sub-queue', async () => {
+            const order: string[] = [];
+            const store = await KeyValueStore.open();
+            vitest.spyOn(store, 'setValue').mockImplementation(async () => {
+                order.push('persist');
+            });
+
+            const manager = new ThrottlingRequestManager({
+                inner: await createQueue(),
+                domains: 'all',
+                requestManagerOpener: async (identifier, options) => {
+                    const queue = await RequestQueue.open(identifier, options);
+                    const addRequest = queue.addRequest.bind(queue);
+                    queue.addRequest = async (...args) => {
+                        order.push('add');
+                        return addRequest(...args);
+                    };
+                    return queue;
+                },
+            });
+
+            await manager.addRequest({ url: 'https://example.com/1' });
+
+            // The other order would let a crash strand that request in a queue nothing knows to reopen.
+            expect(order).toEqual(['persist', 'add']);
+        });
     });
 
     test('setCrawlDelay sets crawl-delay successfully', async () => {

--- a/test/core/storages/throttling_request_manager.test.ts
+++ b/test/core/storages/throttling_request_manager.test.ts
@@ -648,6 +648,22 @@ describe('ThrottlingRequestManager', () => {
             await expect(manager.addRequest({ url: 'https://three.com/1' })).rejects.toThrow(/maxThrottledDomains/);
         });
 
+        test('a batch that overflows maxThrottledDomains still stores the requests that fit', async () => {
+            const manager = new ThrottlingRequestManager({
+                inner: await createQueue(),
+                domains: 'all',
+                maxThrottledDomains: 50,
+            });
+
+            const urls = Array.from({ length: 100 }, (_, i) => `https://${i}.com`);
+            const error = await manager.addRequestsBatched(urls).catch((e: Error) => e);
+
+            expect(error).toBeInstanceOf(Error);
+            // The other 49 domains that did not fit either are named, not just the first one to overflow.
+            expect((error as Error).message).toMatch(/49 other new domain\(s\)/);
+            expect(await manager.getTotalCount()).toBe(50);
+        });
+
         test('a restart reopens the queues of domains the previous run discovered', async () => {
             const firstRun = new ThrottlingRequestManager({ inner: await createQueue(), domains: 'all' });
             await firstRun.addRequest({ url: 'https://example.com/left-behind' });


### PR DESCRIPTION
- closes #3997
- closes #3148

`sameDomainDelaySecs` now runs on `ThrottlingRequestManager`: delayed requests wait in their domain's queue instead of being fetched, parked in memory and re-enqueued. `delayRequest` and `domainAccessedTime` are gone.

The manager grew what that needed:

- `domains` accepts `'all'` as well as a list — every domain gets a clock and a queue created on first sighting. The discovered set is persisted, so a restart with `purgeOnStart` disabled reopens those queues rather than stranding what they hold.
- `minCrawlDelaySecs`, a floor under the robots.txt `Crawl-delay`, instead of a third independent delay source. Each domain now has exactly two clocks: reactive backoff from 429s, and a proactive crawl delay of `max(declared, floor)`.
- `throttleBy: 'hostname' | 'registrableDomain'` — the latter keeps subdomains paced as one site, which is what `sameDomainDelaySecs` has always meant.
- `maxThrottledDomains` (100), which throws rather than quietly letting throttling lapse. A queue per domain is not free. Overflowing it in `addRequestsBatched` still stores the requests that fit before throwing.

Worth knowing:

- combining `sameDomainDelaySecs` with a `requestManager` that already throttles per domain now throws
- requests that never pass through the manager — `requestList`, `requestsFromUrl` — are not paced, and it warns once when it hands one out
- `domains: 'all'` with no delay is newly useful: 429 backoff and `Crawl-delay` honoured for every domain, which wasn't expressible before
- the `EventManager` listener ceiling goes from 50 to 150, since every queue subscribes to `MIGRATING` and a hundred of them used to look like a leak

One bug found on the way, with a test that hangs without the fix: `markRequestAsHandled`/`reclaimRequest` routed by domain, so a request fetched from the wrapped manager was marked handled in a queue that had never seen it, and the crawl looped forever. Latent for `requestsFromUrl` before this; hits every `requestList` crawl once every domain is throttled.

