### PR TITLE
fix(playwright): update handleCloudflareChallenge for new Cloudflare challenge markup

### DIFF
--- a/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
+++ b/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
@@ -755,9 +755,8 @@ async function handleCloudflareChallenge(
 
     options.isChallengeCallback ??= async () => {
         return await page.evaluate(async () => {
-            // Cloudflare nests the ray ID under varying wrapper elements, so we match by descendants
-            // and only rely on the stable outer classes (`.diagnostic-wrapper` was removed in 2026,
-            // a `.footer-wrapper` was inserted earlier).
+            // Cloudflare keeps reshuffling the wrapper elements between `.footer-inner` and `.ray-id`,
+            // so only the stable outer classes are matched.
             return !!document.querySelector('.footer .footer-inner .ray-id');
         });
     };

--- a/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
+++ b/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
@@ -756,8 +756,9 @@ async function handleCloudflareChallenge(
     options.isChallengeCallback ??= async () => {
         return await page.evaluate(async () => {
             // Cloudflare nests the ray ID under varying wrapper elements, so we match by descendants
-            // instead of a direct-child chain (e.g. a `.footer-wrapper` was inserted in between).
-            return !!document.querySelector('.footer .footer-inner .diagnostic-wrapper .ray-id');
+            // and only rely on the stable outer classes (`.diagnostic-wrapper` was removed in 2026,
+            // a `.footer-wrapper` was inserted earlier).
+            return !!document.querySelector('.footer .footer-inner .ray-id');
         });
     };
 

--- a/test/core/playwright_utils.test.ts
+++ b/test/core/playwright_utils.test.ts
@@ -433,4 +433,73 @@ describe('playwrightUtils', () => {
             await browser.close();
         }
     });
+
+    describe('handleCloudflareChallenge() challenge detection', () => {
+        // the function itself is not a named export, it is only reachable via the internal `playwrightUtils` object
+        const { handleCloudflareChallenge } = playwrightUtils.playwrightUtils;
+        let browser: Browser;
+        let page: Page;
+
+        // Detection-only options: no real clicking, no waiting, so an unsolved challenge
+        // fails fast with a SessionError instead of spending ~20 seconds in the click loop.
+        // A fresh object per call, since `handleCloudflareChallenge` assigns default callbacks into it.
+        const fastOptions = () => ({
+            sleepSecs: 0,
+            preChallengeSleepSecs: 0,
+            clickCallback: async () => {},
+        });
+
+        // Challenge page markup as rendered by the current (2026) Cloudflare template:
+        // the ray ID sits under `.footer-wrapper > div`, with no `.diagnostic-wrapper`.
+        const currentChallengeBody = `
+            <div class="main-wrapper" role="main"><div class="main-content">
+                <h1>example.com</h1>
+                <h2>Performing security verification</h2>
+                <div style="display: grid;"><div><div><input type="hidden" name="cf-turnstile-response" id="cf-chl-widget-2swmi_response"></div></div></div>
+            </div></div>
+            <div class="footer" role="contentinfo"><div class="footer-inner"><div class="footer-wrapper">
+                <div><div class="ray-id">Ray ID: <code>a29d9a9cff4fb9e4</code></div></div>
+                <div class="footer-link-wrapper"><span class="footer-text">Performance and Security by Cloudflare</span></div>
+            </div></div></div>`;
+
+        // Older template, where the ray ID was nested under `.diagnostic-wrapper`.
+        const oldChallengeBody = `
+            <div class="main-wrapper" role="main"><div class="main-content">
+                <h1>example.com</h1>
+                <div><input type="hidden" name="cf-turnstile-response" id="cf-chl-widget-2swmi_response"></div>
+            </div></div>
+            <div class="footer" role="contentinfo"><div class="footer-inner"><div class="footer-wrapper"><div class="diagnostic-wrapper">
+                <div class="ray-id">Ray ID: <code>a29d9a9cff4fb9e4</code></div>
+            </div></div></div></div>`;
+
+        beforeAll(async () => {
+            browser = await chromium.launch({ headless: true });
+            page = await browser.newPage();
+        });
+
+        afterAll(async () => {
+            await browser.close();
+        });
+
+        test('detects the current challenge markup', async () => {
+            await page.setContent(`<html><body>${currentChallengeBody}</body></html>`);
+            await expect(
+                handleCloudflareChallenge(page, 'https://example.com', undefined, fastOptions()),
+            ).rejects.toThrow(/Blocked by Cloudflare/);
+        });
+
+        test('detects the old challenge markup', async () => {
+            await page.setContent(`<html><body>${oldChallengeBody}</body></html>`);
+            await expect(
+                handleCloudflareChallenge(page, 'https://example.com', undefined, fastOptions()),
+            ).rejects.toThrow(/Blocked by Cloudflare/);
+        });
+
+        test('resolves without detection on a regular page', async () => {
+            await page.setContent('<html><body><h1>Welcome</h1></body></html>');
+            await expect(
+                handleCloudflareChallenge(page, 'https://example.com', undefined, fastOptions()),
+            ).resolves.toBeUndefined();
+        });
+    });
 });

--- a/test/core/playwright_utils.test.ts
+++ b/test/core/playwright_utils.test.ts
@@ -435,22 +435,19 @@ describe('playwrightUtils', () => {
     });
 
     describe('handleCloudflareChallenge() challenge detection', () => {
-        // the function itself is not a named export, it is only reachable via the internal `playwrightUtils` object
+        // not a named export, only reachable via the internal `playwrightUtils` object
         const { handleCloudflareChallenge } = playwrightUtils.playwrightUtils;
         let browser: Browser;
         let page: Page;
 
-        // Detection-only options: no real clicking, no waiting, so an unsolved challenge
-        // fails fast with a SessionError instead of spending ~20 seconds in the click loop.
-        // A fresh object per call, since `handleCloudflareChallenge` assigns default callbacks into it.
+        // no clicking or waiting, so an unsolved challenge fails fast instead of spending ~20s in the click loop
         const fastOptions = () => ({
             sleepSecs: 0,
             preChallengeSleepSecs: 0,
             clickCallback: async () => {},
         });
 
-        // Challenge page markup as rendered by the current (2026) Cloudflare template:
-        // the ray ID sits under `.footer-wrapper > div`, with no `.diagnostic-wrapper`.
+        // markup as rendered by the current (2026) Cloudflare challenge template
         const currentChallengeBody = `
             <div class="main-wrapper" role="main"><div class="main-content">
                 <h1>example.com</h1>
@@ -462,7 +459,7 @@ describe('playwrightUtils', () => {
                 <div class="footer-link-wrapper"><span class="footer-text">Performance and Security by Cloudflare</span></div>
             </div></div></div>`;
 
-        // Older template, where the ray ID was nested under `.diagnostic-wrapper`.
+        // the older template, with the `.diagnostic-wrapper` element
         const oldChallengeBody = `
             <div class="main-wrapper" role="main"><div class="main-content">
                 <h1>example.com</h1>

--- a/test/e2e/camoufox-cloudflare/actor/main.js
+++ b/test/e2e/camoufox-cloudflare/actor/main.js
@@ -52,7 +52,7 @@ await Actor.main(async () => {
         async requestHandler({ page, parseWithCheerio }) {
             const isBlocked = await page
                 .evaluate(async () => {
-                    return !!document.querySelector('.footer .footer-inner .diagnostic-wrapper .ray-id');
+                    return !!document.querySelector('.footer .footer-inner .ray-id');
                 })
                 .catch(() => false);
             const $ = await parseWithCheerio();


### PR DESCRIPTION
`handleCloudflareChallenge` stopped detecting the Cloudflare challenge page again. The current challenge template no longer has a `.diagnostic-wrapper` element in the footer (the ray ID now sits under `.footer > .footer-inner > .footer-wrapper > div > .ray-id`), so the default `isChallengeCallback` selector never matches. The helper returned without doing anything and the crawler failed on the blocked 403, which is how the `camoufox-cloudflare` e2e test against grabjobs.co caught it.

This is the same drift as #3717, one iteration later. The detection selector now relies only on the stable outer classes (`.footer .footer-inner .ray-id`), which matches both the old and the current markup. I verified it against the live challenge page served by grabjobs.co (a 403 with `cf-mitigated: challenge`, rendered in a headless browser). The Turnstile widget selector used for the checkbox click still matches, so it stays as is.

The e2e actor's own `isBlocked` check used the same dead selector and would report a false green (same situation as in #3717), so it is aligned too. Added unit tests for the challenge detection: current markup, old markup, and a negative case.
