### PR TITLE
fix: respect `maxCrawlDepth` in JSDOM and LinkeDOM context `enqueueLinks`

### DIFF
--- a/packages/jsdom-crawler/src/internals/jsdom-crawler.ts
+++ b/packages/jsdom-crawler/src/internals/jsdom-crawler.ts
@@ -23,7 +23,7 @@ import {
     Router,
     tryAbsoluteURL,
 } from '@crawlee/http';
-import type { Dictionary } from '@crawlee/types';
+import type { BatchAddRequestsResult, Dictionary } from '@crawlee/types';
 import { type CheerioRoot } from '@crawlee/utils/internal';
 import { type RobotsTxtFile, sleep } from '@crawlee/utils';
 import type { DOMWindow } from 'jsdom';
@@ -97,6 +97,11 @@ export interface JSDOMCrawlingContext<
      * ```
      */
     parseWithCheerio(selector?: string, timeoutMs?: number): Promise<CheerioRoot>;
+
+    /**
+     * Helper function for extracting URLs from the parsed HTML and adding them to the request queue.
+     */
+    enqueueLinks(options?: EnqueueLinksOptions): Promise<BatchAddRequestsResult>;
 }
 
 export type JSDOMRequestHandler<
@@ -356,9 +361,11 @@ export class JSDOMCrawler<
     }
 
     private async addHelpers(crawlingContext: InternalHttpCrawlingContext & { body: string; window: DOMWindow }) {
+        const originalEnqueueLinks = crawlingContext.enqueueLinks;
+
         return {
             enqueueLinks: async (enqueueOptions?: EnqueueLinksOptions) => {
-                return domCrawlerEnqueueLinks({
+                return (await domCrawlerEnqueueLinks({
                     options: {
                         ...enqueueOptions,
                         limit: await this.calculateEnqueuedRequestLimit(enqueueOptions?.limit),
@@ -369,7 +376,8 @@ export class JSDOMCrawler<
                     onSkippedRequest: this.handleSkippedRequest,
                     originalRequestUrl: crawlingContext.request.url,
                     finalRequestUrl: crawlingContext.request.loadedUrl,
-                });
+                    enqueueLinks: originalEnqueueLinks,
+                })) as BatchAddRequestsResult; // TODO make this type safe
             },
             async waitForSelector(selector: string, timeoutMs = 5_000) {
                 const cheerio = await import('cheerio');

--- a/packages/linkedom-crawler/src/internals/linkedom-crawler.ts
+++ b/packages/linkedom-crawler/src/internals/linkedom-crawler.ts
@@ -23,7 +23,7 @@ import {
     Router,
     tryAbsoluteURL,
 } from '@crawlee/http';
-import type { Dictionary } from '@crawlee/types';
+import type { BatchAddRequestsResult, Dictionary } from '@crawlee/types';
 import { type CheerioRoot } from '@crawlee/utils/internal';
 import { type RobotsTxtFile, sleep } from '@crawlee/utils';
 import * as cheerio from 'cheerio';
@@ -90,6 +90,11 @@ export interface LinkeDOMCrawlingContext<
      * ```
      */
     parseWithCheerio(selector?: string, timeoutMs?: number): Promise<CheerioRoot>;
+
+    /**
+     * Helper function for extracting URLs from the parsed HTML and adding them to the request queue.
+     */
+    enqueueLinks(options?: LinkeDOMCrawlerEnqueueLinksOptions): Promise<BatchAddRequestsResult>;
 }
 
 export type LinkeDOMRequestHandler<
@@ -244,21 +249,24 @@ export class LinkeDOMCrawler<
         }
     }
 
-    private async addHelpers(crawlingContext: InternalHttpCrawlingContext & { body: string }) {
+    private async addHelpers(crawlingContext: InternalHttpCrawlingContext & { body: string; window: Window }) {
+        const originalEnqueueLinks = crawlingContext.enqueueLinks;
+
         return {
             enqueueLinks: async (enqueueOptions?: LinkeDOMCrawlerEnqueueLinksOptions) => {
-                return linkedomCrawlerEnqueueLinks({
+                return (await linkedomCrawlerEnqueueLinks({
                     options: {
                         ...enqueueOptions,
                         limit: await this.calculateEnqueuedRequestLimit(enqueueOptions?.limit),
                     },
-                    window: document.defaultView,
+                    window: crawlingContext.window,
                     requestManager: await this.getRequestManager(),
                     robotsTxtFile: await this.getRobotsTxtFileForUrl(crawlingContext.request.url),
                     onSkippedRequest: this.handleSkippedRequest,
                     originalRequestUrl: crawlingContext.request.url,
                     finalRequestUrl: crawlingContext.request.loadedUrl,
-                });
+                    enqueueLinks: originalEnqueueLinks,
+                })) as BatchAddRequestsResult; // TODO make this type safe
             },
             async waitForSelector(selector: string, timeoutMs = 5_000) {
                 const $ = cheerio.load(crawlingContext.body);

--- a/test/core/crawlers/dom_crawler.test.ts
+++ b/test/core/crawlers/dom_crawler.test.ts
@@ -3,12 +3,22 @@ import type { AddressInfo } from 'node:net';
 
 import { MemoryStorageBackend, serviceLocator } from '@crawlee/core';
 import { JSDOMCrawler } from '@crawlee/jsdom';
+import { LinkeDOMCrawler } from '@crawlee/linkedom';
 
 const router = new Map<string, http.RequestListener>();
 router.set('/', (req, res) => {
     res.setHeader('content-type', 'text/html; charset=utf-8');
     res.end(`<!DOCTYPE html><html><head><title>Example Domain</title></head><body><p>Hello, world!</p></body></html>`);
 });
+
+for (const depth of [0, 1, 2]) {
+    router.set(`/depth-${depth}`, (req, res) => {
+        res.setHeader('content-type', 'text/html; charset=utf-8');
+        res.end(
+            `<!DOCTYPE html><html><head><title>Depth ${depth}</title></head><body><a href="/depth-${depth + 1}">link</a></body></html>`,
+        );
+    });
+}
 
 let server: http.Server;
 let url: string;
@@ -52,4 +62,38 @@ test('works', async () => {
     await crawler.run([url]);
 
     expect(results).toStrictEqual(['Example Domain', 'Hello, world!']);
+});
+
+test('JSDOMCrawler enqueueLinks should respect maxCrawlDepth', async () => {
+    const titles: string[] = [];
+
+    const crawler = new JSDOMCrawler({
+        maxCrawlDepth: 1,
+        maxRequestsPerCrawl: 10, // to avoid accidental runaway
+        requestHandler: async ({ window, enqueueLinks }) => {
+            titles.push(window.document.title);
+            await enqueueLinks();
+        },
+    });
+
+    await crawler.run([`${url}/depth-0`]);
+
+    expect(titles).toEqual(['Depth 0', 'Depth 1']);
+});
+
+test('LinkeDOMCrawler enqueueLinks should respect maxCrawlDepth', async () => {
+    const titles: string[] = [];
+
+    const crawler = new LinkeDOMCrawler({
+        maxCrawlDepth: 1,
+        maxRequestsPerCrawl: 10, // to avoid accidental runaway
+        requestHandler: async ({ document, enqueueLinks }) => {
+            titles.push(document.title);
+            await enqueueLinks();
+        },
+    });
+
+    await crawler.run([`${url}/depth-0`]);
+
+    expect(titles).toEqual(['Depth 0', 'Depth 1']);
 });


### PR DESCRIPTION
`JSDOMCrawler` and `LinkeDOMCrawler` never passed the context-bound `enqueueLinks` into their enqueue-links helpers (unlike `CheerioCrawler`), so links were enqueued directly through the request manager and bypassed the crawl depth tracking in `BasicCrawler`. As a result, `maxCrawlDepth` had no effect for these two crawlers. Both files already had the `BoundEnqueueLinksInternalOptions` machinery, it just was never reached. This wires it up the same way `CheerioCrawler` does and declares `enqueueLinks` on both context interfaces so it can be called without `urls`.

There was a second bug in `LinkeDOMCrawler`: its helper passed `window: document.defaultView`, reading the DOM lib global `document` that doesn't exist at runtime in Node, so the context `enqueueLinks` always threw. It now uses the crawling context's `window`.

Added crawl depth tests for both crawlers, mirroring the existing `CheerioCrawler` coverage.
