### PR TITLE
fix: respect `maxCrawlDepth` in `JSDOM/LinkeDOM` context `enqueueLinks`

### DIFF
--- a/packages/jsdom-crawler/src/internals/jsdom-crawler.ts
+++ b/packages/jsdom-crawler/src/internals/jsdom-crawler.ts
@@ -296,6 +296,8 @@ export class JSDOMCrawler extends HttpCrawler<JSDOMCrawlingContext> {
             }
         }
 
+        const originalEnqueueLinks = crawlingContext.enqueueLinks;
+
         return {
             window,
             get body() {
@@ -306,13 +308,16 @@ export class JSDOMCrawler extends HttpCrawler<JSDOMCrawlingContext> {
             },
             enqueueLinks: async (enqueueOptions?: EnqueueLinksOptions) => {
                 return domCrawlerEnqueueLinks({
-                    options: { ...enqueueOptions, limit: this.calculateEnqueuedRequestLimit(enqueueOptions?.limit) },
+                    // `originalEnqueueLinks` clamps `limit` by the remaining `maxRequestsPerCrawl` budget itself;
+                    // pre-clamping it here would make the crawler log the internal limit as a user-provided one
+                    options: enqueueOptions,
                     window,
                     requestQueue: await this.getRequestQueue(),
                     robotsTxtFile: await this.getRobotsTxtFileForUrl(crawlingContext.request.url),
                     onSkippedRequest: this.handleSkippedRequest,
                     originalRequestUrl: crawlingContext.request.url,
                     finalRequestUrl: crawlingContext.request.loadedUrl,
+                    enqueueLinks: originalEnqueueLinks,
                 });
             },
         };

--- a/packages/linkedom-crawler/src/internals/linkedom-crawler.ts
+++ b/packages/linkedom-crawler/src/internals/linkedom-crawler.ts
@@ -178,6 +178,8 @@ export class LinkeDOMCrawler extends HttpCrawler<LinkeDOMCrawlingContext> {
 
         const document = LinkeDOMCrawler.parser.parseFromString(body.toString(), isXml ? 'text/xml' : 'text/html');
 
+        const originalEnqueueLinks = crawlingContext.enqueueLinks;
+
         return {
             window: document.defaultView,
             get body() {
@@ -189,13 +191,16 @@ export class LinkeDOMCrawler extends HttpCrawler<LinkeDOMCrawlingContext> {
             },
             enqueueLinks: async (enqueueOptions?: LinkeDOMCrawlerEnqueueLinksOptions) => {
                 return linkedomCrawlerEnqueueLinks({
-                    options: { ...enqueueOptions, limit: this.calculateEnqueuedRequestLimit(enqueueOptions?.limit) },
+                    // `originalEnqueueLinks` clamps `limit` by the remaining `maxRequestsPerCrawl` budget itself;
+                    // pre-clamping it here would make the crawler log the internal limit as a user-provided one
+                    options: enqueueOptions,
                     window: document.defaultView,
                     requestQueue: await this.getRequestQueue(),
                     robotsTxtFile: await this.getRobotsTxtFileForUrl(crawlingContext.request.url),
                     onSkippedRequest: this.handleSkippedRequest,
                     originalRequestUrl: crawlingContext.request.url,
                     finalRequestUrl: crawlingContext.request.loadedUrl,
+                    enqueueLinks: originalEnqueueLinks,
                 });
             },
         };

--- a/test/core/crawlers/dom_crawler.test.ts
+++ b/test/core/crawlers/dom_crawler.test.ts
@@ -2,6 +2,7 @@ import http from 'node:http';
 import type { AddressInfo } from 'node:net';
 
 import { JSDOMCrawler } from '@crawlee/jsdom';
+import { LinkeDOMCrawler } from '@crawlee/linkedom';
 
 import { MemoryStorageEmulator } from '../../shared/MemoryStorageEmulator';
 
@@ -10,6 +11,15 @@ router.set('/', (req, res) => {
     res.setHeader('content-type', 'text/html; charset=utf-8');
     res.end(`<!DOCTYPE html><html><head><title>Example Domain</title></head><body><p>Hello, world!</p></body></html>`);
 });
+
+for (const depth of [0, 1, 2]) {
+    router.set(`/depth-${depth}`, (req, res) => {
+        res.setHeader('content-type', 'text/html; charset=utf-8');
+        res.end(
+            `<!DOCTYPE html><html><head><title>Depth ${depth}</title></head><body><a href="/depth-${depth + 1}">link</a></body></html>`,
+        );
+    });
+}
 
 let server: http.Server;
 let url: string;
@@ -59,4 +69,38 @@ test('works', async () => {
     await crawler.run([url]);
 
     expect(results).toStrictEqual(['Example Domain', 'Hello, world!']);
+});
+
+test('JSDOMCrawler enqueueLinks should respect maxCrawlDepth', async () => {
+    const titles: string[] = [];
+
+    const crawler = new JSDOMCrawler({
+        maxCrawlDepth: 1,
+        maxRequestsPerCrawl: 10, // to avoid accidental runaway
+        requestHandler: async ({ window, enqueueLinks }) => {
+            titles.push(window.document.title);
+            await enqueueLinks();
+        },
+    });
+
+    await crawler.run([`${url}/depth-0`]);
+
+    expect(titles).toEqual(['Depth 0', 'Depth 1']);
+});
+
+test('LinkeDOMCrawler enqueueLinks should respect maxCrawlDepth', async () => {
+    const titles: string[] = [];
+
+    const crawler = new LinkeDOMCrawler({
+        maxCrawlDepth: 1,
+        maxRequestsPerCrawl: 10, // to avoid accidental runaway
+        requestHandler: async ({ document, enqueueLinks }) => {
+            titles.push(document.title);
+            await enqueueLinks();
+        },
+    });
+
+    await crawler.run([`${url}/depth-0`]);
+
+    expect(titles).toEqual(['Depth 0', 'Depth 1']);
 });


### PR DESCRIPTION
`JSDOMCrawler` and `LinkeDOMCrawler` never passed the context-bound `enqueueLinks` into their enqueue-links helpers (unlike `CheerioCrawler`), so links were enqueued straight into the request queue and skipped the crawl depth tracking in `BasicCrawler`. `maxCrawlDepth` has therefore had no effect for these two crawlers since it shipped in v3.14.0. Both files already had the `BoundEnqueueLinksInternalOptions` machinery, it just was never reached. This wires it up the same way `CheerioCrawler` does, including the `limit` pre-clamp removal from #3927, which applies once the bound path is taken.

Added crawl depth tests for both crawlers, mirroring the existing `CheerioCrawler` coverage.

Replaces #4020, which targeted v4; the bug exists on v3 as well, so the fix lands here instead.
