### PR TITLE
chore: keep the Cloudflare detection comment on a single line

### DIFF
--- a/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
+++ b/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
@@ -755,8 +755,7 @@ async function handleCloudflareChallenge(
 
     options.isChallengeCallback ??= async () => {
         return await page.evaluate(async () => {
-            // Cloudflare keeps reshuffling the wrapper elements between `.footer-inner` and `.ray-id`,
-            // so only the stable outer classes are matched.
+            // Cloudflare keeps reshuffling the wrappers between `.footer-inner` and `.ray-id`, so only the stable outer classes are matched
             return !!document.querySelector('.footer .footer-inner .ray-id');
         });
     };


### PR DESCRIPTION
Follow-up to #4019: collapses the selector comment in `handleCloudflareChallenge` to a single line. The commit was pushed moments after the PR got squash-merged, so it missed the merge.
