### PR TITLE
refactor!: replace `browserPoolOptions` with browser pool factories

### DIFF
--- a/docs/guides/avoid_blocking.mdx
+++ b/docs/guides/avoid_blocking.mdx
@@ -45,7 +45,7 @@ In certain cases we want to narrow down the fingerprints used - e.g. specify a c
 
 ## Disabling browser fingerprints
 
-On the contrary, sometimes we want to entirely disable the usage of browser fingerprints. This is easy to do with Crawlee too. All we have to do is set the `useFingerprints` option of the `browserPoolOptions` to `false`:
+On the contrary, sometimes we want to entirely disable the usage of browser fingerprints. This is easy to do with Crawlee too. All we have to do is build the crawler's browser pool with `useFingerprints` set to `false`:
 
 <Tabs groupId="avoid_blocking">
     <TabItem value="playwright" label="PlaywrightCrawler" default>

--- a/docs/guides/avoid_blocking_camoufox.ts
+++ b/docs/guides/avoid_blocking_camoufox.ts
@@ -1,18 +1,18 @@
-import { PlaywrightCrawler, handleCloudflareChallengeHook } from 'crawlee';
+import { PlaywrightCrawler, handleCloudflareChallengeHook, playwrightBrowserPool } from 'crawlee';
 import { launchOptions } from 'camoufox-js';
 import { firefox } from 'playwright';
 
 const crawler = new PlaywrightCrawler({
     postNavigationHooks: [handleCloudflareChallengeHook()],
-    browserPoolOptions: {
+    browserPool: playwrightBrowserPool({
         // Disable the default fingerprint spoofing to avoid conflicts with Camoufox.
         useFingerprints: false,
-    },
-    launchContext: {
-        launcher: firefox,
-        launchOptions: await launchOptions({
-            headless: true,
-        }),
-    },
+        launchContext: {
+            launcher: firefox,
+            launchOptions: await launchOptions({
+                headless: true,
+            }),
+        },
+    }),
     // ...
 });

--- a/docs/guides/avoid_blocking_playwright.ts
+++ b/docs/guides/avoid_blocking_playwright.ts
@@ -1,8 +1,8 @@
-import { PlaywrightCrawler } from 'crawlee';
+import { PlaywrightCrawler, playwrightBrowserPool } from 'crawlee';
 import { BrowserName, DeviceCategory, OperatingSystemsName } from '@crawlee/browser-pool';
 
 const crawler = new PlaywrightCrawler({
-    browserPoolOptions: {
+    browserPool: playwrightBrowserPool({
         useFingerprints: true, // this is the default
         fingerprintOptions: {
             fingerprintGeneratorOptions: {
@@ -16,6 +16,6 @@ const crawler = new PlaywrightCrawler({
                 operatingSystems: [OperatingSystemsName.windows],
             },
         },
-    },
+    }),
     // ...
 });

--- a/docs/guides/avoid_blocking_playwright_fingerprints_off.ts
+++ b/docs/guides/avoid_blocking_playwright_fingerprints_off.ts
@@ -1,8 +1,8 @@
-import { PlaywrightCrawler } from 'crawlee';
+import { PlaywrightCrawler, playwrightBrowserPool } from 'crawlee';
 
 const crawler = new PlaywrightCrawler({
-    browserPoolOptions: {
+    browserPool: playwrightBrowserPool({
         useFingerprints: false,
-    },
+    }),
     // ...
 });

--- a/docs/guides/avoid_blocking_puppeteer.ts
+++ b/docs/guides/avoid_blocking_puppeteer.ts
@@ -1,8 +1,8 @@
-import { PuppeteerCrawler } from 'crawlee';
+import { PuppeteerCrawler, puppeteerBrowserPool } from 'crawlee';
 import { BrowserName, DeviceCategory } from '@crawlee/browser-pool';
 
 const crawler = new PuppeteerCrawler({
-    browserPoolOptions: {
+    browserPool: puppeteerBrowserPool({
         useFingerprints: true, // this is the default
         fingerprintOptions: {
             fingerprintGeneratorOptions: {
@@ -11,6 +11,6 @@ const crawler = new PuppeteerCrawler({
                 locales: ['en-US'],
             },
         },
-    },
+    }),
     // ...
 });

--- a/docs/guides/avoid_blocking_puppeteer_fingerprints_off.ts
+++ b/docs/guides/avoid_blocking_puppeteer_fingerprints_off.ts
@@ -1,8 +1,8 @@
-import { PuppeteerCrawler } from 'crawlee';
+import { PuppeteerCrawler, puppeteerBrowserPool } from 'crawlee';
 
 const crawler = new PuppeteerCrawler({
-    browserPoolOptions: {
+    browserPool: puppeteerBrowserPool({
         useFingerprints: false,
-    },
+    }),
     // ...
 });

--- a/docs/public-api/crawlee-browser.api.md
+++ b/docs/public-api/crawlee-browser.api.md
@@ -9,8 +9,6 @@ import type { Awaitable } from '@crawlee/types';
 import { BaseHttpClient } from '@crawlee/http-client';
 import { BasicCrawler } from '@crawlee/basic';
 import { BasicCrawlerOptions } from '@crawlee/basic';
-import type { BrowserController } from '@crawlee/browser-pool';
-import type { BrowserPlugin } from '@crawlee/browser-pool';
 import type { BrowserPluginOptions } from '@crawlee/browser-pool';
 import type { BrowserPoolHooks } from '@crawlee/browser-pool';
 import type { BrowserPoolOptions } from '@crawlee/browser-pool';
@@ -26,13 +24,15 @@ import { EventManager } from '@crawlee/basic';
 import type { ExtractLinksOptions } from '@crawlee/basic';
 import type { GetUserDataFromRequest } from '@crawlee/basic';
 import type { IBrowserPool } from '@crawlee/types';
-import type { InferBrowserPluginArray } from '@crawlee/browser-pool';
-import type { LaunchContext } from '@crawlee/browser-pool';
 import type { LoadedRequest } from '@crawlee/basic';
+import type { RemoteBrowserPoolOptions } from '@crawlee/browser-pool';
 import { Request as Request_2 } from '@crawlee/basic';
 import type { RequestHandler } from '@crawlee/basic';
 import type { RouterHandler } from '@crawlee/basic';
 import { z } from 'zod';
+
+// @public
+export function assertBrowserPoolNotConfigured(crawlerName: string, ignoredOptions: Dictionary): void;
 
 // Not exported by the entry point; reachable only as a referenced type.
 // @public (undocumented)
@@ -43,9 +43,10 @@ interface BaseResponse {
 }
 
 // @public
-export abstract class BrowserCrawler<Page extends CommonPage = CommonPage, Response extends BaseResponse = BaseResponse, InternalBrowserPoolOptions extends BrowserPoolOptions = BrowserPoolOptions, LaunchOptions extends Dictionary | undefined = Dictionary, Context extends BrowserCrawlingContext<Page, Response> = BrowserCrawlingContext<Page, Response>, ContextExtension = Dictionary<never>, ExtendedContext extends Context = Context & ContextExtension, Routes extends Record<keyof Routes, Dictionary> = Record<string, GetUserDataFromRequest<Context['request']>>, GoToOptions extends Dictionary = Dictionary> extends BasicCrawler<Context, ContextExtension, ExtendedContext, Routes> {
+export abstract class BrowserCrawler<Page extends CommonPage = CommonPage, Response extends BaseResponse = BaseResponse, LaunchOptions extends Dictionary | undefined = Dictionary, Context extends BrowserCrawlingContext<Page, Response> = BrowserCrawlingContext<Page, Response>, ContextExtension = Dictionary<never>, ExtendedContext extends Context = Context & ContextExtension, Routes extends Record<keyof Routes, Dictionary> = Record<string, GetUserDataFromRequest<Context['request']>>, GoToOptions extends Dictionary = Dictionary> extends BasicCrawler<Context, ContextExtension, ExtendedContext, Routes> {
     protected constructor(options: BrowserCrawlerOptions<Page, Response, Context, ContextExtension, ExtendedContext> & {
         contextPipelineBuilder: () => ContextPipeline<CrawlingContext, Context>;
+        browserPoolBuilder: (remoteBrowser?: CrawlerRemoteBrowserOptions) => OwnedBrowserPool<Page>;
     });
     get browserPool(): IBrowserPool<Page>;
     // (undocumented)
@@ -66,10 +67,9 @@ export abstract class BrowserCrawler<Page extends CommonPage = CommonPage, Respo
         preNavigationHooks: z.ZodDefault<z.ZodCustom<unknown[], unknown[]>>;
         postNavigationHooks: z.ZodDefault<z.ZodCustom<unknown[], unknown[]>>;
         launchContext: z.ZodDefault<z.ZodCustom<Dictionary, Dictionary>>;
-        headless: z.ZodOptional<z.ZodUnion<readonly [z.ZodBoolean, z.ZodString]>>;
         browserPool: z.ZodOptional<z.ZodType<Dictionary<any>, unknown, z.core.$ZodTypeInternals<Dictionary<any>, unknown>>>;
+        browserPoolBuilder: z.ZodOptional<z.ZodCustom<(...args: any[]) => unknown, (...args: any[]) => unknown>>;
         remoteBrowser: z.ZodOptional<z.ZodCustom<Dictionary, Dictionary>>;
-        browserPoolOptions: z.ZodOptional<z.ZodCustom<Dictionary, Dictionary>>;
         saveResponseCookies: z.ZodDefault<z.ZodBoolean>;
         proxyConfiguration: z.ZodOptional<z.ZodType<Dictionary<any>, unknown, z.core.$ZodTypeInternals<Dictionary<any>, unknown>>>;
         ignoreIframes: z.ZodDefault<z.ZodBoolean>;
@@ -122,10 +122,9 @@ export abstract class BrowserCrawler<Page extends CommonPage = CommonPage, Respo
         preNavigationHooks: z.ZodDefault<z.ZodCustom<unknown[], unknown[]>>;
         postNavigationHooks: z.ZodDefault<z.ZodCustom<unknown[], unknown[]>>;
         launchContext: z.ZodDefault<z.ZodCustom<Dictionary, Dictionary>>;
-        headless: z.ZodOptional<z.ZodUnion<readonly [z.ZodBoolean, z.ZodString]>>;
         browserPool: z.ZodOptional<z.ZodType<Dictionary<any>, unknown, z.core.$ZodTypeInternals<Dictionary<any>, unknown>>>;
+        browserPoolBuilder: z.ZodOptional<z.ZodCustom<(...args: any[]) => unknown, (...args: any[]) => unknown>>;
         remoteBrowser: z.ZodOptional<z.ZodCustom<Dictionary, Dictionary>>;
-        browserPoolOptions: z.ZodOptional<z.ZodCustom<Dictionary, Dictionary>>;
         saveResponseCookies: z.ZodDefault<z.ZodBoolean>;
         proxyConfiguration: z.ZodOptional<z.ZodType<Dictionary<any>, unknown, z.core.$ZodTypeInternals<Dictionary<any>, unknown>>>;
         ignoreIframes: z.ZodDefault<z.ZodBoolean>;
@@ -176,12 +175,10 @@ export abstract class BrowserCrawler<Page extends CommonPage = CommonPage, Respo
 }
 
 // @public (undocumented)
-export interface BrowserCrawlerOptions<Page extends CommonPage = CommonPage, Response extends BaseResponse = BaseResponse, Context extends BrowserCrawlingContext<Page, Response> = BrowserCrawlingContext<Page, Response>, ContextExtension = Dictionary<never>, ExtendedContext extends Context = Context & ContextExtension, InternalBrowserPoolOptions extends BrowserPoolOptions = BrowserPoolOptions, Routes extends Record<keyof Routes, Dictionary> = Record<string, GetUserDataFromRequest<Context['request']>>, __BrowserPlugins extends BrowserPlugin[] = InferBrowserPluginArray<InternalBrowserPoolOptions['browserPlugins']>, __BrowserControllerReturn extends BrowserController = ReturnType<__BrowserPlugins[number]['createController']>, __LaunchContextReturn extends LaunchContext = ReturnType<__BrowserPlugins[number]['createLaunchContext']>> extends Omit<BasicCrawlerOptions<Context, ContextExtension, ExtendedContext>, 'requestHandler' | 'failedRequestHandler' | 'errorHandler'> {
+export interface BrowserCrawlerOptions<Page extends CommonPage = CommonPage, Response extends BaseResponse = BaseResponse, Context extends BrowserCrawlingContext<Page, Response> = BrowserCrawlingContext<Page, Response>, ContextExtension = Dictionary<never>, ExtendedContext extends Context = Context & ContextExtension, Routes extends Record<keyof Routes, Dictionary> = Record<string, GetUserDataFromRequest<Context['request']>>> extends Omit<BasicCrawlerOptions<Context, ContextExtension, ExtendedContext>, 'requestHandler' | 'failedRequestHandler' | 'errorHandler'> {
     browserPool?: IBrowserPool<Page>;
-    browserPoolOptions?: Partial<BrowserPoolOptions> & Partial<BrowserPoolHooks<__BrowserControllerReturn, __LaunchContextReturn>>;
     errorHandler?: ErrorHandler<CrawlingContext, ExtendedContext>;
     failedRequestHandler?: ErrorHandler<CrawlingContext, ExtendedContext>;
-    headless?: boolean | 'new' | 'old';
     ignoreIframes?: boolean;
     ignoreShadowRoots?: boolean;
     // (undocumented)
@@ -219,6 +216,19 @@ export interface BrowserLaunchContext<TOptions, Launcher> extends BrowserPluginO
     userAgent?: string;
     userDataDir?: string;
 }
+
+// @public
+export type LauncherBrowserPoolOptions = Omit<BrowserPoolOptions, 'browserPlugins'> & {
+    [Hook in keyof BrowserPoolHooks<any, any, any>]?: readonly ((...args: any[]) => unknown)[];
+};
+
+// @public
+export type LauncherRemoteBrowserPoolOptions = Omit<RemoteBrowserPoolOptions, 'browserPlugins'>;
+
+// @public
+export type OwnedBrowserPool<Page> = IBrowserPool<Page> & {
+    destroy: () => Promise<void>;
+};
 
 
 export * from "@crawlee/basic";

--- a/docs/public-api/crawlee-playwright.api.md
+++ b/docs/public-api/crawlee-playwright.api.md
@@ -12,10 +12,13 @@ import type { BasicCrawlerOptions } from '@crawlee/basic';
 import { BatchAddRequestsResult } from '@crawlee/types';
 import type { Browser } from 'playwright';
 import { BrowserCrawler } from '@crawlee/browser';
-import type { BrowserCrawlerOptions } from '@crawlee/browser';
+import { BrowserCrawlerOptions } from '@crawlee/browser';
 import type { BrowserCrawlingContext } from '@crawlee/browser';
 import type { BrowserHook } from '@crawlee/browser';
 import type { BrowserLaunchContext } from '@crawlee/browser';
+import type { BrowserPool } from '@crawlee/browser-pool';
+import type { BrowserPoolHooks } from '@crawlee/browser-pool';
+import type { BrowserPoolOptions } from '@crawlee/browser-pool';
 import type { BrowserType } from 'playwright';
 import { Cheerio } from 'cheerio';
 import { CheerioAPI } from '@crawlee/browser';
@@ -37,6 +40,8 @@ import type { LoadedRequest } from '@crawlee/browser';
 import type { Page } from 'playwright';
 import { PlaywrightPlugin } from '@crawlee/browser-pool';
 import type { RecoverableStatePersistenceOptions } from '@crawlee/core';
+import type { RemoteBrowserPool } from '@crawlee/browser-pool';
+import type { RemoteBrowserPoolOptions } from '@crawlee/browser-pool';
 import type { Request as Request_2 } from '@crawlee/core';
 import { Request as Request_3 } from '@crawlee/browser';
 import type { RequestHandler } from '@crawlee/browser';
@@ -300,6 +305,21 @@ export function launchPlaywright(launchContext?: PlaywrightLaunchContext, config
 // @public
 function parseWithCheerio(page: Page, ignoreShadowRoots?: boolean, ignoreIframes?: boolean): Promise<CheerioRoot>;
 
+// @public
+export type PlaywrightBrowserPool = BrowserPool<{
+    browserPlugins: [PlaywrightPlugin];
+}, [PlaywrightPlugin]>;
+
+// @public
+export function playwrightBrowserPool(options?: PlaywrightBrowserPoolOptions): PlaywrightBrowserPool;
+
+// @public (undocumented)
+export interface PlaywrightBrowserPoolOptions extends Omit<BrowserPoolOptions, 'browserPlugins'>, BrowserPoolHooks<ReturnType<PlaywrightPlugin['createController']>, ReturnType<PlaywrightPlugin['createLaunchContext']>, Page> {
+    configuration?: Configuration;
+    headless?: boolean;
+    launchContext?: PlaywrightLaunchContext;
+}
+
 declare namespace playwrightClickElements {
     export {
         enqueueLinksByClickingElements,
@@ -326,9 +346,7 @@ interface PlaywrightContextUtils {
 }
 
 // @public
-export class PlaywrightCrawler<ContextExtension = Dictionary<never>, ExtendedContext extends PlaywrightCrawlingContext = PlaywrightCrawlingContext & ContextExtension, Routes extends Record<keyof Routes, Dictionary> = Record<string, GetUserDataFromRequest<PlaywrightCrawlingContext['request']>>> extends BrowserCrawler<Page, Response_2, {
-    browserPlugins: [PlaywrightPlugin];
-}, LaunchOptions, PlaywrightCrawlingContext, ContextExtension, ExtendedContext, Routes> {
+export class PlaywrightCrawler<ContextExtension = Dictionary<never>, ExtendedContext extends PlaywrightCrawlingContext = PlaywrightCrawlingContext & ContextExtension, Routes extends Record<keyof Routes, Dictionary> = Record<string, GetUserDataFromRequest<PlaywrightCrawlingContext['request']>>> extends BrowserCrawler<Page, Response_2, LaunchOptions, PlaywrightCrawlingContext, ContextExtension, ExtendedContext, Routes> {
     constructor(options?: PlaywrightCrawlerOptions<ContextExtension, ExtendedContext, Routes>);
     // (undocumented)
     protected buildContextPipeline(): ContextPipeline<CrawlingContext<Dictionary>, BrowserCrawlingContext<Page, Response_2, Dictionary, Dictionary> & {
@@ -349,14 +367,14 @@ export class PlaywrightCrawler<ContextExtension = Dictionary<never>, ExtendedCon
     protected navigationHandler(crawlingContext: PlaywrightCrawlingContext, gotoOptions: PlaywrightDirectNavigationOptions): Promise<Response_2 | null>;
     // (undocumented)
     protected static optionsSchema: z.ZodObject<{
-        browserPoolOptions: z.ZodOptional<z.ZodCustom<Dictionary, Dictionary>>;
+        headless: z.ZodOptional<z.ZodBoolean>;
         launcher: z.ZodOptional<z.ZodCustom<Dictionary, Dictionary>>;
         navigationTimeoutSecs: z.ZodDefault<z.ZodCustom<number, number>>;
         preNavigationHooks: z.ZodDefault<z.ZodCustom<unknown[], unknown[]>>;
         postNavigationHooks: z.ZodDefault<z.ZodCustom<unknown[], unknown[]>>;
         launchContext: z.ZodDefault<z.ZodCustom<Dictionary, Dictionary>>;
-        headless: z.ZodOptional<z.ZodUnion<readonly [z.ZodBoolean, z.ZodString]>>;
         browserPool: z.ZodOptional<z.ZodType<Dictionary<any>, unknown, z.core.$ZodTypeInternals<Dictionary<any>, unknown>>>;
+        browserPoolBuilder: z.ZodOptional<z.ZodCustom<(...args: any[]) => unknown, (...args: any[]) => unknown>>;
         remoteBrowser: z.ZodOptional<z.ZodCustom<Dictionary, Dictionary>>;
         saveResponseCookies: z.ZodDefault<z.ZodBoolean>;
         proxyConfiguration: z.ZodOptional<z.ZodType<Dictionary<any>, unknown, z.core.$ZodTypeInternals<Dictionary<any>, unknown>>>;
@@ -406,14 +424,14 @@ export class PlaywrightCrawler<ContextExtension = Dictionary<never>, ExtendedCon
     }, z.core.$strict>;
     // (undocumented)
     protected static optionsShape: {
-        browserPoolOptions: z.ZodOptional<z.ZodCustom<Dictionary, Dictionary>>;
+        headless: z.ZodOptional<z.ZodBoolean>;
         launcher: z.ZodOptional<z.ZodCustom<Dictionary, Dictionary>>;
         navigationTimeoutSecs: z.ZodDefault<z.ZodCustom<number, number>>;
         preNavigationHooks: z.ZodDefault<z.ZodCustom<unknown[], unknown[]>>;
         postNavigationHooks: z.ZodDefault<z.ZodCustom<unknown[], unknown[]>>;
         launchContext: z.ZodDefault<z.ZodCustom<Dictionary, Dictionary>>;
-        headless: z.ZodOptional<z.ZodUnion<readonly [z.ZodBoolean, z.ZodString]>>;
         browserPool: z.ZodOptional<z.ZodType<Dictionary<any>, unknown, z.core.$ZodTypeInternals<Dictionary<any>, unknown>>>;
+        browserPoolBuilder: z.ZodOptional<z.ZodCustom<(...args: any[]) => unknown, (...args: any[]) => unknown>>;
         remoteBrowser: z.ZodOptional<z.ZodCustom<Dictionary, Dictionary>>;
         saveResponseCookies: z.ZodDefault<z.ZodBoolean>;
         proxyConfiguration: z.ZodOptional<z.ZodType<Dictionary<any>, unknown, z.core.$ZodTypeInternals<Dictionary<any>, unknown>>>;
@@ -464,9 +482,8 @@ export class PlaywrightCrawler<ContextExtension = Dictionary<never>, ExtendedCon
 }
 
 // @public (undocumented)
-export interface PlaywrightCrawlerOptions<ContextExtension = Dictionary<never>, ExtendedContext extends PlaywrightCrawlingContext = PlaywrightCrawlingContext & ContextExtension, Routes extends Record<keyof Routes, Dictionary> = Record<string, GetUserDataFromRequest<PlaywrightCrawlingContext['request']>>> extends BrowserCrawlerOptions<Page, Response_2, PlaywrightCrawlingContext, ContextExtension, ExtendedContext, {
-    browserPlugins: [PlaywrightPlugin];
-}, Routes> {
+export interface PlaywrightCrawlerOptions<ContextExtension = Dictionary<never>, ExtendedContext extends PlaywrightCrawlingContext = PlaywrightCrawlingContext & ContextExtension, Routes extends Record<keyof Routes, Dictionary> = Record<string, GetUserDataFromRequest<PlaywrightCrawlingContext['request']>>> extends BrowserCrawlerOptions<Page, Response_2, PlaywrightCrawlingContext, ContextExtension, ExtendedContext, Routes> {
+    headless?: boolean;
     launchContext?: PlaywrightLaunchContext;
     postNavigationHooks?: BrowserHook<PlaywrightCrawlingContext<GetUserDataFromRequest<ExtendedContext['request']>>, ContextExtension>[];
     preNavigationHooks?: BrowserHook<PlaywrightCrawlingContext<GetUserDataFromRequest<ExtendedContext['request']>>, ContextExtension>[];
@@ -523,6 +540,13 @@ declare namespace playwrightUtils {
         enqueueLinksByClickingElements,
         playwrightUtils_2 as playwrightUtils
     }
+}
+
+// @public
+export function remotePlaywrightBrowserPool(options: RemotePlaywrightBrowserPoolOptions): RemoteBrowserPool<Page>;
+
+// @public (undocumented)
+export interface RemotePlaywrightBrowserPoolOptions extends Pick<PlaywrightBrowserPoolOptions, 'launchContext' | 'headless' | 'configuration'>, Omit<RemoteBrowserPoolOptions, 'browserPlugins'> {
 }
 
 // @public (undocumented)

--- a/docs/public-api/crawlee-puppeteer.api.md
+++ b/docs/public-api/crawlee-puppeteer.api.md
@@ -8,10 +8,13 @@ import { BaseHttpClient } from '@crawlee/http-client';
 import { BatchAddRequestsResult } from '@crawlee/types';
 import type { Browser } from 'puppeteer';
 import { BrowserCrawler } from '@crawlee/browser';
-import type { BrowserCrawlerOptions } from '@crawlee/browser';
+import { BrowserCrawlerOptions } from '@crawlee/browser';
 import type { BrowserCrawlingContext } from '@crawlee/browser';
 import type { BrowserHook } from '@crawlee/browser';
 import type { BrowserLaunchContext } from '@crawlee/browser';
+import type { BrowserPool } from '@crawlee/browser-pool';
+import type { BrowserPoolHooks } from '@crawlee/browser-pool';
+import type { BrowserPoolOptions } from '@crawlee/browser-pool';
 import { CheerioAPI } from '@crawlee/browser';
 import { CheerioRoot } from '@crawlee/utils/internal';
 import type { ClickOptions } from 'puppeteer';
@@ -27,6 +30,8 @@ import { IRequestManager } from '@crawlee/browser';
 import type { LaunchOptions } from 'puppeteer';
 import type { Page } from 'puppeteer';
 import { PuppeteerPlugin } from '@crawlee/browser-pool';
+import type { RemoteBrowserPool } from '@crawlee/browser-pool';
+import type { RemoteBrowserPoolOptions } from '@crawlee/browser-pool';
 import { Request as Request_2 } from '@crawlee/browser';
 import type { RequestTransform } from '@crawlee/browser';
 import type { ResponseForRequest } from 'puppeteer';
@@ -145,6 +150,21 @@ export function launchPuppeteer(launchContext?: PuppeteerLaunchContext, configur
 // @public
 function parseWithCheerio(page: Page, ignoreShadowRoots?: boolean, ignoreIframes?: boolean): Promise<CheerioRoot>;
 
+// @public
+export type PuppeteerBrowserPool = BrowserPool<{
+    browserPlugins: [PuppeteerPlugin];
+}, [PuppeteerPlugin]>;
+
+// @public
+export function puppeteerBrowserPool(options?: PuppeteerBrowserPoolOptions): PuppeteerBrowserPool;
+
+// @public (undocumented)
+export interface PuppeteerBrowserPoolOptions extends Omit<BrowserPoolOptions, 'browserPlugins'>, BrowserPoolHooks<ReturnType<PuppeteerPlugin['createController']>, ReturnType<PuppeteerPlugin['createLaunchContext']>, Page> {
+    configuration?: Configuration;
+    headless?: boolean | 'new' | 'old';
+    launchContext?: PuppeteerLaunchContext;
+}
+
 declare namespace puppeteerClickElements {
     export {
         enqueueLinksByClickingElements,
@@ -172,9 +192,7 @@ interface PuppeteerContextUtils {
 }
 
 // @public
-export class PuppeteerCrawler<ContextExtension = Dictionary<never>, ExtendedContext extends PuppeteerCrawlingContext = PuppeteerCrawlingContext & ContextExtension, Routes extends Record<keyof Routes, Dictionary> = Record<string, GetUserDataFromRequest<PuppeteerCrawlingContext['request']>>> extends BrowserCrawler<Page, HTTPResponse, {
-    browserPlugins: [PuppeteerPlugin];
-}, LaunchOptions, PuppeteerCrawlingContext, ContextExtension, ExtendedContext, Routes> {
+export class PuppeteerCrawler<ContextExtension = Dictionary<never>, ExtendedContext extends PuppeteerCrawlingContext = PuppeteerCrawlingContext & ContextExtension, Routes extends Record<keyof Routes, Dictionary> = Record<string, GetUserDataFromRequest<PuppeteerCrawlingContext['request']>>> extends BrowserCrawler<Page, HTTPResponse, LaunchOptions, PuppeteerCrawlingContext, ContextExtension, ExtendedContext, Routes> {
     constructor(options?: PuppeteerCrawlerOptions<ContextExtension, ExtendedContext, Routes>);
     // (undocumented)
     protected buildContextPipeline(): ContextPipeline<CrawlingContext<Dictionary>, BrowserCrawlingContext<Page, HTTPResponse, Dictionary, Dictionary> & {
@@ -195,13 +213,13 @@ export class PuppeteerCrawler<ContextExtension = Dictionary<never>, ExtendedCont
     protected navigationHandler(crawlingContext: PuppeteerCrawlingContext, gotoOptions: PuppeteerDirectNavigationOptions): Promise<HTTPResponse | null>;
     // (undocumented)
     protected static optionsSchema: z.ZodObject<{
-        browserPoolOptions: z.ZodOptional<z.ZodCustom<Dictionary, Dictionary>>;
+        headless: z.ZodOptional<z.ZodUnion<readonly [z.ZodBoolean, z.ZodString]>>;
         navigationTimeoutSecs: z.ZodDefault<z.ZodCustom<number, number>>;
         preNavigationHooks: z.ZodDefault<z.ZodCustom<unknown[], unknown[]>>;
         postNavigationHooks: z.ZodDefault<z.ZodCustom<unknown[], unknown[]>>;
         launchContext: z.ZodDefault<z.ZodCustom<Dictionary, Dictionary>>;
-        headless: z.ZodOptional<z.ZodUnion<readonly [z.ZodBoolean, z.ZodString]>>;
         browserPool: z.ZodOptional<z.ZodType<Dictionary<any>, unknown, z.core.$ZodTypeInternals<Dictionary<any>, unknown>>>;
+        browserPoolBuilder: z.ZodOptional<z.ZodCustom<(...args: any[]) => unknown, (...args: any[]) => unknown>>;
         remoteBrowser: z.ZodOptional<z.ZodCustom<Dictionary, Dictionary>>;
         saveResponseCookies: z.ZodDefault<z.ZodBoolean>;
         proxyConfiguration: z.ZodOptional<z.ZodType<Dictionary<any>, unknown, z.core.$ZodTypeInternals<Dictionary<any>, unknown>>>;
@@ -251,13 +269,13 @@ export class PuppeteerCrawler<ContextExtension = Dictionary<never>, ExtendedCont
     }, z.core.$strict>;
     // (undocumented)
     protected static optionsShape: {
-        browserPoolOptions: z.ZodOptional<z.ZodCustom<Dictionary, Dictionary>>;
+        headless: z.ZodOptional<z.ZodUnion<readonly [z.ZodBoolean, z.ZodString]>>;
         navigationTimeoutSecs: z.ZodDefault<z.ZodCustom<number, number>>;
         preNavigationHooks: z.ZodDefault<z.ZodCustom<unknown[], unknown[]>>;
         postNavigationHooks: z.ZodDefault<z.ZodCustom<unknown[], unknown[]>>;
         launchContext: z.ZodDefault<z.ZodCustom<Dictionary, Dictionary>>;
-        headless: z.ZodOptional<z.ZodUnion<readonly [z.ZodBoolean, z.ZodString]>>;
         browserPool: z.ZodOptional<z.ZodType<Dictionary<any>, unknown, z.core.$ZodTypeInternals<Dictionary<any>, unknown>>>;
+        browserPoolBuilder: z.ZodOptional<z.ZodCustom<(...args: any[]) => unknown, (...args: any[]) => unknown>>;
         remoteBrowser: z.ZodOptional<z.ZodCustom<Dictionary, Dictionary>>;
         saveResponseCookies: z.ZodDefault<z.ZodBoolean>;
         proxyConfiguration: z.ZodOptional<z.ZodType<Dictionary<any>, unknown, z.core.$ZodTypeInternals<Dictionary<any>, unknown>>>;
@@ -308,9 +326,8 @@ export class PuppeteerCrawler<ContextExtension = Dictionary<never>, ExtendedCont
 }
 
 // @public (undocumented)
-export interface PuppeteerCrawlerOptions<ContextExtension = Dictionary<never>, ExtendedContext extends PuppeteerCrawlingContext = PuppeteerCrawlingContext & ContextExtension, Routes extends Record<keyof Routes, Dictionary> = Record<string, GetUserDataFromRequest<PuppeteerCrawlingContext['request']>>> extends BrowserCrawlerOptions<Page, HTTPResponse, PuppeteerCrawlingContext, ContextExtension, ExtendedContext, {
-    browserPlugins: [PuppeteerPlugin];
-}, Routes> {
+export interface PuppeteerCrawlerOptions<ContextExtension = Dictionary<never>, ExtendedContext extends PuppeteerCrawlingContext = PuppeteerCrawlingContext & ContextExtension, Routes extends Record<keyof Routes, Dictionary> = Record<string, GetUserDataFromRequest<PuppeteerCrawlingContext['request']>>> extends BrowserCrawlerOptions<Page, HTTPResponse, PuppeteerCrawlingContext, ContextExtension, ExtendedContext, Routes> {
+    headless?: boolean | 'new' | 'old';
     launchContext?: PuppeteerLaunchContext;
     postNavigationHooks?: BrowserHook<PuppeteerCrawlingContext<GetUserDataFromRequest<ExtendedContext['request']>>, ContextExtension>[];
     preNavigationHooks?: BrowserHook<PuppeteerCrawlingContext<GetUserDataFromRequest<ExtendedContext['request']>>, ContextExtension>[];
@@ -377,6 +394,13 @@ declare namespace puppeteerUtils {
         removeInterceptRequestHandler,
         puppeteerUtils_2 as puppeteerUtils
     }
+}
+
+// @public
+export function remotePuppeteerBrowserPool(options: RemotePuppeteerBrowserPoolOptions): RemoteBrowserPool<Page>;
+
+// @public (undocumented)
+export interface RemotePuppeteerBrowserPoolOptions extends Pick<PuppeteerBrowserPoolOptions, 'launchContext' | 'headless' | 'configuration'>, Omit<RemoteBrowserPoolOptions, 'browserPlugins'> {
 }
 
 // @public

--- a/docs/public-api/crawlee-stagehand.api.md
+++ b/docs/public-api/crawlee-stagehand.api.md
@@ -13,12 +13,15 @@ import { BaseHttpClient } from '@crawlee/http-client';
 import type { Browser } from 'playwright';
 import type { BrowserController } from '@crawlee/browser-pool';
 import { BrowserCrawler } from '@crawlee/browser';
-import type { BrowserCrawlerOptions } from '@crawlee/browser';
+import { BrowserCrawlerOptions } from '@crawlee/browser';
 import type { BrowserCrawlingContext } from '@crawlee/browser';
 import type { BrowserHook } from '@crawlee/browser';
 import type { BrowserLaunchContext } from '@crawlee/browser';
 import { BrowserPlugin } from '@crawlee/browser-pool';
 import type { BrowserPluginOptions } from '@crawlee/browser-pool';
+import type { BrowserPool } from '@crawlee/browser-pool';
+import type { BrowserPoolHooks } from '@crawlee/browser-pool';
+import type { BrowserPoolOptions } from '@crawlee/browser-pool';
 import type { BrowserType } from 'playwright';
 import { Configuration } from '@crawlee/browser';
 import type { ContextPipeline } from '@crawlee/browser';
@@ -35,6 +38,8 @@ import { ModelConfiguration } from '@browserbasehq/stagehand';
 import type { NonStreamingAgentInstance } from '@browserbasehq/stagehand';
 import { ObserveOptions } from '@browserbasehq/stagehand';
 import type { Page } from 'playwright';
+import type { RemoteBrowserPool } from '@crawlee/browser-pool';
+import type { RemoteBrowserPoolOptions } from '@crawlee/browser-pool';
 import type { RequestHandler } from '@crawlee/browser';
 import type { Response as Response_2 } from 'playwright';
 import type { RouterHandler } from '@crawlee/browser';
@@ -70,12 +75,33 @@ export { ModelConfiguration }
 
 export { ObserveOptions }
 
+// @public
+export function remoteStagehandBrowserPool(options: RemoteStagehandBrowserPoolOptions): RemoteBrowserPool<Page>;
+
+// @public (undocumented)
+export interface RemoteStagehandBrowserPoolOptions extends Pick<StagehandBrowserPoolOptions, 'launchContext' | 'stagehandOptions' | 'headless' | 'configuration'>, Omit<RemoteBrowserPoolOptions, 'browserPlugins'> {
+}
+
 export { Stagehand }
 
 // @public
-export class StagehandCrawler<ContextExtension = Dictionary<never>, ExtendedContext extends StagehandCrawlingContext = StagehandCrawlingContext & ContextExtension, Routes extends Record<keyof Routes, Dictionary> = Record<string, GetUserDataFromRequest<StagehandCrawlingContext['request']>>> extends BrowserCrawler<StagehandPage, Response_2, {
+export type StagehandBrowserPool = BrowserPool<{
     browserPlugins: [StagehandPlugin];
-}, LaunchOptions, StagehandCrawlingContext, ContextExtension, ExtendedContext, Routes> {
+}, [StagehandPlugin]>;
+
+// @public
+export function stagehandBrowserPool(options?: StagehandBrowserPoolOptions): StagehandBrowserPool;
+
+// @public (undocumented)
+export interface StagehandBrowserPoolOptions extends Omit<BrowserPoolOptions, 'browserPlugins'>, BrowserPoolHooks<ReturnType<StagehandPlugin['createController']>, ReturnType<StagehandPlugin['createLaunchContext']>, Page> {
+    configuration?: Configuration;
+    headless?: boolean;
+    launchContext?: StagehandLaunchContext;
+    stagehandOptions?: StagehandOptions;
+}
+
+// @public
+export class StagehandCrawler<ContextExtension = Dictionary<never>, ExtendedContext extends StagehandCrawlingContext = StagehandCrawlingContext & ContextExtension, Routes extends Record<keyof Routes, Dictionary> = Record<string, GetUserDataFromRequest<StagehandCrawlingContext['request']>>> extends BrowserCrawler<StagehandPage, Response_2, LaunchOptions, StagehandCrawlingContext, ContextExtension, ExtendedContext, Routes> {
     constructor(options?: StagehandCrawlerOptions<ContextExtension, ExtendedContext, Routes>);
     // (undocumented)
     protected buildContextPipeline(): ContextPipeline<CrawlingContext, StagehandCrawlingContext>;
@@ -83,13 +109,13 @@ export class StagehandCrawler<ContextExtension = Dictionary<never>, ExtendedCont
     // (undocumented)
     protected static optionsSchema: z.ZodObject<{
         stagehandOptions: z.ZodOptional<z.ZodCustom<Dictionary, Dictionary>>;
-        browserPoolOptions: z.ZodOptional<z.ZodCustom<Dictionary, Dictionary>>;
+        headless: z.ZodOptional<z.ZodBoolean>;
         navigationTimeoutSecs: z.ZodDefault<z.ZodCustom<number, number>>;
         preNavigationHooks: z.ZodDefault<z.ZodCustom<unknown[], unknown[]>>;
         postNavigationHooks: z.ZodDefault<z.ZodCustom<unknown[], unknown[]>>;
         launchContext: z.ZodDefault<z.ZodCustom<Dictionary, Dictionary>>;
-        headless: z.ZodOptional<z.ZodUnion<readonly [z.ZodBoolean, z.ZodString]>>;
         browserPool: z.ZodOptional<z.ZodType<Dictionary<any>, unknown, z.core.$ZodTypeInternals<Dictionary<any>, unknown>>>;
+        browserPoolBuilder: z.ZodOptional<z.ZodCustom<(...args: any[]) => unknown, (...args: any[]) => unknown>>;
         remoteBrowser: z.ZodOptional<z.ZodCustom<Dictionary, Dictionary>>;
         saveResponseCookies: z.ZodDefault<z.ZodBoolean>;
         proxyConfiguration: z.ZodOptional<z.ZodType<Dictionary<any>, unknown, z.core.$ZodTypeInternals<Dictionary<any>, unknown>>>;
@@ -140,13 +166,13 @@ export class StagehandCrawler<ContextExtension = Dictionary<never>, ExtendedCont
     // (undocumented)
     protected static optionsShape: {
         stagehandOptions: z.ZodOptional<z.ZodCustom<Dictionary, Dictionary>>;
-        browserPoolOptions: z.ZodOptional<z.ZodCustom<Dictionary, Dictionary>>;
+        headless: z.ZodOptional<z.ZodBoolean>;
         navigationTimeoutSecs: z.ZodDefault<z.ZodCustom<number, number>>;
         preNavigationHooks: z.ZodDefault<z.ZodCustom<unknown[], unknown[]>>;
         postNavigationHooks: z.ZodDefault<z.ZodCustom<unknown[], unknown[]>>;
         launchContext: z.ZodDefault<z.ZodCustom<Dictionary, Dictionary>>;
-        headless: z.ZodOptional<z.ZodUnion<readonly [z.ZodBoolean, z.ZodString]>>;
         browserPool: z.ZodOptional<z.ZodType<Dictionary<any>, unknown, z.core.$ZodTypeInternals<Dictionary<any>, unknown>>>;
+        browserPoolBuilder: z.ZodOptional<z.ZodCustom<(...args: any[]) => unknown, (...args: any[]) => unknown>>;
         remoteBrowser: z.ZodOptional<z.ZodCustom<Dictionary, Dictionary>>;
         saveResponseCookies: z.ZodDefault<z.ZodBoolean>;
         proxyConfiguration: z.ZodOptional<z.ZodType<Dictionary<any>, unknown, z.core.$ZodTypeInternals<Dictionary<any>, unknown>>>;
@@ -197,9 +223,8 @@ export class StagehandCrawler<ContextExtension = Dictionary<never>, ExtendedCont
 }
 
 // @public
-export interface StagehandCrawlerOptions<ContextExtension = Dictionary<never>, ExtendedContext extends StagehandCrawlingContext = StagehandCrawlingContext & ContextExtension, Routes extends Record<keyof Routes, Dictionary> = Record<string, GetUserDataFromRequest<StagehandCrawlingContext['request']>>> extends BrowserCrawlerOptions<StagehandPage, Response_2, StagehandCrawlingContext, ContextExtension, ExtendedContext, {
-    browserPlugins: [StagehandPlugin];
-}, Routes> {
+export interface StagehandCrawlerOptions<ContextExtension = Dictionary<never>, ExtendedContext extends StagehandCrawlingContext = StagehandCrawlingContext & ContextExtension, Routes extends Record<keyof Routes, Dictionary> = Record<string, GetUserDataFromRequest<StagehandCrawlingContext['request']>>> extends BrowserCrawlerOptions<StagehandPage, Response_2, StagehandCrawlingContext, ContextExtension, ExtendedContext, Routes> {
+    headless?: boolean;
     launchContext?: StagehandLaunchContext;
     postNavigationHooks?: BrowserHook<StagehandCrawlingContext<GetUserDataFromRequest<ExtendedContext['request']>>, ContextExtension>[];
     preNavigationHooks?: BrowserHook<StagehandCrawlingContext<GetUserDataFromRequest<ExtendedContext['request']>>, ContextExtension>[];

--- a/docs/upgrading/upgrading_v4.md
+++ b/docs/upgrading/upgrading_v4.md
@@ -53,6 +53,7 @@ The purely mechanical renames, collected in one place. Where a row links to a se
 | `enqueueLinks({ globs, regexps, pseudoUrls })` | `enqueueLinks({ include })` ([details](#globs-regexps-and-pseudourls-replaced-by-include)) |
 | `(await enqueueLinks()).processedRequests` | `(await enqueueLinks()).addedRequests` ([details](#enqueuelinks-return-value-reshaped-addrequestsbatchedresult-instead-of-batchaddrequestsresult)) |
 | `autoscaledPoolOptions` | `taskLoopOptions` ([narrowed](#autoscaledpooloptions-is-now-taskloopoptions-and-no-longer-carries-concurrency-config)) |
+| `browserPoolOptions` | `browserPool` + a `*BrowserPool()` factory ([details](#browserpooloptions-is-removed)) |
 | `gotScraping` (from `@crawlee/utils`) | `GotScrapingHttpClient` (`@crawlee/got-scraping-client`) |
 | `SDK_`-prefixed internal KVS keys | `CRAWLEE_`-prefixed ([details](#internal-kvs-keys-renamed)) |
 | `ArgumentError` (from `ow`) | `ArgumentValidationError` ([details](#argument-validation-errors-use-zod)) |
@@ -442,6 +443,42 @@ The `persistCookiesPerSession` crawler option has been renamed to `saveResponseC
 Previously, `BrowserCrawler` with `saveResponseCookies` (formerly `persistCookiesPerSession`) only copied cookies from the page into the session after navigation and **before** `requestHandler` ran. Cookies set during the handler — login flows, `page.setCookie()`, or XHR/`fetch` `Set-Cookie` responses — were not stored on the session for later requests.
 
 In v4, when `saveResponseCookies` is enabled (the default), browser cookies are also re-read and stored in the session cookie jar **after** `requestHandler` completes. If you relied on handler-set cookies staying page-local and not affecting later requests on the same session, set `saveResponseCookies: false` or clear/overwrite cookies on the session explicitly.
+
+### `browserPoolOptions` is removed
+
+`browserPoolOptions` is gone from every browser crawler. It was a second way of configuring the very pool that the `browserPool` option accepts, and the two could not be combined — passing a pool made the options silently disappear.
+
+Build the pool with the factory that matches your crawler instead. Each factory takes every `BrowserPool` option plus the crawler's own `launchContext` and `headless`, and derives the browser plugin from them, so the pool can never mismatch the crawler it is passed to:
+
+| crawler | factory | remote counterpart |
+| --- | --- | --- |
+| `PlaywrightCrawler` | `playwrightBrowserPool()` | `remotePlaywrightBrowserPool()` |
+| `PuppeteerCrawler` | `puppeteerBrowserPool()` | `remotePuppeteerBrowserPool()` |
+| `StagehandCrawler` | `stagehandBrowserPool()` | `remoteStagehandBrowserPool()` |
+
+**Before:**
+```typescript
+const crawler = new PlaywrightCrawler({
+    browserPoolOptions: { useFingerprints: false },
+    launchContext: { launcher: firefox },
+});
+```
+
+**After:**
+```typescript
+const crawler = new PlaywrightCrawler({
+    browserPool: playwrightBrowserPool({
+        useFingerprints: false,
+        launchContext: { launcher: firefox },
+    }),
+});
+```
+
+Building the pool outside the crawler has one consequence worth knowing: a pool passed as `browserPool` is borrowed, so the crawler never destroys it, and the options that would have configured a pool of the crawler's own — `launchContext`, `headless` and `remoteBrowser` — are now **rejected** instead of silently ignored. Move them into the factory call.
+
+`remoteBrowser` keeps working on its own for the terse case; reach for a `remote*BrowserPool()` factory when you also want to tune the pool wrapping the remote connection, or to share one remote pool between crawlers.
+
+`headless` is now declared on each concrete crawler rather than on `BrowserCrawler`, so the puppeteer-only `'new'` and `'old'` values are only accepted by `PuppeteerCrawler`.
 
 ### `ignoreSslErrors` is renamed to `ignoreTlsErrors`
 

--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -32,17 +32,7 @@ import {
     tryAbsoluteURL,
     validators,
 } from '@crawlee/basic';
-import type {
-    BrowserController,
-    BrowserPlugin,
-    BrowserPoolHooks,
-    BrowserPoolOptions,
-    CommonPage,
-    CrawlerRemoteBrowserOptions,
-    InferBrowserPluginArray,
-    LaunchContext,
-} from '@crawlee/browser-pool';
-import { BrowserPool, RemoteBrowserPool } from '@crawlee/browser-pool';
+import type { CommonPage, CrawlerRemoteBrowserOptions } from '@crawlee/browser-pool';
 import type { Awaitable, Cookie as CookieObject, Dictionary, IBrowserPool, ISession } from '@crawlee/types';
 import { CLOUDFLARE_RETRY_CSS_SELECTORS, RETRY_CSS_SELECTORS } from '@crawlee/utils/internal';
 import { sleep } from '@crawlee/utils';
@@ -63,7 +53,26 @@ interface BaseResponse {
  * additionally exposes `destroy()` — the crawler only ever tears down pools it created, which is why {@apilink IBrowserPool}
  * itself intentionally omits `destroy`.
  */
-type OwnedBrowserPool<Page> = IBrowserPool<Page> & { destroy: () => Promise<void> };
+export type OwnedBrowserPool<Page> = IBrowserPool<Page> & { destroy: () => Promise<void> };
+
+/**
+ * Rejects options that exist only to configure the browser pool the crawler would have built for itself.
+ * Accepting them alongside a pre-built `browserPool` and quietly ignoring them is how `browserPoolOptions` grew
+ * into a second, half-working way of configuring the same pool.
+ */
+export function assertBrowserPoolNotConfigured(crawlerName: string, ignoredOptions: Dictionary): void {
+    const names = Object.keys(ignoredOptions).filter((name) => ignoredOptions[name] !== undefined);
+
+    if (names.length === 0) {
+        return;
+    }
+
+    throw new Error(
+        `${crawlerName}: ${names.map((name) => `\`${name}\``).join(', ')} cannot be combined with \`browserPool\`, ` +
+            `${names.length > 1 ? 'they configure' : 'it configures'} the browser pool the crawler would build for ` +
+            'itself. Configure the pool you pass in instead.',
+    );
+}
 
 type ContextDifference<T, U> = Omit<U, keyof T> & Partial<U>;
 
@@ -119,11 +128,7 @@ export interface BrowserCrawlerOptions<
     Context extends BrowserCrawlingContext<Page, Response> = BrowserCrawlingContext<Page, Response>,
     ContextExtension = Dictionary<never>,
     ExtendedContext extends Context = Context & ContextExtension,
-    InternalBrowserPoolOptions extends BrowserPoolOptions = BrowserPoolOptions,
     Routes extends Record<keyof Routes, Dictionary> = Record<string, GetUserDataFromRequest<Context['request']>>,
-    __BrowserPlugins extends BrowserPlugin[] = InferBrowserPluginArray<InternalBrowserPoolOptions['browserPlugins']>,
-    __BrowserControllerReturn extends BrowserController = ReturnType<__BrowserPlugins[number]['createController']>,
-    __LaunchContextReturn extends LaunchContext = ReturnType<__BrowserPlugins[number]['createLaunchContext']>,
 > extends Omit<
     BasicCrawlerOptions<Context, ContextExtension, ExtendedContext>,
     // Overridden with browser context
@@ -132,9 +137,17 @@ export interface BrowserCrawlerOptions<
     launchContext?: BrowserLaunchContext<any, any>;
 
     /**
-     * An existing browser pool instance to use. When provided, the crawler will use this pool directly instead of
-     * constructing a new one from `browserPoolOptions`, enabling browser sharing across multiple crawlers. The crawler
-     * will not tear down a shared pool — the caller is responsible for its lifecycle.
+     * The browser pool the crawler should serve its pages from. This is the single way to run a pool with
+     * non-default options: build one with the factory that matches your crawler
+     * ({@apilink playwrightBrowserPool}, {@apilink puppeteerBrowserPool}, {@apilink stagehandBrowserPool}) - it
+     * accepts every {@apilink BrowserPoolOptions|`BrowserPool` option} and supplies the correct browser plugin
+     * itself, so the pool can never mismatch the crawler.
+     *
+     * A pool passed in this way is borrowed, not owned: the crawler will not tear it down, which is what makes it
+     * shareable across crawlers. Since the crawler then builds nothing itself, the options that configure its own
+     * pool (`launchContext`, `headless`, `remoteBrowser`) are rejected rather than silently ignored.
+     *
+     * When omitted, the crawler builds - and tears down - a default pool for its own browser.
      */
     browserPool?: IBrowserPool<Page>;
 
@@ -146,8 +159,9 @@ export interface BrowserCrawlerOptions<
      * crawler. Supply the connection details only: a static `endpoint` URL, a function returning one per launch,
      * or a {@apilink RemoteBrowserProvider}.
      *
-     * Ignored when `browserPool` is set. For sharing a remote pool across crawlers, construct a
-     * {@apilink RemoteBrowserPool} yourself and pass it as `browserPool` instead.
+     * Cannot be combined with `browserPool`. To tune the pool wrapping the remote connection, or to share it
+     * across crawlers, build it with the remote factory for your crawler ({@apilink remotePlaywrightBrowserPool},
+     * {@apilink remotePuppeteerBrowserPool}, {@apilink remoteStagehandBrowserPool}) and pass it as `browserPool`.
      */
     remoteBrowser?: CrawlerRemoteBrowserOptions;
 
@@ -201,13 +215,6 @@ export interface BrowserCrawlerOptions<
      * represents the last error thrown during processing of the request.
      */
     failedRequestHandler?: ErrorHandler<CrawlingContext, ExtendedContext>;
-
-    /**
-     * Custom options passed to the underlying {@apilink BrowserPool} constructor.
-     * We can tweak those to fine-tune browser management.
-     */
-    browserPoolOptions?: Partial<BrowserPoolOptions> &
-        Partial<BrowserPoolHooks<__BrowserControllerReturn, __LaunchContextReturn>>;
 
     /**
      * Async functions that are sequentially evaluated before the navigation. Good for setting additional cookies
@@ -276,12 +283,6 @@ export interface BrowserCrawlerOptions<
      * Defines whether the cookies should be persisted for sessions. Enabled by default.
      */
     saveResponseCookies?: boolean;
-
-    /**
-     * Whether to run browser in headless mode. Defaults to `true`.
-     * Can be also set via {@apilink Configuration}.
-     */
-    headless?: boolean | 'new' | 'old'; // `new`/`old` are for puppeteer only
 
     /**
      * Whether to ignore custom elements (and their #shadow-roots) when processing the page content via `parseWithCheerio` helper.
@@ -353,7 +354,6 @@ function isNavigationTimeoutError(error: Error): boolean {
 export abstract class BrowserCrawler<
     Page extends CommonPage = CommonPage,
     Response extends BaseResponse = BaseResponse,
-    InternalBrowserPoolOptions extends BrowserPoolOptions = BrowserPoolOptions,
     LaunchOptions extends Dictionary | undefined = Dictionary,
     Context extends BrowserCrawlingContext<Page, Response> = BrowserCrawlingContext<Page, Response>,
     ContextExtension = Dictionary<never>,
@@ -392,10 +392,9 @@ export abstract class BrowserCrawler<
         postNavigationHooks: schemas.anyArray.default(() => []),
 
         launchContext: schemas.anyObject.default(() => ({})),
-        headless: z.union([z.boolean(), z.string()]).optional(),
         browserPool: validators.browserPool.optional(),
+        browserPoolBuilder: schemas.anyFunction.optional(),
         remoteBrowser: schemas.anyObject.optional(),
-        browserPoolOptions: schemas.anyObject.optional(),
         saveResponseCookies: z.boolean().default(true),
         proxyConfiguration: validators.proxyConfiguration.optional(),
         ignoreIframes: z.boolean().default(false),
@@ -410,6 +409,12 @@ export abstract class BrowserCrawler<
     protected constructor(
         options: BrowserCrawlerOptions<Page, Response, Context, ContextExtension, ExtendedContext> & {
             contextPipelineBuilder: () => ContextPipeline<CrawlingContext, Context>;
+            /**
+             * Builds the pool the crawler owns, used only when the user injected no `browserPool`. Supplied by the
+             * concrete crawler, which is the only place that knows which browser plugin to run - that is also why
+             * `remoteBrowser` is handed to it rather than acted upon here.
+             */
+            browserPoolBuilder: (remoteBrowser?: CrawlerRemoteBrowserOptions) => OwnedBrowserPool<Page>;
         },
     ) {
         const {
@@ -418,16 +423,19 @@ export abstract class BrowserCrawler<
             launchContext,
             browserPool,
             remoteBrowser,
-            browserPoolOptions,
             preNavigationHooks,
             postNavigationHooks,
-            headless,
             ignoreIframes,
             ignoreShadowRoots,
             contextPipelineBuilder,
+            browserPoolBuilder,
             extendContext,
             ...basicCrawlerOptions
         } = parseArgument(options, BrowserCrawler.optionsSchema, 'BrowserCrawlerOptions');
+
+        if (browserPool) {
+            assertBrowserPoolNotConfigured(new.target.name, { remoteBrowser });
+        }
 
         const skipGuard = <Ctx extends Context>(
             action: (ctx: Ctx) => Awaitable<void | Partial<Ctx>>,
@@ -489,44 +497,9 @@ export abstract class BrowserCrawler<
         this.ignoreIframes = ignoreIframes;
         this.ignoreShadowRoots = ignoreShadowRoots;
 
-        if (headless != null) {
-            this.launchContext.launchOptions ??= {} as LaunchOptions;
-            (this.launchContext.launchOptions as Dictionary).headless = headless;
-        }
-
         this.#saveResponseCookies = saveResponseCookies;
 
-        // `browserPool` wins over `remoteBrowser` — a passed-in pool is used as-is (borrowed), the sugar is ignored.
-        // The default is only built when no pool was injected, so all the option/launchContext fiddling below stays
-        // inside the factory.
-        this.#browserPoolDep = OwnedOrInjected.resolve(browserPool, () => {
-            const resolvedBrowserPoolOptions = browserPoolOptions ?? ({} as Partial<BrowserPoolOptions>);
-
-            if (launchContext?.userAgent) {
-                if (resolvedBrowserPoolOptions.useFingerprints)
-                    this.log.info('Custom user agent provided, disabling automatic browser fingerprint injection!');
-                resolvedBrowserPoolOptions.useFingerprints = false;
-            }
-
-            if (remoteBrowser) {
-                // The crawler already built the right plugin for its browser — hand it to a RemoteBrowserPool so the
-                // remote connection is always for the matching browser (no plugin to construct, no way to mismatch).
-                const { browserPlugins, ...remoteBrowserPoolOptions } = resolvedBrowserPoolOptions;
-                return new RemoteBrowserPool({
-                    browserPlugins: browserPlugins as BrowserPlugin[],
-                    ...remoteBrowser,
-                    browserPoolOptions: remoteBrowserPoolOptions as any,
-                }) as OwnedBrowserPool<Page>;
-            }
-
-            // Double cast: `BrowserPool` implements `IBrowserPool<PageReturn>`, where `PageReturn` is derived from the
-            // plugin/controller generics and doesn't overlap with the crawler's free `Page` type param, so TS won't
-            // narrow it directly. The concrete pool does satisfy the `Page`/`destroy` contract at runtime — this is the
-            // long-standing `Page` variance gap, not a `destroy`-related hole.
-            return new BrowserPool<InternalBrowserPoolOptions>({
-                ...(resolvedBrowserPoolOptions as any),
-            }) as unknown as OwnedBrowserPool<Page>;
-        });
+        this.#browserPoolDep = OwnedOrInjected.resolve(browserPool, () => browserPoolBuilder(remoteBrowser));
     }
 
     protected override getNavigationTimeoutMillis(): number {

--- a/packages/browser-crawler/src/internals/browser-launcher.ts
+++ b/packages/browser-crawler/src/internals/browser-launcher.ts
@@ -2,8 +2,15 @@ import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import os from 'node:os';
 
-import { Configuration, schemas } from '@crawlee/basic';
-import type { BrowserPlugin, BrowserPluginOptions } from '@crawlee/browser-pool';
+import { Configuration, schemas, serviceLocator } from '@crawlee/basic';
+import type {
+    BrowserPlugin,
+    BrowserPluginOptions,
+    BrowserPoolHooks,
+    BrowserPoolOptions,
+    RemoteBrowserPoolOptions,
+} from '@crawlee/browser-pool';
+import { BrowserPool, RemoteBrowserPool } from '@crawlee/browser-pool';
 import type { Constructor, Dictionary } from '@crawlee/types';
 import { z } from 'zod';
 
@@ -83,6 +90,21 @@ export interface BrowserLaunchContext<TOptions, Launcher> extends BrowserPluginO
      */
     launcher?: Launcher;
 }
+
+/**
+ * The {@apilink BrowserPool} options a launcher-built pool accepts: everything the pool itself takes except
+ * `browserPlugins`, which the launcher derives from its launch context. The hooks are deliberately unconstrained -
+ * the browser they run against is only known to the concrete `*BrowserPool()` factory, which is where the
+ * caller-facing types are pinned down.
+ */
+export type LauncherBrowserPoolOptions = Omit<BrowserPoolOptions, 'browserPlugins'> & {
+    [Hook in keyof BrowserPoolHooks<any, any, any>]?: readonly ((...args: any[]) => unknown)[];
+};
+
+/**
+ * The {@apilink RemoteBrowserPool} counterpart of {@apilink LauncherBrowserPoolOptions}.
+ */
+export type LauncherRemoteBrowserPoolOptions = Omit<RemoteBrowserPoolOptions, 'browserPlugins'>;
 
 /**
  * Abstract class for creating browser launchers, such as `PlaywrightLauncher` and `PuppeteerLauncher`.
@@ -171,6 +193,54 @@ export abstract class BrowserLauncher<
             launchOptions: this.createLaunchOptions(),
             ...this.otherLaunchContextProps,
         });
+    }
+
+    /**
+     * Builds a {@apilink BrowserPool} running a single plugin for this launcher's browser. Shared body of the
+     * per-library `*BrowserPool()` factories, which exist so that configuring a pool never requires assembling
+     * a plugin by hand — and therefore never lets the plugin drift away from the crawler it is used with.
+     * @internal
+     */
+    createBrowserPool(options: LauncherBrowserPoolOptions = {}): BrowserPool<{ browserPlugins: [Plugin] }, [Plugin]> {
+        // The hook types `BrowserPool` derives from `Plugin` are unresolvable while `Plugin` is still a free type
+        // parameter, so the argument cannot be checked here. The concrete `*BrowserPool()` factories are where the
+        // caller-facing hook types get pinned down.
+        return new BrowserPool<{ browserPlugins: [Plugin] }, [Plugin]>({
+            ...this.resolveFingerprinting(options),
+            browserPlugins: [this.createBrowserPlugin()],
+        } as any);
+    }
+
+    /**
+     * The {@apilink RemoteBrowserPool} counterpart of {@apilink BrowserLauncher.createBrowserPool}: the launcher
+     * supplies the plugin, the caller supplies the remote connection details.
+     * @internal
+     */
+    createRemoteBrowserPool<Page>(options: LauncherRemoteBrowserPoolOptions): RemoteBrowserPool<Page> {
+        return new RemoteBrowserPool<Page>({
+            ...options,
+            browserPlugins: [this.createBrowserPlugin()],
+            browserPoolOptions: this.resolveFingerprinting(options.browserPoolOptions ?? {}),
+        });
+    }
+
+    /**
+     * A custom `userAgent` and Crawlee's fingerprint injection would both write the same headers, so an
+     * explicitly requested user agent wins.
+     */
+    private resolveFingerprinting<T extends { useFingerprints?: boolean }>(options: T): T {
+        if (!this.userAgent) {
+            return options;
+        }
+
+        if (options.useFingerprints) {
+            serviceLocator
+                .getLogger()
+                .child({ prefix: 'BrowserLauncher' })
+                .info('Custom user agent provided, disabling automatic browser fingerprint injection!');
+        }
+
+        return { ...options, useFingerprints: false };
     }
 
     /**

--- a/packages/browser-pool/src/remote-browser-pool.ts
+++ b/packages/browser-pool/src/remote-browser-pool.ts
@@ -159,10 +159,10 @@ export interface RemoteBrowserPoolOptions {
 }
 
 /**
- * The remote-connection configuration a browser crawler accepts on its `remoteBrowser` option. It is the
- * {@apilink RemoteBrowserPoolOptions} a user supplies *minus* the parts the crawler provides itself — the
- * `browserPlugins` (the crawler builds the correct one for its browser) and `browserPoolOptions` (taken from
- * the crawler's own `browserPoolOptions`). This is what makes the crawler path both terse and mismatch-proof.
+ * The remote-connection configuration a browser crawler accepts on its `remoteBrowser` option: the
+ * {@apilink RemoteBrowserPoolOptions} minus the `browserPlugins` (the crawler builds the correct one for its
+ * browser, which is what makes this path mismatch-proof) and minus `browserPoolOptions` — tuning the wrapping
+ * pool means building the pool yourself, through the `remote*BrowserPool()` factory for your crawler.
  */
 export type CrawlerRemoteBrowserOptions = Omit<RemoteBrowserPoolOptions, 'browserPlugins' | 'browserPoolOptions'>;
 

--- a/packages/playwright-crawler/src/index.ts
+++ b/packages/playwright-crawler/src/index.ts
@@ -1,4 +1,5 @@
 export * from '@crawlee/browser';
+export * from './internals/playwright-browser-pool.js';
 export * from './internals/playwright-crawler.js';
 export * from './internals/playwright-launcher.js';
 export * from './internals/adaptive-playwright-crawler.js';

--- a/packages/playwright-crawler/src/internals/playwright-browser-pool.ts
+++ b/packages/playwright-crawler/src/internals/playwright-browser-pool.ts
@@ -1,0 +1,114 @@
+import type { Configuration } from '@crawlee/browser';
+import type {
+    BrowserPool,
+    BrowserPoolHooks,
+    BrowserPoolOptions,
+    PlaywrightPlugin,
+    RemoteBrowserPool,
+    RemoteBrowserPoolOptions,
+} from '@crawlee/browser-pool';
+import type { Page } from 'playwright';
+
+import type { PlaywrightLaunchContext } from './playwright-launcher.js';
+import { PlaywrightLauncher } from './playwright-launcher.js';
+
+/** A {@apilink BrowserPool} of Playwright browsers, as built by {@apilink playwrightBrowserPool}. */
+export type PlaywrightBrowserPool = BrowserPool<{ browserPlugins: [PlaywrightPlugin] }, [PlaywrightPlugin]>;
+
+export interface PlaywrightBrowserPoolOptions
+    extends
+        Omit<BrowserPoolOptions, 'browserPlugins'>,
+        BrowserPoolHooks<
+            ReturnType<PlaywrightPlugin['createController']>,
+            ReturnType<PlaywrightPlugin['createLaunchContext']>,
+            Page
+        > {
+    /** How to launch the browser: which Playwright browser type, proxy, user data dir, ... */
+    launchContext?: PlaywrightLaunchContext;
+
+    /**
+     * Whether to run the browser in headless mode. Shorthand for `launchContext.launchOptions.headless`.
+     * Defaults to `true`, and can also be set via {@apilink Configuration}.
+     */
+    headless?: boolean;
+
+    /** Configuration to read the browser defaults from. Defaults to the global configuration. */
+    configuration?: Configuration;
+}
+
+export interface RemotePlaywrightBrowserPoolOptions
+    extends
+        Pick<PlaywrightBrowserPoolOptions, 'launchContext' | 'headless' | 'configuration'>,
+        Omit<RemoteBrowserPoolOptions, 'browserPlugins'> {}
+
+/**
+ * Builds a {@apilink BrowserPool} of Playwright browsers to pass to a {@apilink PlaywrightCrawler} as its
+ * {@apilink BrowserCrawlerOptions.browserPool|`browserPool`}.
+ *
+ * It accepts every {@apilink BrowserPoolOptions|`BrowserPool` option} plus the crawler's own `launchContext` and
+ * `headless`, and derives the browser plugin from them - so a pool built here always matches the crawler it is
+ * given to, and configuring one never means assembling a {@apilink PlaywrightPlugin} by hand.
+ *
+ * **Example usage:**
+ *
+ * ```javascript
+ * const crawler = new PlaywrightCrawler({
+ *     browserPool: playwrightBrowserPool({
+ *         maxOpenPagesPerBrowser: 1,
+ *         launchContext: { launcher: firefox },
+ *     }),
+ *     requestHandler: async ({ page }) => { ... },
+ * });
+ * ```
+ *
+ * The returned pool is *not* torn down by the crawler, which is what makes it shareable between crawlers.
+ *
+ * @category Browser management
+ */
+export function playwrightBrowserPool(options: PlaywrightBrowserPoolOptions = {}): PlaywrightBrowserPool {
+    const { launchContext, headless, configuration, ...poolOptions } = options;
+
+    return playwrightLauncher(launchContext, headless, configuration).createBrowserPool(poolOptions);
+}
+
+/**
+ * The {@apilink RemoteBrowserPool} counterpart of {@apilink playwrightBrowserPool}: connects to a remote browser
+ * service (Browserbase, Browserless, Steel, ...) with a Playwright plugin derived from `launchContext`.
+ *
+ * A {@apilink PlaywrightCrawler} accepts the same connection details directly via
+ * {@apilink BrowserCrawlerOptions.remoteBrowser|`remoteBrowser`}; reach for this factory when you also need to
+ * tune the wrapping pool, or to share one remote pool between crawlers.
+ *
+ * **Example usage:**
+ *
+ * ```javascript
+ * const crawler = new PlaywrightCrawler({
+ *     browserPool: remotePlaywrightBrowserPool({
+ *         endpoint: 'wss://production-sfo.browserless.io?token=xxx',
+ *         maxOpenBrowsers: 2,
+ *         browserPoolOptions: { useFingerprints: false },
+ *     }),
+ *     requestHandler: async ({ page }) => { ... },
+ * });
+ * ```
+ *
+ * @category Browser management
+ */
+export function remotePlaywrightBrowserPool(options: RemotePlaywrightBrowserPoolOptions): RemoteBrowserPool<Page> {
+    const { launchContext, headless, configuration, ...remoteOptions } = options;
+
+    return playwrightLauncher(launchContext, headless, configuration).createRemoteBrowserPool<Page>(remoteOptions);
+}
+
+function playwrightLauncher(
+    launchContext: PlaywrightLaunchContext = {},
+    headless?: boolean,
+    configuration?: Configuration,
+): PlaywrightLauncher {
+    return new PlaywrightLauncher(
+        headless == null
+            ? launchContext
+            : { ...launchContext, launchOptions: { ...launchContext.launchOptions, headless } },
+        configuration,
+    );
+}

--- a/packages/playwright-crawler/src/internals/playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/playwright-crawler.ts
@@ -9,15 +9,22 @@ import type {
     RouteSchemas,
     RoutesFromSchemas,
 } from '@crawlee/browser';
-import { BrowserCrawler, parseArgument, RequestState, Router, schemas, serviceLocator } from '@crawlee/browser';
-import type { BrowserPoolOptions, PlaywrightPlugin } from '@crawlee/browser-pool';
+import {
+    assertBrowserPoolNotConfigured,
+    BrowserCrawler,
+    parseArgument,
+    RequestState,
+    Router,
+    schemas,
+    serviceLocator,
+} from '@crawlee/browser';
 import type { Dictionary } from '@crawlee/types';
 import type { Download, LaunchOptions, Page, Response } from 'playwright';
 import { z } from 'zod';
 
 import type { EnqueueLinksByClickingElementsOptions } from './enqueue-links/click-elements.js';
+import { playwrightBrowserPool, remotePlaywrightBrowserPool } from './playwright-browser-pool.js';
 import type { PlaywrightLaunchContext } from './playwright-launcher.js';
-import { PlaywrightLauncher } from './playwright-launcher.js';
 import type {
     BlockRequestsOptions,
     DirectNavigationOptions,
@@ -46,19 +53,17 @@ export interface PlaywrightCrawlerOptions<
         string,
         GetUserDataFromRequest<PlaywrightCrawlingContext['request']>
     >,
-> extends BrowserCrawlerOptions<
-    Page,
-    Response,
-    PlaywrightCrawlingContext,
-    ContextExtension,
-    ExtendedContext,
-    { browserPlugins: [PlaywrightPlugin] },
-    Routes
-> {
+> extends BrowserCrawlerOptions<Page, Response, PlaywrightCrawlingContext, ContextExtension, ExtendedContext, Routes> {
     /**
      * The same options as used by {@apilink launchPlaywright}.
      */
     launchContext?: PlaywrightLaunchContext;
+
+    /**
+     * Whether to run browser in headless mode. Defaults to `true`.
+     * Can be also set via {@apilink Configuration}.
+     */
+    headless?: boolean;
 
     /**
      * Function that is called to process each request.
@@ -202,7 +207,6 @@ export class PlaywrightCrawler<
 > extends BrowserCrawler<
     Page,
     Response,
-    { browserPlugins: [PlaywrightPlugin] },
     LaunchOptions,
     PlaywrightCrawlingContext,
     ContextExtension,
@@ -211,7 +215,7 @@ export class PlaywrightCrawler<
 > {
     protected static override optionsShape = {
         ...BrowserCrawler.optionsShape,
-        browserPoolOptions: schemas.anyObject.optional(),
+        headless: z.boolean().optional(),
         launcher: schemas.anyObject.optional(),
     };
 
@@ -223,11 +227,8 @@ export class PlaywrightCrawler<
     constructor(options: PlaywrightCrawlerOptions<ContextExtension, ExtendedContext, Routes> = {}) {
         const parsedOptions = parseArgument(options, PlaywrightCrawler.optionsSchema, 'PlaywrightCrawlerOptions');
 
-        const { launchContext, headless, contextPipelineBuilder, ...browserCrawlerOptions } = parsedOptions;
-
-        const browserPoolOptions = {
-            ...parsedOptions.browserPoolOptions,
-        } as BrowserPoolOptions;
+        const { launchContext, headless, configuration, contextPipelineBuilder, ...browserCrawlerOptions } =
+            parsedOptions;
 
         if (launchContext.proxyUrl) {
             throw new Error(
@@ -236,25 +237,22 @@ export class PlaywrightCrawler<
             );
         }
 
-        // `browserPlugins` is working when it's not overridden by `launchContext`,
-        // which for crawlers it is always overridden. Hence the error to use the other option.
-        if (browserPoolOptions.browserPlugins) {
-            throw new Error('browserPoolOptions.browserPlugins is disallowed. Use launchContext.launcher instead.');
+        if (options.browserPool) {
+            // The raw options, not the parsed ones: `launchContext` has a default, so by now it is always set.
+            assertBrowserPoolNotConfigured(new.target.name, {
+                launchContext: options.launchContext,
+                headless: options.headless,
+            });
         }
-
-        if (headless != null) {
-            launchContext.launchOptions ??= {} as LaunchOptions;
-            launchContext.launchOptions.headless = headless as boolean;
-        }
-
-        const playwrightLauncher = new PlaywrightLauncher(launchContext, parsedOptions.configuration);
-
-        browserPoolOptions.browserPlugins = [playwrightLauncher.createBrowserPlugin()];
 
         super({
             ...(browserCrawlerOptions as unknown as PlaywrightCrawlerOptions<ContextExtension, ExtendedContext>),
             launchContext,
-            browserPoolOptions,
+            configuration,
+            browserPoolBuilder: (remoteBrowser) =>
+                remoteBrowser
+                    ? remotePlaywrightBrowserPool({ ...remoteBrowser, launchContext, headless, configuration })
+                    : playwrightBrowserPool({ launchContext, headless, configuration }),
             contextPipelineBuilder: contextPipelineBuilder ?? (() => this.buildContextPipeline()),
         });
     }

--- a/packages/puppeteer-crawler/src/index.ts
+++ b/packages/puppeteer-crawler/src/index.ts
@@ -1,4 +1,5 @@
 export * from '@crawlee/browser';
+export * from './internals/puppeteer-browser-pool.js';
 export * from './internals/puppeteer-crawler.js';
 export * from './internals/puppeteer-launcher.js';
 

--- a/packages/puppeteer-crawler/src/internals/puppeteer-browser-pool.ts
+++ b/packages/puppeteer-crawler/src/internals/puppeteer-browser-pool.ts
@@ -1,0 +1,102 @@
+import type { Configuration } from '@crawlee/browser';
+import type {
+    BrowserPool,
+    BrowserPoolHooks,
+    BrowserPoolOptions,
+    PuppeteerPlugin,
+    RemoteBrowserPool,
+    RemoteBrowserPoolOptions,
+} from '@crawlee/browser-pool';
+// @ts-ignore This only throws when compiled against puppeteer 25+ (ESM only), we only import types, so its alllll gooooood
+import type { Page } from 'puppeteer';
+
+import type { PuppeteerLaunchContext } from './puppeteer-launcher.js';
+import { PuppeteerLauncher } from './puppeteer-launcher.js';
+
+/** A {@apilink BrowserPool} of Puppeteer browsers, as built by {@apilink puppeteerBrowserPool}. */
+export type PuppeteerBrowserPool = BrowserPool<{ browserPlugins: [PuppeteerPlugin] }, [PuppeteerPlugin]>;
+
+export interface PuppeteerBrowserPoolOptions
+    extends
+        Omit<BrowserPoolOptions, 'browserPlugins'>,
+        BrowserPoolHooks<
+            ReturnType<PuppeteerPlugin['createController']>,
+            ReturnType<PuppeteerPlugin['createLaunchContext']>,
+            Page
+        > {
+    /** How to launch the browser: proxy, user data dir, whether to use full Chrome, ... */
+    launchContext?: PuppeteerLaunchContext;
+
+    /**
+     * Whether to run the browser in headless mode. Shorthand for `launchContext.launchOptions.headless`.
+     * Defaults to `true`, and can also be set via {@apilink Configuration}.
+     */
+    headless?: boolean | 'new' | 'old';
+
+    /** Configuration to read the browser defaults from. Defaults to the global configuration. */
+    configuration?: Configuration;
+}
+
+export interface RemotePuppeteerBrowserPoolOptions
+    extends
+        Pick<PuppeteerBrowserPoolOptions, 'launchContext' | 'headless' | 'configuration'>,
+        Omit<RemoteBrowserPoolOptions, 'browserPlugins'> {}
+
+/**
+ * Builds a {@apilink BrowserPool} of Puppeteer browsers to pass to a {@apilink PuppeteerCrawler} as its
+ * {@apilink BrowserCrawlerOptions.browserPool|`browserPool`}.
+ *
+ * It accepts every {@apilink BrowserPoolOptions|`BrowserPool` option} plus the crawler's own `launchContext` and
+ * `headless`, and derives the browser plugin from them - so a pool built here always matches the crawler it is
+ * given to, and configuring one never means assembling a {@apilink PuppeteerPlugin} by hand.
+ *
+ * **Example usage:**
+ *
+ * ```javascript
+ * const crawler = new PuppeteerCrawler({
+ *     browserPool: puppeteerBrowserPool({ maxOpenPagesPerBrowser: 1 }),
+ *     requestHandler: async ({ page }) => { ... },
+ * });
+ * ```
+ *
+ * The returned pool is *not* torn down by the crawler, which is what makes it shareable between crawlers.
+ *
+ * @category Browser management
+ */
+export function puppeteerBrowserPool(options: PuppeteerBrowserPoolOptions = {}): PuppeteerBrowserPool {
+    const { launchContext, headless, configuration, ...poolOptions } = options;
+
+    return puppeteerLauncher(launchContext, headless, configuration).createBrowserPool(poolOptions);
+}
+
+/**
+ * The {@apilink RemoteBrowserPool} counterpart of {@apilink puppeteerBrowserPool}: connects to a remote browser
+ * service (Browserbase, Browserless, Steel, ...) with a Puppeteer plugin derived from `launchContext`.
+ *
+ * A {@apilink PuppeteerCrawler} accepts the same connection details directly via
+ * {@apilink BrowserCrawlerOptions.remoteBrowser|`remoteBrowser`}; reach for this factory when you also need to
+ * tune the wrapping pool, or to share one remote pool between crawlers.
+ *
+ * @category Browser management
+ */
+export function remotePuppeteerBrowserPool(options: RemotePuppeteerBrowserPoolOptions): RemoteBrowserPool<Page> {
+    const { launchContext, headless, configuration, ...remoteOptions } = options;
+
+    return puppeteerLauncher(launchContext, headless, configuration).createRemoteBrowserPool<Page>(remoteOptions);
+}
+
+function puppeteerLauncher(
+    launchContext: PuppeteerLaunchContext = {},
+    headless?: boolean | 'new' | 'old',
+    configuration?: Configuration,
+): PuppeteerLauncher {
+    return new PuppeteerLauncher(
+        headless == null
+            ? launchContext
+            : {
+                  ...launchContext,
+                  launchOptions: { ...launchContext.launchOptions, headless: headless as boolean },
+              },
+        configuration,
+    );
+}

--- a/packages/puppeteer-crawler/src/internals/puppeteer-crawler.ts
+++ b/packages/puppeteer-crawler/src/internals/puppeteer-crawler.ts
@@ -8,17 +8,16 @@ import type {
     RouteSchemas,
     RoutesFromSchemas,
 } from '@crawlee/browser';
-import { BrowserCrawler, RequestState, Router } from '@crawlee/browser';
-import type { BrowserPoolOptions, PuppeteerPlugin } from '@crawlee/browser-pool';
-import { parseArgument, schemas, serviceLocator } from '@crawlee/core';
+import { assertBrowserPoolNotConfigured, BrowserCrawler, RequestState, Router } from '@crawlee/browser';
+import { parseArgument, serviceLocator } from '@crawlee/core';
 import type { Dictionary } from '@crawlee/types';
 // @ts-ignore This only throws when compiled against puppeteer 25+ (ESM only), we only import types, so its alllll gooooood
 import type { HTTPResponse, LaunchOptions, Page } from 'puppeteer';
 import { z } from 'zod';
 
 import type { EnqueueLinksByClickingElementsOptions } from './enqueue-links/click-elements.js';
+import { puppeteerBrowserPool, remotePuppeteerBrowserPool } from './puppeteer-browser-pool.js';
 import type { PuppeteerLaunchContext } from './puppeteer-launcher.js';
-import { PuppeteerLauncher } from './puppeteer-launcher.js';
 import type { InterceptHandler } from './utils/puppeteer_request_interception.js';
 import type {
     BlockRequestsOptions,
@@ -53,13 +52,18 @@ export interface PuppeteerCrawlerOptions<
     PuppeteerCrawlingContext,
     ContextExtension,
     ExtendedContext,
-    { browserPlugins: [PuppeteerPlugin] },
     Routes
 > {
     /**
      * Options used by {@apilink launchPuppeteer} to start new Puppeteer instances.
      */
     launchContext?: PuppeteerLaunchContext;
+
+    /**
+     * Whether to run browser in headless mode. Defaults to `true`.
+     * Can be also set via {@apilink Configuration}.
+     */
+    headless?: boolean | 'new' | 'old';
 
     /**
      * Async functions that are sequentially evaluated before the navigation. Good for setting additional cookies
@@ -179,7 +183,6 @@ export class PuppeteerCrawler<
 > extends BrowserCrawler<
     Page,
     HTTPResponse,
-    { browserPlugins: [PuppeteerPlugin] },
     LaunchOptions,
     PuppeteerCrawlingContext,
     ContextExtension,
@@ -188,7 +191,9 @@ export class PuppeteerCrawler<
 > {
     protected static override optionsShape = {
         ...BrowserCrawler.optionsShape,
-        browserPoolOptions: schemas.anyObject.optional(),
+        // Deliberately looser than the declared type: Puppeteer's own accepted string values have moved over
+        // time (`'new'`/`'old'`, now `'shell'`), and the value is forwarded to it verbatim.
+        headless: z.union([z.boolean(), z.string()]).optional(),
     };
 
     protected static override optionsSchema = z.strictObject(PuppeteerCrawler.optionsShape);
@@ -199,12 +204,14 @@ export class PuppeteerCrawler<
     constructor(options: PuppeteerCrawlerOptions<ContextExtension, ExtendedContext, Routes> = {}) {
         const parsedOptions = parseArgument(options, PuppeteerCrawler.optionsSchema, 'PuppeteerCrawlerOptions');
 
-        const { launchContext, headless, proxyConfiguration, contextPipelineBuilder, ...browserCrawlerOptions } =
-            parsedOptions;
-
-        const browserPoolOptions = {
-            ...parsedOptions.browserPoolOptions,
-        } as BrowserPoolOptions;
+        const {
+            launchContext,
+            headless,
+            configuration,
+            proxyConfiguration,
+            contextPipelineBuilder,
+            ...browserCrawlerOptions
+        } = parsedOptions;
 
         if (launchContext.proxyUrl) {
             throw new Error(
@@ -213,20 +220,13 @@ export class PuppeteerCrawler<
             );
         }
 
-        // `browserPlugins` is working when it's not overridden by `launchContext`,
-        // which for crawlers it is always overridden. Hence the error to use the other option.
-        if (browserPoolOptions.browserPlugins) {
-            throw new Error('browserPoolOptions.browserPlugins is disallowed. Use launchContext.launcher instead.');
+        if (options.browserPool) {
+            // The raw options, not the parsed ones: `launchContext` has a default, so by now it is always set.
+            assertBrowserPoolNotConfigured(new.target.name, {
+                launchContext: options.launchContext,
+                headless: options.headless,
+            });
         }
-
-        if (headless != null) {
-            launchContext.launchOptions ??= {} as LaunchOptions;
-            launchContext.launchOptions.headless = headless as boolean;
-        }
-
-        const puppeteerLauncher = new PuppeteerLauncher(launchContext, parsedOptions.configuration);
-
-        browserPoolOptions.browserPlugins = [puppeteerLauncher.createBrowserPlugin()];
 
         super({
             ...(browserCrawlerOptions as BrowserCrawlerOptions<
@@ -237,8 +237,12 @@ export class PuppeteerCrawler<
                 ExtendedContext
             >),
             launchContext,
+            configuration,
             proxyConfiguration,
-            browserPoolOptions,
+            browserPoolBuilder: (remoteBrowser) =>
+                remoteBrowser
+                    ? remotePuppeteerBrowserPool({ ...remoteBrowser, launchContext, headless, configuration })
+                    : puppeteerBrowserPool({ launchContext, headless, configuration }),
             contextPipelineBuilder: contextPipelineBuilder ?? (() => this.buildContextPipeline()),
         });
     }

--- a/packages/stagehand-crawler/src/index.ts
+++ b/packages/stagehand-crawler/src/index.ts
@@ -56,6 +56,14 @@ export * from '@crawlee/browser';
 // Export main crawler class
 export { StagehandCrawler, createStagehandRouter } from './internals/stagehand-crawler';
 
+// Export the browser pool factories, which are how a pool with non-default options reaches the crawler
+export { stagehandBrowserPool, remoteStagehandBrowserPool } from './internals/stagehand-browser-pool';
+export type {
+    StagehandBrowserPool,
+    StagehandBrowserPoolOptions,
+    RemoteStagehandBrowserPoolOptions,
+} from './internals/stagehand-browser-pool';
+
 // Export types
 export type {
     StagehandOptions,

--- a/packages/stagehand-crawler/src/internals/stagehand-browser-pool.ts
+++ b/packages/stagehand-crawler/src/internals/stagehand-browser-pool.ts
@@ -1,0 +1,111 @@
+import type { Configuration } from '@crawlee/browser';
+import type {
+    BrowserPool,
+    BrowserPoolHooks,
+    BrowserPoolOptions,
+    RemoteBrowserPool,
+    RemoteBrowserPoolOptions,
+} from '@crawlee/browser-pool';
+import type { Page } from 'playwright';
+
+import type { StagehandOptions } from './stagehand-crawler';
+import type { StagehandLaunchContext } from './stagehand-launcher';
+import { StagehandLauncher } from './stagehand-launcher';
+import type { StagehandPlugin } from './stagehand-plugin';
+
+/** A {@apilink BrowserPool} of Stagehand browsers, as built by {@apilink stagehandBrowserPool}. */
+export type StagehandBrowserPool = BrowserPool<{ browserPlugins: [StagehandPlugin] }, [StagehandPlugin]>;
+
+export interface StagehandBrowserPoolOptions
+    extends
+        Omit<BrowserPoolOptions, 'browserPlugins'>,
+        BrowserPoolHooks<
+            ReturnType<StagehandPlugin['createController']>,
+            ReturnType<StagehandPlugin['createLaunchContext']>,
+            Page
+        > {
+    /** How to launch the browser: which Playwright browser type, proxy, user data dir, ... */
+    launchContext?: StagehandLaunchContext;
+
+    /** Stagehand configuration for the AI behavior and Browserbase integration. */
+    stagehandOptions?: StagehandOptions;
+
+    /**
+     * Whether to run the browser in headless mode. Shorthand for `launchContext.launchOptions.headless`.
+     * Defaults to `true`, and can also be set via {@apilink Configuration}.
+     */
+    headless?: boolean;
+
+    /** Configuration to read the browser defaults from. Defaults to the global configuration. */
+    configuration?: Configuration;
+}
+
+export interface RemoteStagehandBrowserPoolOptions
+    extends
+        Pick<StagehandBrowserPoolOptions, 'launchContext' | 'stagehandOptions' | 'headless' | 'configuration'>,
+        Omit<RemoteBrowserPoolOptions, 'browserPlugins'> {}
+
+/**
+ * Builds a {@apilink BrowserPool} of Stagehand browsers to pass to a {@apilink StagehandCrawler} as its
+ * {@apilink BrowserCrawlerOptions.browserPool|`browserPool`}.
+ *
+ * It accepts every {@apilink BrowserPoolOptions|`BrowserPool` option} plus the crawler's own `launchContext`,
+ * `stagehandOptions` and `headless`, and derives the browser plugin from them - so a pool built here always
+ * matches the crawler it is given to, and configuring one never means assembling a {@apilink StagehandPlugin}
+ * by hand.
+ *
+ * **Example usage:**
+ *
+ * ```javascript
+ * const crawler = new StagehandCrawler({
+ *     browserPool: stagehandBrowserPool({
+ *         maxOpenPagesPerBrowser: 1,
+ *         stagehandOptions: { env: 'LOCAL', model: 'openai/gpt-4.1-mini' },
+ *     }),
+ *     requestHandler: async ({ page }) => { ... },
+ * });
+ * ```
+ *
+ * The returned pool is *not* torn down by the crawler, which is what makes it shareable between crawlers.
+ *
+ * @category Browser management
+ */
+export function stagehandBrowserPool(options: StagehandBrowserPoolOptions = {}): StagehandBrowserPool {
+    const { launchContext, stagehandOptions, headless, configuration, ...poolOptions } = options;
+
+    return stagehandLauncher(launchContext, stagehandOptions, headless, configuration).createBrowserPool(poolOptions);
+}
+
+/**
+ * The {@apilink RemoteBrowserPool} counterpart of {@apilink stagehandBrowserPool}: connects to a remote browser
+ * service with a Stagehand plugin derived from `launchContext` and `stagehandOptions`.
+ *
+ * A {@apilink StagehandCrawler} accepts the same connection details directly via
+ * {@apilink BrowserCrawlerOptions.remoteBrowser|`remoteBrowser`}; reach for this factory when you also need to
+ * tune the wrapping pool, or to share one remote pool between crawlers.
+ *
+ * @category Browser management
+ */
+export function remoteStagehandBrowserPool(options: RemoteStagehandBrowserPoolOptions): RemoteBrowserPool<Page> {
+    const { launchContext, stagehandOptions, headless, configuration, ...remoteOptions } = options;
+
+    return stagehandLauncher(launchContext, stagehandOptions, headless, configuration).createRemoteBrowserPool<Page>(
+        remoteOptions,
+    );
+}
+
+function stagehandLauncher(
+    launchContext: StagehandLaunchContext = {},
+    stagehandOptions: StagehandOptions = {},
+    headless?: boolean,
+    configuration?: Configuration,
+): StagehandLauncher {
+    return new StagehandLauncher(
+        {
+            ...launchContext,
+            stagehandOptions,
+            ...(headless == null ? {} : { launchOptions: { ...launchContext.launchOptions, headless } }),
+        },
+        configuration,
+    );
+}

--- a/packages/stagehand-crawler/src/internals/stagehand-crawler.ts
+++ b/packages/stagehand-crawler/src/internals/stagehand-crawler.ts
@@ -19,22 +19,21 @@ import type {
     CrawlingContext,
     GetUserDataFromRequest,
     LoadedContext,
+    OwnedBrowserPool,
     RequestHandler,
     RouterHandler,
     RouterRoutes,
     RouteSchemas,
     RoutesFromSchemas,
 } from '@crawlee/browser';
-import { BrowserCrawler, parseArgument, Router, schemas } from '@crawlee/browser';
-import type { BrowserPoolOptions } from '@crawlee/browser-pool';
+import { assertBrowserPoolNotConfigured, BrowserCrawler, parseArgument, Router, schemas } from '@crawlee/browser';
 import type { Dictionary } from '@crawlee/types';
 import type { LaunchOptions, Page, Response } from 'playwright';
 import { z } from 'zod';
 
+import { remoteStagehandBrowserPool, stagehandBrowserPool } from './stagehand-browser-pool';
 import type { StagehandController } from './stagehand-controller';
 import type { StagehandLaunchContext } from './stagehand-launcher';
-import { StagehandLauncher } from './stagehand-launcher';
-import type { StagehandPlugin } from './stagehand-plugin';
 import { enhancePageWithStagehand } from './utils/stagehand-utils';
 
 /**
@@ -258,7 +257,6 @@ export interface StagehandCrawlerOptions<
     StagehandCrawlingContext,
     ContextExtension,
     ExtendedContext,
-    { browserPlugins: [StagehandPlugin] },
     Routes
 > {
     /**
@@ -271,6 +269,12 @@ export interface StagehandCrawlerOptions<
      * Launch context with Stagehand-specific options.
      */
     launchContext?: StagehandLaunchContext;
+
+    /**
+     * Whether to run browser in headless mode. Defaults to `true`.
+     * Can be also set via {@apilink Configuration}.
+     */
+    headless?: boolean;
 
     /**
      * Function that is called to process each request.
@@ -398,7 +402,6 @@ export class StagehandCrawler<
 > extends BrowserCrawler<
     StagehandPage,
     Response,
-    { browserPlugins: [StagehandPlugin] },
     LaunchOptions,
     StagehandCrawlingContext,
     ContextExtension,
@@ -408,7 +411,7 @@ export class StagehandCrawler<
     protected static override optionsShape = {
         ...BrowserCrawler.optionsShape,
         stagehandOptions: schemas.anyObject.optional(),
-        browserPoolOptions: schemas.anyObject.optional(),
+        headless: z.boolean().optional(),
     };
 
     protected static override optionsSchema = z.strictObject(StagehandCrawler.optionsShape);
@@ -422,29 +425,44 @@ export class StagehandCrawler<
         const parsedOptions = parseArgument(options, StagehandCrawler.optionsSchema, 'StagehandCrawlerOptions');
 
         const {
-            stagehandOptions = {},
+            stagehandOptions,
             launchContext,
+            headless,
+            configuration,
             contextPipelineBuilder,
             ...browserCrawlerOptions
         } = parsedOptions;
 
-        const browserPoolOptions = {
-            ...parsedOptions.browserPoolOptions,
-        } as BrowserPoolOptions;
+        if (options.browserPool) {
+            // The raw options, not the parsed ones: `launchContext` has a default, so by now it is always set.
+            assertBrowserPoolNotConfigured(new.target.name, {
+                launchContext: options.launchContext,
+                stagehandOptions: options.stagehandOptions,
+                headless: options.headless,
+            });
+        }
 
-        // Create launcher with Stagehand plugin
-        const launcher = new StagehandLauncher({
-            ...launchContext,
-            stagehandOptions,
-        });
-
-        browserPoolOptions.browserPlugins = [launcher.createBrowserPlugin()];
-
-        // Initialize BrowserCrawler with Stagehand plugin and fingerprinting enabled
         super({
             ...(browserCrawlerOptions as StagehandCrawlerOptions<ContextExtension, ExtendedContext>),
             launchContext,
-            browserPoolOptions,
+            configuration,
+            // The pool serves plain Playwright pages - a page only becomes a `StagehandPage` further down the
+            // pipeline, once `setUpStagehand` enhances it - so its page type is narrower than the crawler's.
+            browserPoolBuilder: (remoteBrowser) =>
+                (remoteBrowser
+                    ? remoteStagehandBrowserPool({
+                          ...remoteBrowser,
+                          launchContext,
+                          stagehandOptions,
+                          headless,
+                          configuration,
+                      })
+                    : stagehandBrowserPool({
+                          launchContext,
+                          stagehandOptions,
+                          headless,
+                          configuration,
+                      })) as unknown as OwnedBrowserPool<StagehandPage>,
             contextPipelineBuilder: contextPipelineBuilder ?? (() => this.buildContextPipeline()),
         });
     }

--- a/packages/templates/templates/camoufox-ts/src/main.ts
+++ b/packages/templates/templates/camoufox-ts/src/main.ts
@@ -1,7 +1,7 @@
 // For more information, see https://crawlee.dev/
 import { Browser, ImpitHttpClient } from '@crawlee/impit-client';
 import { launchOptions } from 'camoufox-js';
-import { PlaywrightCrawler, ProxyConfiguration } from 'crawlee';
+import { PlaywrightCrawler, playwrightBrowserPool, ProxyConfiguration } from 'crawlee';
 import { firefox } from 'playwright';
 
 import { router } from './routes.js';
@@ -14,20 +14,20 @@ const crawler = new PlaywrightCrawler({
     requestHandler: router,
     // Comment this option to scrape the full website.
     maxRequestsPerCrawl: 20,
-    browserPoolOptions: {
+    browserPool: playwrightBrowserPool({
         // Disable the default fingerprint spoofing to avoid conflicts with Camoufox.
         useFingerprints: false,
-    },
-    launchContext: {
-        launcher: firefox,
-        launchOptions: await launchOptions({
-            headless: false,
-            // Pass your own Camoufox parameters here...
-            // block_images: true,
-            // fonts: ['Times New Roman'],
-            // ...
-        }),
-    },
+        launchContext: {
+            launcher: firefox,
+            launchOptions: await launchOptions({
+                headless: false,
+                // Pass your own Camoufox parameters here...
+                // block_images: true,
+                // fonts: ['Times New Roman'],
+                // ...
+            }),
+        },
+    }),
 });
 
 await crawler.run(startUrls);

--- a/test/core/crawlers/basic_browser_crawler.ts
+++ b/test/core/crawlers/basic_browser_crawler.ts
@@ -1,4 +1,5 @@
-import type { PuppeteerPlugin } from '@crawlee/browser-pool';
+import type { BrowserPlugin, BrowserPoolHooks, BrowserPoolOptions, PuppeteerPlugin } from '@crawlee/browser-pool';
+import { BrowserPool, RemoteBrowserPool } from '@crawlee/browser-pool';
 import type {
     BrowserCrawlerOptions,
     BrowserCrawlingContext,
@@ -12,16 +13,34 @@ import type { HTTPResponse, LaunchOptions, Page } from 'puppeteer';
 
 export type TestCrawlingContext = BrowserCrawlingContext<Page, HTTPResponse, Dictionary>;
 
-export class BrowserCrawlerTest extends BrowserCrawler<
-    Page,
-    HTTPResponse,
-    { browserPlugins: [PuppeteerPlugin] },
-    LaunchOptions,
-    TestCrawlingContext
-> {
-    constructor(options: Partial<BrowserCrawlerOptions<Page, HTTPResponse, TestCrawlingContext>> = {}) {
+type TestBrowserPoolOptions = BrowserPoolOptions<PuppeteerPlugin> &
+    BrowserPoolHooks<
+        ReturnType<PuppeteerPlugin['createController']>,
+        ReturnType<PuppeteerPlugin['createLaunchContext']>,
+        Page
+    >;
+
+export class BrowserCrawlerTest extends BrowserCrawler<Page, HTTPResponse, LaunchOptions, TestCrawlingContext> {
+    constructor(
+        options: Partial<BrowserCrawlerOptions<Page, HTTPResponse, TestCrawlingContext>> & {
+            /**
+             * The concrete crawlers derive their plugin from a `launchContext`; this bare test subclass has no
+             * launcher, so tests hand it the pool options - `browserPlugins` included - directly.
+             */
+            browserPoolOptions?: TestBrowserPoolOptions;
+        } = {},
+    ) {
+        const { browserPoolOptions, ...browserCrawlerOptions } = options;
+
         super({
-            ...options,
+            ...browserCrawlerOptions,
+            browserPoolBuilder: (remoteBrowser) =>
+                remoteBrowser
+                    ? new RemoteBrowserPool<Page>({
+                          ...remoteBrowser,
+                          browserPlugins: browserPoolOptions!.browserPlugins as unknown as BrowserPlugin[],
+                      })
+                    : new BrowserPool(browserPoolOptions!),
             contextPipelineBuilder: () => this.buildContextPipeline(),
         });
     }

--- a/test/core/crawlers/browser_crawler.test.ts
+++ b/test/core/crawlers/browser_crawler.test.ts
@@ -191,17 +191,18 @@ describe('BrowserCrawler', () => {
         await (crawler.browserPool as RemoteBrowserPool).destroy();
     });
 
-    test.concurrent('uses browserPool and ignores remoteBrowser when both are set', async () => {
+    test.concurrent('rejects remoteBrowser when a browserPool is passed in', async () => {
         const externalPool = new BrowserPoolClass({ browserPlugins: [new PuppeteerPlugin(puppeteer)] });
 
         try {
-            const crawler = new BrowserCrawlerTest({
-                browserPool: externalPool,
-                remoteBrowser: { endpoint: 'ws://remote:9222' },
-                requestHandler: async () => {},
-            });
-
-            expect(crawler.browserPool).toBe(externalPool);
+            expect(
+                () =>
+                    new BrowserCrawlerTest({
+                        browserPool: externalPool,
+                        remoteBrowser: { endpoint: 'ws://remote:9222' },
+                        requestHandler: async () => {},
+                    }),
+            ).toThrow('`remoteBrowser` cannot be combined with `browserPool`');
         } finally {
             await externalPool.destroy();
         }

--- a/test/core/crawlers/playwright_crawler.test.ts
+++ b/test/core/crawlers/playwright_crawler.test.ts
@@ -4,7 +4,13 @@ import os from 'node:os';
 
 import type { PlaywrightCrawlingContext, PlaywrightGotoOptions, Request } from '@crawlee/playwright';
 import { type ConcurrencySystem, MemoryStorageBackend, serviceLocator } from '@crawlee/core';
-import { createPlaywrightRouter, PlaywrightCrawler, RequestList, RequestValidationError } from '@crawlee/playwright';
+import {
+    createPlaywrightRouter,
+    PlaywrightCrawler,
+    playwrightBrowserPool,
+    RequestList,
+    RequestValidationError,
+} from '@crawlee/playwright';
 import type { Cheerio, CheerioAPI, CheerioRoot, Element } from '@crawlee/utils/internal';
 import { sleep } from '@crawlee/utils';
 import express from 'express';
@@ -101,10 +107,10 @@ describe('PlaywrightCrawler', () => {
             };
 
             const playwrightCrawler = new PlaywrightCrawler({
-                launchContext: {
-                    launcher: playwright[browser],
-                },
-                browserPoolOptions: { useFingerprints: false },
+                browserPool: playwrightBrowserPool({
+                    launchContext: { launcher: playwright[browser] },
+                    useFingerprints: false,
+                }),
                 requestList: requestListLarge,
                 minConcurrency: 1,
                 maxConcurrency: 1,
@@ -134,9 +140,7 @@ describe('PlaywrightCrawler', () => {
 
         const crawler = new PlaywrightCrawler({
             maxRequestRetries: 0,
-            browserPoolOptions: {
-                operationTimeoutSecs: 0.001,
-            },
+            browserPool: playwrightBrowserPool({ operationTimeoutSecs: 0.001 }),
             requestHandler: async ({ request }) => {
                 success.push(request.url);
             },
@@ -182,16 +186,49 @@ describe('PlaywrightCrawler', () => {
         expect(options!.timeout).toEqual(timeoutSecs * 1000);
     });
 
-    test('shallow clones browserPoolOptions before normalization', () => {
+    test('does not mutate the launchContext it was given', () => {
         const options = {
-            browserPoolOptions: {},
+            launchContext: {},
+            headless: false,
             requestHandler: async () => {},
         };
 
         void new PlaywrightCrawler(options);
-        void new PlaywrightCrawler(options);
 
-        expect(Object.keys(options.browserPoolOptions).length).toBe(0);
+        expect(options.launchContext).toEqual({});
+    });
+
+    describe('playwrightBrowserPool', () => {
+        test('runs a plugin for the requested browser and forwards the pool options', () => {
+            const browserPool = playwrightBrowserPool({
+                maxOpenPagesPerBrowser: 3,
+                headless: false,
+                launchContext: { launcher: playwright.firefox },
+            });
+
+            expect(browserPool.maxOpenPagesPerBrowser).toBe(3);
+            expect(browserPool.browserPlugins).toHaveLength(1);
+            expect(browserPool.browserPlugins[0].library).toBe(playwright.firefox);
+            expect(browserPool.browserPlugins[0].launchOptions).toMatchObject({ headless: false });
+        });
+
+        test('turns off fingerprint injection when a custom userAgent is given', () => {
+            expect(
+                playwrightBrowserPool({ launchContext: { userAgent: 'Definitely Not A Crawler' } }).useFingerprints,
+            ).toBe(false);
+        });
+
+        test('is rejected by the crawler alongside the options that would configure its own pool', () => {
+            const browserPool = playwrightBrowserPool();
+
+            expect(() => new PlaywrightCrawler({ browserPool, headless: false })).toThrow(
+                'PlaywrightCrawler: `headless` cannot be combined with `browserPool`',
+            );
+            expect(
+                () => new PlaywrightCrawler({ browserPool, launchContext: { launcher: playwright.firefox } }),
+            ).toThrow('PlaywrightCrawler: `launchContext` cannot be combined with `browserPool`');
+            expect(() => new PlaywrightCrawler({ browserPool })).not.toThrow();
+        });
     });
 
     test.each([{ useIncognitoPages: true }, { useIncognitoPages: false }])(
@@ -209,14 +246,11 @@ describe('PlaywrightCrawler', () => {
 
             const playwrightCrawler = new PlaywrightCrawler({
                 maxConcurrency: 1,
-                launchContext: {
-                    useIncognitoPages,
-                    launchOptions,
-                },
-                browserPoolOptions: {
+                browserPool: playwrightBrowserPool({
+                    launchContext: { useIncognitoPages, launchOptions },
                     // don't overwrite locale with fingerprint's locale
                     useFingerprints: false,
-                },
+                }),
                 requestHandler: async ({ page }) => {
                     [timezone, locale, reducedMotion] = await Promise.all([
                         page.evaluate(() => Intl.DateTimeFormat().resolvedOptions().timeZone),

--- a/test/core/crawlers/puppeteer_crawler.test.ts
+++ b/test/core/crawlers/puppeteer_crawler.test.ts
@@ -18,6 +18,7 @@ import {
     createPuppeteerRouter,
     ProxyConfiguration,
     PuppeteerCrawler,
+    puppeteerBrowserPool,
     RequestList,
     RequestQueue,
     RequestValidationError,
@@ -115,7 +116,7 @@ describe('PuppeteerCrawler', () => {
 
         const puppeteerCrawler = new PuppeteerCrawler({
             requestList: requestListLarge,
-            browserPoolOptions: { useFingerprints: false },
+            browserPool: puppeteerBrowserPool({ useFingerprints: false }),
             minConcurrency: 1,
             maxConcurrency: 1,
             requestHandler,
@@ -275,14 +276,14 @@ describe('PuppeteerCrawler', () => {
         const crawler = new PuppeteerCrawler({
             requestQueue,
             navigationTimeoutSecs: 0.005,
-            browserPoolOptions: {
+            browserPool: puppeteerBrowserPool({
                 preLaunchHooks: [
                     async () => {
                         // Do some async work that's longer than navigationTimeoutSecs
                         await sleep(20);
                     },
                 ],
-            },
+            }),
             requestHandler,
         });
 
@@ -363,16 +364,16 @@ describe('PuppeteerCrawler', () => {
         expect(sessions.size).toBe(3); // 3 different sessions used
     });
 
-    test('shallow clones browserPoolOptions before normalization', () => {
+    test('does not mutate the launchContext it was given', () => {
         const options = {
-            browserPoolOptions: {},
+            launchContext: {},
+            headless: false,
             requestHandler: async () => {},
         };
 
         void new PuppeteerCrawler(options);
-        void new PuppeteerCrawler(options);
 
-        expect(Object.keys(options.browserPoolOptions).length).toBe(0);
+        expect(options.launchContext).toEqual({});
     });
 
     if (os.platform() !== 'darwin') {
@@ -397,16 +398,14 @@ describe('PuppeteerCrawler', () => {
             const puppeteerCrawler = new PuppeteerCrawler({
                 requestList: requestListLarge,
 
-                launchContext: {
-                    useIncognitoPages: true,
-                },
-                browserPoolOptions: {
+                browserPool: puppeteerBrowserPool({
+                    launchContext: { useIncognitoPages: true },
                     prePageCreateHooks: [
                         (_id, _controller, options) => {
                             options!.proxyBypassList = ['<-loopback>'];
                         },
                     ],
-                },
+                }),
                 proxyConfiguration,
                 requestHandler: async ({ page }) => {
                     const content = await page.content();

--- a/test/e2e/camoufox-cloudflare/actor/main.js
+++ b/test/e2e/camoufox-cloudflare/actor/main.js
@@ -1,4 +1,4 @@
-import { Dataset, handleCloudflareChallengeHook, PlaywrightCrawler } from '@crawlee/playwright';
+import { Dataset, handleCloudflareChallengeHook, PlaywrightCrawler, playwrightBrowserPool } from '@crawlee/playwright';
 import { Actor } from 'apify';
 import { launchOptions } from 'camoufox-js';
 import { firefox } from 'playwright';
@@ -16,9 +16,17 @@ await Actor.main(async () => {
         // The target hard-blocks datacenter IP ranges outright (block page, not a solvable
         // challenge), so this test needs residential exit nodes.
         proxyConfiguration: await Actor.createProxyConfiguration({ groups: ['RESIDENTIAL'] }),
-        // Camoufox ships its own anti-detection; Crawlee's fingerprint injection conflicts with it
-        // and keeps Cloudflare from ever clearing the challenge.
-        browserPoolOptions: { useFingerprints: false },
+        browserPool: playwrightBrowserPool({
+            // Camoufox ships its own anti-detection; Crawlee's fingerprint injection conflicts with it
+            // and keeps Cloudflare from ever clearing the challenge.
+            useFingerprints: false,
+            launchContext: {
+                launcher: firefox,
+                launchOptions: await launchOptions({
+                    headless: true,
+                }),
+            },
+        }),
         preNavigationHooks: [
             async ({ page }) => {
                 // TODO: remove this hook once a Camoufox build with daijro/camoufox#625 is released.
@@ -42,12 +50,6 @@ await Actor.main(async () => {
         ],
         // verbose keeps the challenge detection visible in the nightly run logs
         postNavigationHooks: [handleCloudflareChallengeHook({ verbose: true })],
-        launchContext: {
-            launcher: firefox,
-            launchOptions: await launchOptions({
-                headless: true,
-            }),
-        },
         async requestHandler({ page, parseWithCheerio }) {
             const isBlocked = await page
                 .evaluate(async () => {

--- a/test/e2e/stagehand-concurrent/actor/main.js
+++ b/test/e2e/stagehand-concurrent/actor/main.js
@@ -1,4 +1,4 @@
-import { StagehandCrawler } from '@crawlee/stagehand';
+import { StagehandCrawler, stagehandBrowserPool } from '@crawlee/stagehand';
 import { Actor } from 'apify';
 import { z } from 'zod';
 
@@ -21,15 +21,15 @@ await Actor.main(async () => {
     const crawler = new StagehandCrawler({
         maxConcurrency: 3,
         maxRequestsPerCrawl: 3,
-        // Force one page per browser to ensure multiple browsers are used
-        browserPoolOptions: {
+        browserPool: stagehandBrowserPool({
+            // Force one page per browser to ensure multiple browsers are used
             maxOpenPagesPerBrowser: 1,
-        },
-        stagehandOptions: {
-            env: 'LOCAL',
-            model: 'anthropic/claude-haiku-4-5-20251001',
-            verbose: 0,
-        },
+            stagehandOptions: {
+                env: 'LOCAL',
+                model: 'anthropic/claude-haiku-4-5-20251001',
+                verbose: 0,
+            },
+        }),
         async requestHandler({ page, request, log, pushData }) {
             log.info(`Processing ${request.loadedUrl}`);
 

--- a/test/integration/remote-browser-incognito.test.ts
+++ b/test/integration/remote-browser-incognito.test.ts
@@ -11,7 +11,7 @@
  *
  * With the wrapper removed, request 2's body should report no cookies.
  */
-import { PlaywrightCrawler } from 'crawlee';
+import { PlaywrightCrawler, remotePlaywrightBrowserPool } from 'crawlee';
 import { expect, test } from 'vitest';
 
 import { BROWSERLESS_URL, httpbin } from './helpers.js';
@@ -24,11 +24,11 @@ test.skipIf(!process.env.CRAWLEE_DIFFICULT_TESTS)(
         const observations: { controllerId: string; body: { cookies: Record<string, string> } }[] = [];
         const controllerIdByPage = new WeakMap<object, string>();
 
-        const crawler = new PlaywrightCrawler({
-            remoteBrowser: {
-                endpoint: BROWSERLESS_URL,
-                maxOpenBrowsers: 1,
-            },
+        // Tuning the pool that wraps the remote connection means building it here rather than using the
+        // crawler's terser `remoteBrowser` option - and owning its teardown as a result.
+        const browserPool = remotePlaywrightBrowserPool({
+            endpoint: BROWSERLESS_URL,
+            maxOpenBrowsers: 1,
             browserPoolOptions: {
                 retireBrowserAfterPageCount: 10, // keep the same browser across both requests
                 maxOpenPagesPerBrowser: 2,
@@ -38,6 +38,10 @@ test.skipIf(!process.env.CRAWLEE_DIFFICULT_TESTS)(
                     },
                 ],
             },
+        });
+
+        const crawler = new PlaywrightCrawler({
+            browserPool,
             saveResponseCookies: false, // remove Session-based propagation
             maxConcurrency: 1,
             maxRequestsPerCrawl: 2,
@@ -50,7 +54,11 @@ test.skipIf(!process.env.CRAWLEE_DIFFICULT_TESTS)(
             },
         });
 
-        await crawler.run([httpbin('/cookies/set?TOKEN=integration-test'), httpbin('/cookies')]);
+        try {
+            await crawler.run([httpbin('/cookies/set?TOKEN=integration-test'), httpbin('/cookies')]);
+        } finally {
+            await browserPool.destroy();
+        }
 
         expect(observations).toHaveLength(2);
         // Same browser handled both requests — otherwise the assertion below proves nothing.

--- a/test/stagehand-crawler/stagehand-crawler.test.ts
+++ b/test/stagehand-crawler/stagehand-crawler.test.ts
@@ -1,6 +1,13 @@
 import { z } from 'zod';
 
-import { createStagehandRouter, StagehandCrawler } from '../../packages/stagehand-crawler/src/index.js';
+import type { IBrowserPool } from '@crawlee/types';
+
+import type { StagehandBrowserPool, StagehandPage } from '../../packages/stagehand-crawler/src/index.js';
+import {
+    createStagehandRouter,
+    stagehandBrowserPool,
+    StagehandCrawler,
+} from '../../packages/stagehand-crawler/src/index.js';
 import { enhancePageWithStagehand } from '../../packages/stagehand-crawler/src/internals/utils/stagehand-utils.js';
 
 // Mock Stagehand to avoid actual browser launches and API calls
@@ -106,6 +113,26 @@ describe('StagehandCrawler', () => {
         });
 
         expect(crawler).toBeDefined();
+    });
+
+    // The launcher used to be built before `BrowserCrawler` folded `headless` into the launch context, so the
+    // option never reached the plugin.
+    test('forwards headless to the browser plugin', () => {
+        const crawler = new StagehandCrawler({ headless: false, stagehandOptions: { env: 'LOCAL' } });
+
+        expect((crawler.browserPool as unknown as StagehandBrowserPool).browserPlugins[0].launchOptions).toMatchObject({
+            headless: false,
+        });
+    });
+
+    test('rejects the options that would configure its own pool when a browserPool is passed in', () => {
+        // The pool serves plain Playwright pages, the crawler types its own as enhanced `StagehandPage`s.
+        const browserPool = stagehandBrowserPool() as unknown as IBrowserPool<StagehandPage>;
+
+        expect(() => new StagehandCrawler({ browserPool, stagehandOptions: { env: 'LOCAL' } })).toThrow(
+            'StagehandCrawler: `stagehandOptions` cannot be combined with `browserPool`',
+        );
+        expect(() => new StagehandCrawler({ browserPool })).not.toThrow();
     });
 });
 


### PR DESCRIPTION
- closes #3728
- supersedes #3785, thanks @yuvrajsingh2428 for getting the discussion started

`browserPoolOptions` was a second way of configuring the pool that `browserPool` already accepts, and the two could not be combined. The blocker on dropping it was [#3785 (comment)](https://github.com/apify/crawlee/pull/3785#discussion_r3506051694): with `browserPlugins` living in the pool options, anyone who wanted to change `useFingerprints` had to hand-build a plugin and keep it in sync with their crawler.

So each browser package now exports a factory that does that part. It takes every `BrowserPool` option *plus* the crawler's own `launchContext` / `headless`, and derives the plugin itself:

| crawler | factory | remote counterpart |
| --- | --- | --- |
| `PlaywrightCrawler` | `playwrightBrowserPool()` | `remotePlaywrightBrowserPool()` |
| `PuppeteerCrawler` | `puppeteerBrowserPool()` | `remotePuppeteerBrowserPool()` |
| `StagehandCrawler` | `stagehandBrowserPool()` | `remoteStagehandBrowserPool()` |

```ts
const crawler = new PlaywrightCrawler({
    browserPool: playwrightBrowserPool({
        useFingerprints: false,
        launchContext: { launcher: firefox },
    }),
});
```

This is roughly crawlee-python's `BrowserPool.with_default_plugin()`, split per package because our launchers are.

## Notable consequences

- Pool construction moves out of `BrowserCrawler` into the concrete crawlers, through a `browserPoolBuilder` seam alongside the existing `contextPipelineBuilder`. The base no longer imports `BrowserPool` or `RemoteBrowserPool`, and the `InternalBrowserPoolOptions` generic plus the three parameters it fed (`__BrowserPlugins`, `__BrowserControllerReturn`, `__LaunchContextReturn`) are gone.
- Combining `browserPool` with the options that configure a pool the crawler would have built for itself (`launchContext`, `headless`, `remoteBrowser`, `stagehandOptions`) now throws instead of silently ignoring them — same call as python's `ValueError`.
- `headless` moves from `BrowserCrawlerOptions` to the three concrete crawlers, since only they can honor it now. `'new'`/`'old'` are therefore `PuppeteerCrawler`-only, which is all they ever meant.
- `remoteBrowser` keeps working on its own; tuning the pool that wraps the remote connection is what the `remote*BrowserPool()` factories are for.

## Drive-by fixes

- `StagehandCrawler` ignored `headless` entirely — it built its launcher before `super()` folded the option into the launch context. Now covered by a test.
- `InferBrowserPluginArray` only knows Playwright and Puppeteer, so `BrowserPool<{ browserPlugins: [StagehandPlugin] }>` inferred `never` throughout. Bypassed by passing the plugin tuple explicitly, which surfaced a real pre-existing mismatch: the Stagehand pool serves plain Playwright pages, and a page only becomes a `StagehandPage` once the pipeline enhances it. That is now an explicit cast with a comment instead of a `never` papering over it.
- The crawlers no longer mutate the `launchContext` object they were handed.

## Bikeshed material

- Factory naming: `playwrightBrowserPool()` vs `createPlaywrightBrowserPool()`.
- `assertBrowserPoolNotConfigured` is exported from `@crawlee/browser` because three sibling packages need the same message. It is subclass-author plumbing, and it does widen the public surface.
