### PR TITLE
fix(core): accept the documented requestManager crawler option

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -587,6 +587,7 @@ export class BasicCrawler<Context extends CrawlingContext = BasicCrawlingContext
     protected static optionsShape = {
         requestList: ow.optional.object.validate(validators.requestList),
         requestQueue: ow.optional.object.validate(validators.requestQueue),
+        requestManager: ow.optional.object.validate(validators.requestManager),
         // Subclasses override this function instead of passing it
         // in constructor, so this validation needs to apply only
         // if the user creates an instance of BasicCrawler directly.

--- a/packages/core/src/validators.ts
+++ b/packages/core/src/validators.ts
@@ -20,4 +20,8 @@ export const validators = {
         validator: ow.isValid(value, ow.object.hasKeys('fetchNextRequest', 'addRequest')),
         message: (label: string) => `Expected argument '${label}' to be a RequestQueue, got something else.`,
     }),
+    requestManager: (value: Dictionary) => ({
+        validator: ow.isValid(value, ow.object.hasKeys('fetchNextRequest', 'addRequest', 'addRequestsBatched')),
+        message: (label: string) => `Expected argument '${label}' to be an IRequestManager, got something else.`,
+    }),
 };

--- a/test/core/crawlers/basic_crawler.test.ts
+++ b/test/core/crawlers/basic_crawler.test.ts
@@ -26,7 +26,7 @@ import {
     RequestValidationError,
     Router,
 } from '@crawlee/basic';
-import { RequestState, SessionPool, Statistics } from '@crawlee/core';
+import { RequestManagerTandem, RequestState, SessionPool, Statistics } from '@crawlee/core';
 import type { Dictionary } from '@crawlee/utils';
 import { RobotsTxtFile, sleep } from '@crawlee/utils';
 import express from 'express';
@@ -93,6 +93,23 @@ describe('BasicCrawler', () => {
         await crawler.run(['https://example.com']);
 
         expect(process.listenerCount('SIGINT')).toBe(count - 1);
+    });
+
+    test('should accept a request manager and crawl from it', async () => {
+        const requestList = await RequestList.open(null, ['https://example.com/1']);
+        const requestQueue = await RequestQueue.open();
+        const processed: string[] = [];
+
+        const basicCrawler = new BasicCrawler({
+            requestManager: new RequestManagerTandem(requestList, requestQueue),
+            requestHandler: async ({ request }) => {
+                processed.push(request.url);
+            },
+        });
+
+        await basicCrawler.run();
+
+        expect(processed).toEqual(['https://example.com/1']);
     });
 
     test('should run in parallel thru all the requests', async () => {


### PR DESCRIPTION
Went to share a queue between two crawlers, found `requestManager` in the `BasicCrawlerOptions` docs, and passing it throws before anything runs:

```
ArgumentError: Did not expect property `requestManager` to exist, got `[object Object]` in object `BasicCrawlerOptions`
```

The key just isn't in `optionsShape`, and `ow.object.exactShape` is the first thing the constructor does - so the handling below it, including the "cannot be used in conjunction with `requestList` and/or `requestQueue`" error, is unreachable. No way round it short of subclassing.

Borrowed the validator key list from the one on `v4` so the two branches agree. Every subclass spreads `optionsShape`, so this covers Cheerio/ Playwright/ Puppeteer/ JSDOM/ HTTP too.

Happy to drop the `validators` entry and use a plain `ow.optional.object` if you'd rather keep the diff to one line.
