### PR TITLE
fix(playwright): poll for late-rendered Cloudflare challenge markup

### DIFF
--- a/packages/playwright-crawler/src/internals/playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/playwright-crawler.ts
@@ -337,7 +337,13 @@ export class PlaywrightCrawler<
             compileScript: (scriptString: string, ctx?: Dictionary) => playwrightUtils.compileScript(scriptString, ctx),
             closeCookieModals: async () => playwrightUtils.closeCookieModals(context.page),
             handleCloudflareChallenge: async (options?: HandleCloudflareChallengeOptions) => {
-                return playwrightUtils.handleCloudflareChallenge(context.page, context.request.url, options);
+                let response: Response | undefined;
+                try {
+                    response = context.response;
+                } catch {
+                    // the `response` getter throws before navigation (or when navigation produced no response)
+                }
+                return playwrightUtils.handleCloudflareChallenge(context.page, context.request.url, options, response);
             },
         };
     }
@@ -346,6 +352,11 @@ export class PlaywrightCrawler<
 /**
  * Returns a `postNavigationHooks`-ready hook that runs {@apilink PlaywrightContextUtils.handleCloudflareChallenge}
  * and propagates the post-challenge {@apilink Response} back into the crawling context via its return value.
+ *
+ * Cloudflare serves its challenge pages with a 403 status, which is part of the default `blockedStatusCodes`.
+ * Keep it there - the hook runs before the blocked-status check and replaces the response on a solved
+ * challenge, so solved requests pass it, while unsolved or undetected challenges keep the 403 and get
+ * retried with a fresh session.
  *
  * **Example usage**
  * ```ts

--- a/packages/playwright-crawler/src/internals/playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/playwright-crawler.ts
@@ -336,7 +336,13 @@ export class PlaywrightCrawler<
             compileScript: (scriptString: string, ctx?: Dictionary) => playwrightUtils.compileScript(scriptString, ctx),
             closeCookieModals: async () => playwrightUtils.closeCookieModals(context.page),
             handleCloudflareChallenge: async (options?: HandleCloudflareChallengeOptions) => {
-                return playwrightUtils.handleCloudflareChallenge(context.page, context.request.url, options);
+                let response: Response | undefined;
+                try {
+                    response = context.response;
+                } catch {
+                    // the `response` getter throws before navigation (or when navigation produced no response)
+                }
+                return playwrightUtils.handleCloudflareChallenge(context.page, context.request.url, options, response);
             },
         };
     }
@@ -345,6 +351,11 @@ export class PlaywrightCrawler<
 /**
  * Returns a `postNavigationHooks`-ready hook that runs {@apilink PlaywrightContextUtils.handleCloudflareChallenge}
  * and propagates the post-challenge {@apilink Response} back into the crawling context via its return value.
+ *
+ * Cloudflare serves its challenge pages with a 403 status, which is part of the default `blockedStatusCodes`.
+ * Keep it there - the hook runs before the blocked-status check and replaces the response on a solved
+ * challenge, so solved requests pass it, while unsolved or undetected challenges keep the 403 and get
+ * retried with a fresh session.
  *
  * **Example usage**
  * ```ts

--- a/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
+++ b/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
@@ -721,23 +721,30 @@ async function handleCloudflareChallenge(
     options: HandleCloudflareChallengeOptions = {},
     response?: Response,
 ): Promise<Response | undefined> {
-    options.isBlockedCallback ??= async () => {
-        const isBlocked = await page.evaluate(() => {
-            return document.querySelector('h1')?.textContent?.trim().includes('Sorry, you have been blocked');
+    // The options object may outlive this call (the pre-wrapped hook reuses one instance for all
+    // requests and retries), so the defaults are kept local instead of being memoized on `options` -
+    // memoizing them would pin the closed-over `page` of the first call forever.
+    const isBlockedCallback =
+        options.isBlockedCallback ??
+        (async (p: Page) => {
+            const isBlocked = await p.evaluate(() => {
+                return document.querySelector('h1')?.textContent?.trim().includes('Sorry, you have been blocked');
+            });
+            return !!isBlocked;
         });
-        return !!isBlocked;
-    };
 
-    options.isChallengeCallback ??= async () => {
-        return await page.evaluate(async () => {
-            // Cloudflare keeps reshuffling the wrapper elements between `.footer-inner` and `.ray-id`,
-            // so only the stable outer classes are matched.
-            return !!document.querySelector('.footer .footer-inner .ray-id');
+    const isChallengeCallback =
+        options.isChallengeCallback ??
+        (async (p: Page) => {
+            return await p.evaluate(async () => {
+                // Cloudflare keeps reshuffling the wrapper elements between `.footer-inner` and `.ray-id`,
+                // so only the stable outer classes are matched.
+                return !!document.querySelector('.footer .footer-inner .ray-id');
+            });
         });
-    };
 
     const retryBlocked = async () => {
-        const isBlocked = await options.isBlockedCallback!(page).catch(() => false);
+        const isBlocked = await isBlockedCallback(page).catch(() => false);
 
         if (isBlocked) {
             throw new SessionError(`Blocked by Cloudflare when processing ${url}`);
@@ -746,7 +753,7 @@ async function handleCloudflareChallenge(
 
     // check if we ended up on the CF challenge page
     const isChallenge = async () => {
-        return options.isChallengeCallback!(page).catch(() => false);
+        return isChallengeCallback(page).catch(() => false);
     };
 
     // The challenge markup can finish rendering only after the `load` event, so when the response signals

--- a/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
+++ b/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
@@ -697,7 +697,9 @@ export interface HandleCloudflareChallengeOptions {
  *
  * On a successfully solved challenge the page is reloaded and the new {@apilink Response} is returned, so
  * it can be propagated back to the crawling context via a hook return value (see
- * {@apilink handleCloudflareChallengeHook}).
+ * {@apilink handleCloudflareChallengeHook}). Thanks to that, the 403 status of the challenge page does not
+ * need to be removed from `blockedStatusCodes` - a solved challenge replaces the response before the
+ * blocked-status check runs, and an unsolved one is retried with a fresh session.
  *
  * Works best with camoufox.
  *
@@ -711,11 +713,13 @@ export interface HandleCloudflareChallengeOptions {
  * @param page Playwright [`Page`](https://playwright.dev/docs/api/class-page) object
  * @param url current URL for request identification, only used for logging
  * @param [options]
+ * @param [response] navigation response, used to poll for late-rendered challenge markup when it signals a likely challenge
  */
 async function handleCloudflareChallenge(
     page: Page,
     url: string,
     options: HandleCloudflareChallengeOptions = {},
+    response?: Response,
 ): Promise<Response | undefined> {
     options.isBlockedCallback ??= async () => {
         const isBlocked = await page.evaluate(() => {
@@ -745,7 +749,20 @@ async function handleCloudflareChallenge(
         return options.isChallengeCallback!(page).catch(() => false);
     };
 
-    if (!(await isChallenge())) {
+    // The challenge markup can finish rendering only after the `load` event, so when the response signals
+    // a likely challenge (403 status or the `cf-mitigated` header), poll for it instead of checking once.
+    const likelyChallenge = response?.status() === 403 || response?.headers()['cf-mitigated'] === 'challenge';
+
+    let detected = await isChallenge();
+
+    for (let i = 0; !detected && likelyChallenge && i < 10; i++) {
+        // a hard-blocked page never turns into a challenge, so fail fast instead of finishing the poll
+        await retryBlocked();
+        await sleep(500);
+        detected = await isChallenge();
+    }
+
+    if (!detected) {
         await retryBlocked();
         return undefined;
     }

--- a/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
+++ b/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
@@ -713,23 +713,30 @@ async function handleCloudflareChallenge(
     options: HandleCloudflareChallengeOptions = {},
     response?: Response,
 ): Promise<Response | undefined> {
-    options.isBlockedCallback ??= async () => {
-        const isBlocked = await page.evaluate(() => {
-            return document.querySelector('h1')?.textContent?.trim().includes('Sorry, you have been blocked');
+    // The options object may outlive this call (the pre-wrapped hook reuses one instance for all
+    // requests and retries), so the defaults are kept local instead of being memoized on `options` -
+    // memoizing them would pin the closed-over `page` of the first call forever.
+    const isBlockedCallback =
+        options.isBlockedCallback ??
+        (async (p: Page) => {
+            const isBlocked = await p.evaluate(() => {
+                return document.querySelector('h1')?.textContent?.trim().includes('Sorry, you have been blocked');
+            });
+            return !!isBlocked;
         });
-        return !!isBlocked;
-    };
 
-    options.isChallengeCallback ??= async () => {
-        return await page.evaluate(async () => {
-            // Cloudflare keeps reshuffling the wrapper elements between `.footer-inner` and `.ray-id`,
-            // so only the stable outer classes are matched.
-            return !!document.querySelector('.footer .footer-inner .ray-id');
+    const isChallengeCallback =
+        options.isChallengeCallback ??
+        (async (p: Page) => {
+            return await p.evaluate(async () => {
+                // Cloudflare keeps reshuffling the wrapper elements between `.footer-inner` and `.ray-id`,
+                // so only the stable outer classes are matched.
+                return !!document.querySelector('.footer .footer-inner .ray-id');
+            });
         });
-    };
 
     const retryBlocked = async () => {
-        const isBlocked = await options.isBlockedCallback!(page).catch(() => false);
+        const isBlocked = await isBlockedCallback(page).catch(() => false);
 
         if (isBlocked) {
             throw new SessionError(`Blocked by Cloudflare when processing ${url}`);
@@ -738,7 +745,7 @@ async function handleCloudflareChallenge(
 
     // check if we ended up on the CF challenge page
     const isChallenge = async () => {
-        return options.isChallengeCallback!(page).catch(() => false);
+        return isChallengeCallback(page).catch(() => false);
     };
 
     // The challenge markup can finish rendering only after the `load` event, so when the response signals

--- a/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
+++ b/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
@@ -689,7 +689,9 @@ export interface HandleCloudflareChallengeOptions {
  *
  * On a successfully solved challenge the page is reloaded and the new {@apilink Response} is returned, so
  * it can be propagated back to the crawling context via a hook return value (see
- * {@apilink handleCloudflareChallengeHook}).
+ * {@apilink handleCloudflareChallengeHook}). Thanks to that, the 403 status of the challenge page does not
+ * need to be removed from `blockedStatusCodes` - a solved challenge replaces the response before the
+ * blocked-status check runs, and an unsolved one is retried with a fresh session.
  *
  * Works best with camoufox.
  *
@@ -703,11 +705,13 @@ export interface HandleCloudflareChallengeOptions {
  * @param page Playwright [`Page`](https://playwright.dev/docs/api/class-page) object
  * @param url current URL for request identification, only used for logging
  * @param [options]
+ * @param [response] navigation response, used to poll for late-rendered challenge markup when it signals a likely challenge
  */
 async function handleCloudflareChallenge(
     page: Page,
     url: string,
     options: HandleCloudflareChallengeOptions = {},
+    response?: Response,
 ): Promise<Response | undefined> {
     options.isBlockedCallback ??= async () => {
         const isBlocked = await page.evaluate(() => {
@@ -737,7 +741,20 @@ async function handleCloudflareChallenge(
         return options.isChallengeCallback!(page).catch(() => false);
     };
 
-    if (!(await isChallenge())) {
+    // The challenge markup can finish rendering only after the `load` event, so when the response signals
+    // a likely challenge (403 status or the `cf-mitigated` header), poll for it instead of checking once.
+    const likelyChallenge = response?.status() === 403 || response?.headers()['cf-mitigated'] === 'challenge';
+
+    let detected = await isChallenge();
+
+    for (let i = 0; !detected && likelyChallenge && i < 10; i++) {
+        // a hard-blocked page never turns into a challenge, so fail fast instead of finishing the poll
+        await retryBlocked();
+        await sleep(500);
+        detected = await isChallenge();
+    }
+
+    if (!detected) {
         await retryBlocked();
         return undefined;
     }

--- a/test/core/playwright_utils.test.ts
+++ b/test/core/playwright_utils.test.ts
@@ -503,6 +503,25 @@ describe('playwrightUtils', () => {
             ).resolves.toBeUndefined();
         });
 
+        test('detects the challenge on a new page when the same options object is reused across calls', async () => {
+            // the pre-wrapped hook from `handleCloudflareChallengeHook()` passes one options object to
+            // every call, spanning retries (and their new pages) - the detection must not stick to the
+            // page of the first call
+            const options = fastOptions();
+
+            const firstPage = await browser.newPage();
+            await firstPage.setContent(`<html><body>${currentChallengeBody}</body></html>`);
+            await expect(handleCloudflareChallenge(firstPage, 'https://example.com', options)).rejects.toThrow(
+                /Blocked by Cloudflare/,
+            );
+            await firstPage.close();
+
+            await page.setContent(`<html><body>${currentChallengeBody}</body></html>`);
+            await expect(handleCloudflareChallenge(page, 'https://example.com', options)).rejects.toThrow(
+                /Blocked by Cloudflare/,
+            );
+        });
+
         test('detects challenge markup that renders only after the load event on a 403 response', async () => {
             await page.setContent('<html><body><h1>Loading</h1></body></html>');
             await page.evaluate((body) => {

--- a/test/core/playwright_utils.test.ts
+++ b/test/core/playwright_utils.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 
 import { MemoryStorageBackend, serviceLocator } from '@crawlee/core';
 import { KeyValueStore, launchPlaywright, playwrightUtils, Request } from '@crawlee/playwright';
-import type { Browser, Page } from 'playwright';
+import type { Browser, Page, Response } from 'playwright';
 import { chromium } from 'playwright';
 import { runExampleComServer } from '../shared/_helper.js';
 
@@ -501,6 +501,85 @@ describe('playwrightUtils', () => {
             await expect(
                 handleCloudflareChallenge(page, 'https://example.com', fastOptions()),
             ).resolves.toBeUndefined();
+        });
+
+        test('detects challenge markup that renders only after the load event on a 403 response', async () => {
+            await page.setContent('<html><body><h1>Loading</h1></body></html>');
+            await page.evaluate((body) => {
+                setTimeout(() => {
+                    document.body.innerHTML = body;
+                }, 1500);
+            }, currentChallengeBody);
+
+            const response = { status: () => 403, headers: () => ({}) } as unknown as Response;
+            await expect(
+                handleCloudflareChallenge(page, 'https://example.com', fastOptions(), response),
+            ).rejects.toThrow(/Blocked by Cloudflare/);
+        });
+
+        test('detects a late-rendered challenge via the cf-mitigated response header', async () => {
+            await page.setContent('<html><body><h1>Loading</h1></body></html>');
+            await page.evaluate((body) => {
+                setTimeout(() => {
+                    document.body.innerHTML = body;
+                }, 1500);
+            }, currentChallengeBody);
+
+            const response = {
+                status: () => 200,
+                headers: () => ({ 'cf-mitigated': 'challenge' }),
+            } as unknown as Response;
+            await expect(
+                handleCloudflareChallenge(page, 'https://example.com', fastOptions(), response),
+            ).rejects.toThrow(/Blocked by Cloudflare/);
+        });
+
+        test('fails fast on a hard-blocked 403 page instead of polling for challenge markup', async () => {
+            await page.setContent('<html><body><h1>Sorry, you have been blocked</h1></body></html>');
+            const response = { status: () => 403, headers: () => ({}) } as unknown as Response;
+            const start = Date.now();
+            await expect(
+                handleCloudflareChallenge(page, 'https://example.com', fastOptions(), response),
+            ).rejects.toThrow(/Blocked by Cloudflare/);
+            expect(Date.now() - start).toBeLessThan(4000);
+        }, 10_000);
+
+        test('resolves without detection on a plain 403 page without challenge markup', async () => {
+            await page.setContent('<html><body><h1>Forbidden</h1></body></html>');
+            const response = { status: () => 403, headers: () => ({}) } as unknown as Response;
+            await expect(
+                handleCloudflareChallenge(page, 'https://example.com', fastOptions(), response),
+            ).resolves.toBeUndefined();
+        }, 10_000);
+
+        test('returns the reloaded response once the challenge is solved', async () => {
+            let served = 0;
+            await page.route('**/cf-test', async (route) => {
+                served += 1;
+                await route.fulfill({
+                    status: served === 1 ? 403 : 200,
+                    contentType: 'text/html',
+                    body:
+                        served === 1
+                            ? `<html><body>${currentChallengeBody}</body></html>`
+                            : '<html><body><h1>Welcome</h1></body></html>',
+                });
+            });
+
+            try {
+                await page.goto('https://example.com/cf-test');
+                const response = await handleCloudflareChallenge(page, 'https://example.com/cf-test', {
+                    ...fastOptions(),
+                    // simulate a solved challenge by removing the challenge markup
+                    clickCallback: async () => {
+                        await page.evaluate(() => document.querySelector('.footer')?.remove());
+                    },
+                });
+
+                expect(response?.status()).toBe(200);
+            } finally {
+                await page.unroute('**/cf-test');
+            }
         });
     });
 });

--- a/test/e2e/camoufox-cloudflare/actor/main.js
+++ b/test/e2e/camoufox-cloudflare/actor/main.js
@@ -16,11 +16,6 @@ await Actor.main(async () => {
         // The target hard-blocks datacenter IP ranges outright (block page, not a solvable
         // challenge), so this test needs residential exit nodes.
         proxyConfiguration: await Actor.createProxyConfiguration({ groups: ['RESIDENTIAL'] }),
-        // Cloudflare serves its challenge with a 403 status. v3's handleCloudflareChallenge removed
-        // 403 from the session pool's blocked status codes itself; in v4 that is an explicit crawler
-        // option, and keeping 403 in the default set would fail challenged requests before the hook
-        // below gets a chance to solve them on retries.
-        blockedStatusCodes: [401, 429],
         browserPool: playwrightBrowserPool({
             // Camoufox ships its own anti-detection; Crawlee's fingerprint injection conflicts with it
             // and keeps Cloudflare from ever clearing the challenge.


### PR DESCRIPTION
Fixes two ways `handleCloudflareChallengeHook()` lost track of challenges after the first attempt, found while stabilizing the camoufox-cloudflare E2E fixture.

The first is a stale page pinned in reused options. `handleCloudflareChallenge()` memoized its default `isChallengeCallback`/`isBlockedCallback` onto the caller's options object, with the current page captured in the closure. The pre-wrapped hook passes one options object to every call, so after the first attempt the detection kept querying the first (by then closed) page: the evaluate rejected, the `catch` turned that into "no challenge", and retries silently ran the request handler on challenge pages. Unit tests never see this because they construct fresh options per call; it took platform runs with debug instrumentation to find (the retry pages had the full challenge markup, yet detection saw nothing). The defaults are now kept local and bound to the page argument. Verified on the platform (run `m6QgmOqsSQ5wBvb1p`): every retry detects the challenge again and the solver runs each time.

The second is single-shot detection. The current Cloudflare template can finish rendering the challenge markup after the `load` event. When the navigation response signals a likely challenge (a 403 status, or Cloudflare's documented `cf-mitigated: challenge` header), the helper now polls for the markup for up to 5 seconds instead of checking once, and bails out early when the page is a hard block. The crawling-context util passes the response through to make that possible. Pages with other status codes keep the single immediate check and pay no extra cost.

This also answers the follow-up question from 99d465d56: the hook should not remove 403 from `blockedStatusCodes` automatically the way v3 did. v3 spliced 403 out of the session pool because it never reloaded the page, so even a solved challenge kept the original 403 response. v4 reloads and propagates the fresh response, so a solved challenge passes the blocked-status check on its own. Keeping 403 blocked is a safety net: an unsolved or undetected challenge gets retried with a fresh session instead of reaching the request handler. The E2E fixture drops its `blockedStatusCodes` workaround, and the hook docs now spell out the 403 interplay.

The fixture still does not pass, because the click-solver currently cannot clear the challenge at all. Master's nightly fails the same fixture the same way (run from 2026-08-13 06:14 UTC), so that part is environmental and independent of this change.
