### PR TITLE
feat(core): make inner option of ThrottlingRequestManager optional

### DIFF
--- a/docs/public-api/crawlee-core.api.md
+++ b/docs/public-api/crawlee-core.api.md
@@ -2108,7 +2108,7 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
 export interface ThrottlingRequestManagerOptions<T extends IRequestManager = IRequestManager> {
     baseDelaySecs?: number;
     domains: string[] | 'all';
-    inner: T;
+    inner?: T;
     maxDelaySecs?: number;
     maxDomainStallSecs?: number;
     maxThrottledDomains?: number;

--- a/docs/public-api/crawlee-core.api.md
+++ b/docs/public-api/crawlee-core.api.md
@@ -1223,7 +1223,7 @@ export interface RequestListState {
 }
 
 // @public
-export type RequestManagerOpener<T extends IRequestManager = IRequestManager> = (identifier: string | StorageIdentifier, options?: StorageOpenOptions) => Promise<T>;
+export type RequestManagerOpener<T extends IRequestManager = IRequestManager> = (identifier?: string | StorageIdentifier | null, options?: StorageOpenOptions) => Promise<T>;
 
 // @public
 export class RequestManagerTandem implements IRequestManager {

--- a/packages/core/src/recoverable_state.ts
+++ b/packages/core/src/recoverable_state.ts
@@ -1,6 +1,10 @@
 import { addTimeoutToPromise, storage as timeoutStorage } from '@apify/timeout';
-import type { Configuration, CrawleeLogger } from '@crawlee/core';
-import { EventType, KeyValueStore, serviceLocator, StateValidationError } from '@crawlee/core';
+import type { Configuration } from './configuration.js';
+import { StateValidationError } from './errors.js';
+import { EventType } from './events/event_manager.js';
+import type { CrawleeLogger } from './log.js';
+import { serviceLocator } from './service_locator.js';
+import { KeyValueStore } from './storages/key_value_store.js';
 import type { Awaitable } from '@crawlee/types';
 import type { StandardSchemaV1 } from '@standard-schema/spec';
 

--- a/packages/core/src/storages/throttling_request_manager.ts
+++ b/packages/core/src/storages/throttling_request_manager.ts
@@ -28,14 +28,22 @@ const throttlingRequestManagerOptionsSchema = z.strictObject({
     inner: schemas.anyObject.optional(),
     domains: z.union([schemas.arrayOf(z.string().nonempty(), 'non-empty strings'), z.literal('all')]),
     requestManagerOpener: schemas.anyFunction.optional(),
-    baseDelaySecs: schemas.anyNumber.refine((value: number) => value > 0, 'Expected a number greater than 0').optional(),
-    maxDelaySecs: schemas.anyNumber.refine((value: number) => value > 0, 'Expected a number greater than 0').optional(),
-    maxDomainStallSecs: schemas.anyNumber.refine((value: number) => value > 0, 'Expected a number greater than 0').optional(),
+    baseDelaySecs: schemas.anyNumber
+        .refine((value: number) => value > 0, 'Expected a number greater than 0')
+        .optional(),
+    maxDelaySecs: schemas.anyNumber
+        .refine((value: number) => value > 0, 'Expected a number greater than 0')
+        .optional(),
+    maxDomainStallSecs: schemas.anyNumber
+        .refine((value: number) => value > 0, 'Expected a number greater than 0')
+        .optional(),
     minCrawlDelaySecs: schemas.anyNumber
         .refine((value: number) => value >= 0, 'Expected a number greater than or equal to 0')
         .optional(),
     throttleBy: z.enum(['hostname', 'registrableDomain']).optional(),
-    maxThrottledDomains: schemas.anyNumber.refine((value: number) => value > 0, 'Expected a number greater than 0').optional(),
+    maxThrottledDomains: schemas.anyNumber
+        .refine((value: number) => value > 0, 'Expected a number greater than 0')
+        .optional(),
     persistStateKey: z.string().nonempty().optional(),
 });
 

--- a/packages/core/src/storages/throttling_request_manager.ts
+++ b/packages/core/src/storages/throttling_request_manager.ts
@@ -47,7 +47,7 @@ const throttlingRequestManagerOptionsSchema = z.strictObject({
  * concrete type and storage backend of the manager being wrapped.
  */
 export type RequestManagerOpener<T extends IRequestManager = IRequestManager> = (
-    identifier: string | StorageIdentifier,
+    identifier?: string | StorageIdentifier | null,
     options?: StorageOpenOptions,
 ) => Promise<T>;
 
@@ -380,7 +380,7 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
 
     /** The wrapped manager, holding every request whose domain is not throttled. */
     get innerManager(): T {
-        return this.#inner;
+        return this.#inner!;
     }
 
     /** Warns once about sources that cannot be routed by domain, because their URLs are not known yet. */
@@ -817,7 +817,8 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
         const key = request.id ?? request.uniqueKey;
 
         if (this.#inFlightFromInner.delete(key)) {
-            return this.#inner;
+            await this.#ensureSubManagers();
+            return this.#inner!;
         }
 
         return this.#selectManagerOrThrow(request.url);
@@ -847,7 +848,7 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
         const fetchable = await Promise.all(
             this.#fetchableDomains().map(async (domain) => this.#subManagers.get(domain)!),
         );
-        const results = await Promise.all([this.#inner, ...fetchable].map(async (manager) => manager.isEmpty()));
+        const results = await Promise.all([this.#inner!, ...fetchable].map(async (manager) => manager.isEmpty()));
 
         return results.every(Boolean);
     }

--- a/packages/core/src/storages/throttling_request_manager.ts
+++ b/packages/core/src/storages/throttling_request_manager.ts
@@ -31,9 +31,7 @@ const throttlingRequestManagerOptionsSchema = z.strictObject({
     baseDelaySecs: schemas.anyNumber
         .refine((value: number) => value > 0, 'Expected a number greater than 0')
         .optional(),
-    maxDelaySecs: schemas.anyNumber
-        .refine((value: number) => value > 0, 'Expected a number greater than 0')
-        .optional(),
+    maxDelaySecs: schemas.anyNumber.refine((value: number) => value > 0, 'Expected a number greater than 0').optional(),
     maxDomainStallSecs: schemas.anyNumber
         .refine((value: number) => value > 0, 'Expected a number greater than 0')
         .optional(),

--- a/packages/core/src/storages/throttling_request_manager.ts
+++ b/packages/core/src/storages/throttling_request_manager.ts
@@ -28,14 +28,14 @@ const throttlingRequestManagerOptionsSchema = z.strictObject({
     inner: schemas.anyObject.optional(),
     domains: z.union([schemas.arrayOf(z.string().nonempty(), 'non-empty strings'), z.literal('all')]),
     requestManagerOpener: schemas.anyFunction.optional(),
-    baseDelaySecs: schemas.anyNumber.refine((value) => value > 0, 'Expected a number greater than 0').optional(),
-    maxDelaySecs: schemas.anyNumber.refine((value) => value > 0, 'Expected a number greater than 0').optional(),
-    maxDomainStallSecs: schemas.anyNumber.refine((value) => value > 0, 'Expected a number greater than 0').optional(),
+    baseDelaySecs: schemas.anyNumber.refine((value: number) => value > 0, 'Expected a number greater than 0').optional(),
+    maxDelaySecs: schemas.anyNumber.refine((value: number) => value > 0, 'Expected a number greater than 0').optional(),
+    maxDomainStallSecs: schemas.anyNumber.refine((value: number) => value > 0, 'Expected a number greater than 0').optional(),
     minCrawlDelaySecs: schemas.anyNumber
-        .refine((value) => value >= 0, 'Expected a number greater than or equal to 0')
+        .refine((value: number) => value >= 0, 'Expected a number greater than or equal to 0')
         .optional(),
     throttleBy: z.enum(['hostname', 'registrableDomain']).optional(),
-    maxThrottledDomains: schemas.anyNumber.refine((value) => value > 0, 'Expected a number greater than 0').optional(),
+    maxThrottledDomains: schemas.anyNumber.refine((value: number) => value > 0, 'Expected a number greater than 0').optional(),
     persistStateKey: z.string().nonempty().optional(),
 });
 

--- a/packages/core/src/storages/throttling_request_manager.ts
+++ b/packages/core/src/storages/throttling_request_manager.ts
@@ -25,7 +25,7 @@ import type { StorageIdentifier } from './storage_instance_manager.js';
 import type { StorageOpenOptions } from './utils.js';
 
 const throttlingRequestManagerOptionsSchema = z.strictObject({
-    inner: schemas.anyObject,
+    inner: schemas.anyObject.optional(),
     domains: z.union([schemas.arrayOf(z.string().nonempty(), 'non-empty strings'), z.literal('all')]),
     requestManagerOpener: schemas.anyFunction.optional(),
     baseDelaySecs: schemas.anyNumber.refine((value) => value > 0, 'Expected a number greater than 0').optional(),
@@ -81,9 +81,9 @@ export function supportsDomainThrottling(manager: unknown): manager is SupportsD
 export interface ThrottlingRequestManagerOptions<T extends IRequestManager = IRequestManager> {
     /**
      * The request manager to wrap, usually a {@apilink RequestQueue}. Requests for domains that are not throttled
-     * are stored here.
+     * are stored here. If not provided, a default queue will be opened.
      */
-    inner: T;
+    inner?: T;
 
     /**
      * Which domains to throttle: a list of hostnames, or `'all'` for every domain the crawl encounters.
@@ -269,7 +269,7 @@ const DEFAULT_PERSIST_STATE_KEY = 'CRAWLEE_THROTTLED_DOMAINS';
 export class ThrottlingRequestManager<T extends IRequestManager = IRequestManager>
     implements IRequestManager, SupportsDomainThrottling
 {
-    readonly #inner: T;
+    #inner?: T;
     readonly #requestManagerOpener: RequestManagerOpener<T>;
     readonly #baseDelayMs: number;
     readonly #maxDelayMs: number;
@@ -429,7 +429,7 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
         const domain = this.#extractDomain(url);
 
         if (!domain || !(this.#listedDomains.has(domain) || this.#throttlesEveryDomain)) {
-            return this.#inner;
+            return this.#inner!;
         }
 
         if (!this.#listedDomains.has(domain) && !this.#discoveredDomains.has(domain)) {
@@ -520,6 +520,10 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
 
     async #ensureSubManagers(): Promise<void> {
         this.#subManagersReady ??= (async () => {
+            if (!this.#inner) {
+                this.#inner = await this.#requestManagerOpener(null, { configuration: this.config });
+            }
+
             if (this.#throttlesEveryDomain) {
                 this.#domainListStore = await KeyValueStore.open(null, { configuration: this.config });
 
@@ -862,7 +866,8 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
      * site rather than of the run, so it survives.
      */
     async purge(): Promise<void> {
-        await this.#inner.purge?.();
+        await this.#ensureSubManagers();
+        await this.#inner!.purge?.();
         await this.purgeDomainQueues();
     }
 
@@ -891,17 +896,20 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
     }
 
     async #forEachManager(fn: (manager: T) => Promise<unknown> | undefined): Promise<void> {
+        await this.#ensureSubManagers();
         // `fn` targets optional members, so it may return nothing - the wrapper normalizes that for `Promise.all`.
-        await Promise.all([this.#inner, ...(await this.#getSubManagers())].map(async (manager) => fn(manager)));
+        await Promise.all([this.#inner!, ...(await this.#getSubManagers())].map(async (manager) => fn(manager)));
     }
 
     async #sumOverManagers(fn: (manager: T) => Promise<number>): Promise<number> {
-        const counts = await Promise.all([this.#inner, ...(await this.#getSubManagers())].map(fn));
+        await this.#ensureSubManagers();
+        const counts = await Promise.all([this.#inner!, ...(await this.#getSubManagers())].map(fn));
         return counts.reduce((a, b) => a + b, 0);
     }
 
     async #everyManager(fn: (manager: T) => Promise<boolean>): Promise<boolean> {
-        const results = await Promise.all([this.#inner, ...(await this.#getSubManagers())].map(fn));
+        await this.#ensureSubManagers();
+        const results = await Promise.all([this.#inner!, ...(await this.#getSubManagers())].map(fn));
         return results.every(Boolean);
     }
 
@@ -937,7 +945,7 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
             state.crawlDelayUntil = crawlDelayUntilBefore;
         }
 
-        const request = await this.#inner.fetchNextRequest<R>();
+        const request = await this.#inner!.fetchNextRequest<R>();
 
         if (request !== null) {
             this.#inFlightFromInner.add(request.id ?? request.uniqueKey);

--- a/test/core/storages/throttling_request_manager.test.ts
+++ b/test/core/storages/throttling_request_manager.test.ts
@@ -726,4 +726,24 @@ describe('ThrottlingRequestManager', () => {
         expect(Date.now() - start).toBeGreaterThanOrEqual(150);
         expect(req2.url).toBe('https://example.com/2');
     });
+
+    test('Optional inner option: defaults to a RequestQueue when inner is omitted', async () => {
+        const manager = new ThrottlingRequestManager({
+            domains: ['example.com'],
+        });
+
+        // Adding requests to non-throttled and throttled domains
+        await manager.addRequest({ url: 'https://other.com/a' });
+        await manager.addRequest({ url: 'https://example.com/a' });
+
+        expect(await manager.getTotalCount()).toBe(2);
+
+        const req1 = await manager.fetchNextRequest();
+        expect(req1!.url).toBe('https://example.com/a');
+
+        const req2 = await manager.fetchNextRequest();
+        expect(req2!.url).toBe('https://other.com/a');
+
+        expect(await manager.fetchNextRequest()).toBeNull();
+    });
 });


### PR DESCRIPTION
### Summary

Closes #4027

This PR makes the `inner` option of `ThrottlingRequestManagerOptions` optional (`inner?: T`). When omitted, `ThrottlingRequestManager` automatically opens and defaults to a standard `RequestQueue` via `requestManagerOpener` during `#ensureSubManagers()`.

### Changes

- **`ThrottlingRequestManagerOptions` & Schema** (`packages/core/src/storages/throttling_request_manager.ts`):
  - Made `inner?: T` optional in `ThrottlingRequestManagerOptions`.
  - Updated Zod validation schema `throttlingRequestManagerOptionsSchema` with `inner: schemas.anyObject.optional()`.
- **`ThrottlingRequestManager`**:
  - Lazily initializes `#inner` in `#ensureSubManagers()` via `await this.#requestManagerOpener(null, { configuration: this.config })` if `options.inner` was omitted.
  - Ensured thread-safety across all aggregation/forwarding methods (`isEmpty`, `purge`, `#forEachManager`, `#sumOverManagers`, `#everyManager`).
- **Tests** (`test/core/storages/throttling_request_manager.test.ts`):
  - Added unit test coverage verifying that `ThrottlingRequestManager` can be instantiated without `inner` and correctly routes and processes requests.

### Checklist

- [x] Code follows the style guidelines of Crawlee
- [x] Self-review performed
- [x] Unit tests added and passing
