### PR TITLE
fix(core): honour domain backoff for requests the wrapped manager holds

### DIFF
--- a/packages/core/src/storages/throttling_request_manager.ts
+++ b/packages/core/src/storages/throttling_request_manager.ts
@@ -428,6 +428,16 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
         return this.#resolvedInner;
     }
 
+    /**
+     * Notes that a request landed in `manager`. If that is the wrapped one, what it holds has changed, so
+     * whatever an earlier sweep concluded about it no longer holds.
+     */
+    #noteRequestRouted(manager: T): void {
+        if (manager === this.#resolvedInner) {
+            this.#innerBlockedUntil = 0;
+        }
+    }
+
     /** Warns once about sources that cannot be routed by domain, because their URLs are not known yet. */
     #warnIfNotRoutable(requestLike: Source): void {
         if ('requestsFromUrl' in requestLike && requestLike.requestsFromUrl !== undefined && this.#throttlingEnabled) {
@@ -789,10 +799,7 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
 
         const manager = await this.#selectManagerOrThrow(requestLike.url ?? '');
 
-        if (manager === this.#resolvedInner) {
-            // What it holds has changed, so whatever an earlier sweep concluded about it no longer holds.
-            this.#innerBlockedUntil = 0;
-        }
+        this.#noteRequestRouted(manager);
 
         return manager.addRequest(requestLike, options);
     }
@@ -842,9 +849,7 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
                         continue;
                     }
 
-                    if (manager === this.#resolvedInner) {
-                        this.#innerBlockedUntil = 0;
-                    }
+                    this.#noteRequestRouted(manager);
 
                     const bucket = byManager.get(manager);
                     if (bucket) {
@@ -888,9 +893,7 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
     ): Promise<RequestQueueOperationInfo | null> {
         const manager = await this.#managerHolding(request);
 
-        if (manager === this.#resolvedInner) {
-            this.#innerBlockedUntil = 0;
-        }
+        this.#noteRequestRouted(manager);
 
         return manager.reclaimRequest(request, options);
     }

--- a/packages/core/src/storages/throttling_request_manager.ts
+++ b/packages/core/src/storages/throttling_request_manager.ts
@@ -6,7 +6,8 @@ import { z } from 'zod';
 import type { Configuration } from '../configuration.js';
 import { asyncifyIterable } from '../iterables.js';
 import type { CrawleeLogger } from '../log.js';
-import type { Request, Source } from '../request.js';
+import type { Source } from '../request.js';
+import { Request } from '../request.js';
 import { serviceLocator } from '../service_locator.js';
 import { normalizeHostname } from '../url.js';
 import { parseArgument, schemas } from '../validators.js';
@@ -181,11 +182,6 @@ interface DomainState {
      * `rateLimitedSince` to tell a domain that is still turning us away from one that is merely being waited out.
      */
     lastRateLimitedAt: number;
-    /**
-     * Whether the wrapped manager was found holding a request for this domain. Those requests are not in its
-     * sub-queue, so they are the only trace stall detection has that the domain still has work waiting.
-     */
-    hasInnerBacklog: boolean;
 }
 
 /** The moment a domain may be dispatched to again - whichever of its two independent clocks runs longer. */
@@ -208,18 +204,16 @@ function newDomainState(domain: string): DomainState {
         declaredCrawlDelayMs: null,
         rateLimitedSince: 0,
         lastRateLimitedAt: 0,
-        hasInnerBacklog: false,
     };
 }
 
 const DEFAULT_PERSIST_STATE_KEY = 'CRAWLEE_THROTTLED_DOMAINS';
 
 /**
- * How far into the wrapped manager one sweep looks for a request that can be dispatched. Bounded because the
- * requests it walks past are held in memory until the sweep ends, and a queue holding a million URLs of a
- * single throttled domain would otherwise be pulled into it in full.
+ * How many requests one fetch may move out of the wrapped manager before giving up on finding a dispatchable
+ * one. The next fetch resumes where it left off, and a migrated request is never walked again.
  */
-const MAX_INNER_SWEEP = 1000;
+const MAX_INNER_MIGRATIONS = 1000;
 
 /**
  * A request manager that wraps another one and paces requests per domain.
@@ -306,12 +300,6 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
     #domainListStore?: KeyValueStore;
     #lastDomainListWrite: Promise<unknown> = Promise.resolve();
     #queuedDomainListWrite?: Promise<void>;
-
-    /**
-     * Until when the wrapped manager is known to hold nothing but requests for domains that are backing off,
-     * as a `Date.now()` timestamp. Sweeping it again before then would only put the same requests back.
-     */
-    #innerBlockedUntil = 0;
 
     /**
      * Sub-managers are keyed by a stable alias, so with `purgeOnStart` disabled they outlive the process. They
@@ -426,16 +414,6 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
         }
 
         return this.#resolvedInner;
-    }
-
-    /**
-     * Notes that a request landed in `manager`. If that is the wrapped one, what it holds has changed, so
-     * whatever an earlier sweep concluded about it no longer holds.
-     */
-    #noteRequestRouted(manager: T): void {
-        if (manager === this.#resolvedInner) {
-            this.#innerBlockedUntil = 0;
-        }
     }
 
     /** Warns once about sources that cannot be routed by domain, because their URLs are not known yet. */
@@ -787,8 +765,6 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
         const state = this.#getDomainState(url);
         if (state) {
             state.rateLimitedSince = 0;
-            // Both describe the episode that just ended; a later sweep sets this again if it is still true.
-            state.hasInnerBacklog = false;
         }
     }
 
@@ -798,8 +774,6 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
         this.#warnIfNotRoutable(requestLike);
 
         const manager = await this.#selectManagerOrThrow(requestLike.url ?? '');
-
-        this.#noteRequestRouted(manager);
 
         return manager.addRequest(requestLike, options);
     }
@@ -849,8 +823,6 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
                         continue;
                     }
 
-                    this.#noteRequestRouted(manager);
-
                     const bucket = byManager.get(manager);
                     if (bucket) {
                         bucket.push(request);
@@ -892,8 +864,6 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
         options?: RequestQueueOperationOptions,
     ): Promise<RequestQueueOperationInfo | null> {
         const manager = await this.#managerHolding(request);
-
-        this.#noteRequestRouted(manager);
 
         return manager.reclaimRequest(request, options);
     }
@@ -980,9 +950,11 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
             }
         }
 
+        const inner = await this.#getInner();
+
         const probed = (
             await Promise.all([
-                this.#checkInnerReadiness(),
+                inner.checkReadiness(),
                 ...dispatchable.map(async (subManager) => (await subManager).checkReadiness()),
             ])
         ).reduce(joinRequestSourceStatuses);
@@ -996,9 +968,6 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
             const stalled = (
                 await Promise.all(
                     stallCandidates.map(async (state) =>
-                        // Requests the wrapped manager holds count too: a domain whose work only lives there
-                        // has an empty sub-queue, and would otherwise be waited on forever.
-                        state.hasInnerBacklog ||
                         (await (await this.#subManagers.get(state.domain)!).checkReadiness()).status === 'ready'
                             ? state
                             : null,
@@ -1035,22 +1004,6 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
     }
 
     /**
-     * What the wrapped manager can offer *this* manager, which is not the same as what it holds: while a sweep
-     * has found nothing in it but requests for domains that are backing off, it is `waiting` rather than
-     * `ready`, no matter how much work it reports. Answering `ready` there would send the crawler polling for a
-     * request {@link fetchNextRequest} cannot hand out.
-     */
-    async #checkInnerReadiness(): Promise<RequestSourceStatus> {
-        const status = await (await this.#getInner()).checkReadiness();
-
-        if (status.status === 'ready' && Date.now() < this.#innerBlockedUntil) {
-            return { status: 'waiting', readyAt: this.#innerBlockedUntil };
-        }
-
-        return status;
-    }
-
-    /**
      * Empties every manager and clears the accumulated backoff. A robots.txt `Crawl-delay` is a property of the
      * site rather than of the run, so it survives.
      */
@@ -1067,8 +1020,6 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
         const subManagers = await this.#getSubManagers();
         await Promise.all(subManagers.map(async (manager) => manager.purge?.()));
 
-        this.#innerBlockedUntil = 0;
-
         for (const state of this.domainStates.values()) {
             state.consecutive429Count = 0;
             state.backoffUntil = 0;
@@ -1076,7 +1027,6 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
             state.backoffDecaysAt = 0;
             state.rateLimitedSince = 0;
             state.lastRateLimitedAt = 0;
-            state.hasInnerBacklog = false;
         }
     }
 
@@ -1165,60 +1115,53 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
     /**
      * The next request the wrapped manager can offer whose domain is not being held back.
      *
-     * Its requests are not stored per domain, so they cannot be skipped the way a sub-queue can - the only way
-     * to find out which domain one belongs to is to take it out. Any that turn out to be backing off go
-     * straight back, because handing one over would have the crawler hammer the domain that just told us to
-     * wait: a request deferred this way costs no retry, so nothing else would ever slow it down.
+     * Its requests are not stored per domain, so they cannot be skipped the way a sub-queue can - the only
+     * way to find out which domain one belongs to is to take it out. One that turns out to be backing off is
+     * moved into its domain's sub-queue, where that domain's clocks hold it back like any other: dispatching
+     * it would have the crawler hammer the domain that just told us to wait, and putting it back would have
+     * every later fetch walk past it again.
      */
     async #fetchFromInner<R extends Dictionary = Dictionary>(): Promise<Request<R> | null> {
-        if (Date.now() < this.#innerBlockedUntil) {
-            return null;
-        }
-
         const inner = await this.#getInner();
 
-        // Held for the length of the sweep rather than reclaimed one by one: a reclaimed request can be
-        // handed straight back by the very next fetch, which would make walking past it impossible.
-        const heldBack: Request[] = [];
-        let heldBackUntil = Infinity;
-        let dispatchable: Request<R> | null = null;
+        for (let migrated = 0; migrated < MAX_INNER_MIGRATIONS; migrated++) {
+            const request = await inner.fetchNextRequest<R>();
 
+            if (request === null) {
+                return null;
+            }
+
+            const state = this.#getDomainState(request.url);
+
+            if (state === null || Date.now() >= throttledUntil(state)) {
+                return request;
+            }
+
+            await this.#migrateToSubQueue(request, inner);
+        }
+
+        return null;
+    }
+
+    /**
+     * Moves a request from the wrapped manager into its domain's sub-queue.
+     *
+     * Added there before it is marked handled here, so that a crash in between duplicates the request rather
+     * than dropping it, and `uniqueKey` absorbs the duplicate. A copy is what lands in the sub-queue: adding
+     * the request itself would overwrite the `id` the wrapped manager knows it by.
+     */
+    async #migrateToSubQueue(request: Request, inner: T): Promise<void> {
         try {
-            while (heldBack.length < MAX_INNER_SWEEP) {
-                const request = await inner.fetchNextRequest<R>();
-
-                if (request === null) {
-                    break;
-                }
-
-                const state = this.#getDomainState(request.url);
-                const until = state ? throttledUntil(state) : 0;
-
-                if (until > Date.now()) {
-                    state!.hasInnerBacklog = true;
-                    heldBackUntil = Math.min(heldBackUntil, until);
-                    heldBack.push(request);
-                    continue;
-                }
-
-                dispatchable = request;
-                break;
-            }
-        } finally {
-            // Backwards and to the front, so the sweep leaves the order it walked through as it found it.
-            for (const request of heldBack.reverse()) {
-                await inner.reclaimRequest(request, { forefront: true });
-            }
+            const subManager = await this.#selectManagerOrThrow(request.url);
+            await subManager.addRequest(new Request({ ...request, id: undefined }));
+        } catch (error) {
+            // Whatever the reason, the request is out of the wrapped manager and in nobody's hands, so it
+            // goes back before the failure is raised.
+            await inner.reclaimRequest(request, { forefront: true });
+            throw error;
         }
 
-        // Nothing it offered could be dispatched, so sweeping it again before the first of those domains is
-        // due would only walk the same requests. `checkReadiness()` reports `waiting` meanwhile, so the
-        // crawler idles instead of spinning through the whole queue on every poll.
-        if (dispatchable === null && heldBackUntil !== Infinity) {
-            this.#innerBlockedUntil = heldBackUntil;
-        }
-
-        return dispatchable;
+        await inner.markRequestAsHandled(request);
     }
 
     async *[Symbol.asyncIterator]() {

--- a/packages/core/src/storages/throttling_request_manager.ts
+++ b/packages/core/src/storages/throttling_request_manager.ts
@@ -201,6 +201,11 @@ interface DomainState {
      * `rateLimitedSince` to tell a domain that is still turning us away from one that is merely being waited out.
      */
     lastRateLimitedAt: number;
+    /**
+     * Whether the wrapped manager was found holding a request for this domain. Those requests are not in its
+     * sub-queue, so they are the only trace stall detection has that the domain still has work waiting.
+     */
+    hasInnerBacklog: boolean;
 }
 
 /** The moment a domain may be dispatched to again - whichever of its two independent clocks runs longer. */
@@ -223,10 +228,18 @@ function newDomainState(domain: string): DomainState {
         declaredCrawlDelayMs: null,
         rateLimitedSince: 0,
         lastRateLimitedAt: 0,
+        hasInnerBacklog: false,
     };
 }
 
 const DEFAULT_PERSIST_STATE_KEY = 'CRAWLEE_THROTTLED_DOMAINS';
+
+/**
+ * How far into the wrapped manager one sweep looks for a request that can be dispatched. Bounded because the
+ * requests it walks past are held in memory until the sweep ends, and a queue holding a million URLs of a
+ * single throttled domain would otherwise be pulled into it in full.
+ */
+const MAX_INNER_SWEEP = 1000;
 
 /**
  * A request manager that wraps another one and paces requests per domain.
@@ -305,6 +318,12 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
     #domainListStore?: KeyValueStore;
     #lastDomainListWrite: Promise<unknown> = Promise.resolve();
     #queuedDomainListWrite?: Promise<void>;
+
+    /**
+     * Until when the wrapped manager is known to hold nothing but requests for domains that are backing off,
+     * as a `Date.now()` timestamp. Sweeping it again before then would only put the same requests back.
+     */
+    #innerBlockedUntil = 0;
 
     /**
      * Sub-managers are keyed by a stable alias, so with `purgeOnStart` disabled they outlive the process. They
@@ -670,6 +689,12 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
         const stalled = (
             await Promise.all(
                 candidates.map(async (state) => {
+                    // Requests the wrapped manager holds count too: a domain whose work only lives there has an
+                    // empty sub-queue, and would otherwise be waited on forever.
+                    if (state.hasInnerBacklog) {
+                        return state;
+                    }
+
                     const subManager = await this.#subManagers.get(state.domain);
                     return subManager && !(await subManager.isEmpty()) ? state : null;
                 }),
@@ -697,6 +722,8 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
         const state = this.#getDomainState(url);
         if (state) {
             state.rateLimitedSince = 0;
+            // Both describe the episode that just ended; a later sweep sets this again if it is still true.
+            state.hasInnerBacklog = false;
         }
     }
 
@@ -706,6 +733,12 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
         this.#warnIfNotRoutable(requestLike);
 
         const manager = await this.#selectManagerOrThrow(requestLike.url ?? '');
+
+        if (manager === this.#inner) {
+            // What it holds has changed, so whatever an earlier sweep concluded about it no longer holds.
+            this.#innerBlockedUntil = 0;
+        }
+
         return manager.addRequest(requestLike, options);
     }
 
@@ -754,6 +787,10 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
                         continue;
                     }
 
+                    if (manager === this.#inner) {
+                        this.#innerBlockedUntil = 0;
+                    }
+
                     const bucket = byManager.get(manager);
                     if (bucket) {
                         bucket.push(request);
@@ -795,6 +832,11 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
         options?: RequestQueueOperationOptions,
     ): Promise<RequestQueueOperationInfo | null> {
         const manager = await this.#managerHolding(request);
+
+        if (manager === this.#inner) {
+            this.#innerBlockedUntil = 0;
+        }
+
         return manager.reclaimRequest(request, options);
     }
 
@@ -843,7 +885,10 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
         const fetchable = await Promise.all(
             this.#fetchableDomains().map(async (domain) => this.#subManagers.get(domain)!),
         );
-        const results = await Promise.all([this.#inner, ...fetchable].map(async (manager) => manager.isEmpty()));
+        // The wrapped manager counts as unavailable while everything it holds is backing off, the same way a
+        // sub-queue does - otherwise the crawler would keep polling for a request that cannot be handed out.
+        const inner = Date.now() < this.#innerBlockedUntil ? [] : [this.#inner];
+        const results = await Promise.all([...inner, ...fetchable].map(async (manager) => manager.isEmpty()));
 
         return results.every(Boolean);
     }
@@ -876,6 +921,8 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
         const subManagers = await this.#getSubManagers();
         await Promise.all(subManagers.map(async (manager) => manager.purge?.()));
 
+        this.#innerBlockedUntil = 0;
+
         for (const state of this.domainStates.values()) {
             state.consecutive429Count = 0;
             state.backoffUntil = 0;
@@ -883,6 +930,7 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
             state.backoffDecaysAt = 0;
             state.rateLimitedSince = 0;
             state.lastRateLimitedAt = 0;
+            state.hasInnerBacklog = false;
         }
     }
 
@@ -937,7 +985,7 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
             state.crawlDelayUntil = crawlDelayUntilBefore;
         }
 
-        const request = await this.#inner.fetchNextRequest<R>();
+        const request = await this.#fetchFromInner<R>();
 
         if (request !== null) {
             this.#inFlightFromInner.add(request.id ?? request.uniqueKey);
@@ -957,6 +1005,63 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
         }
 
         return request;
+    }
+
+    /**
+     * The next request the wrapped manager can offer whose domain is not being held back.
+     *
+     * Its requests are not stored per domain, so they cannot be skipped the way a sub-queue can - the only way
+     * to find out which domain one belongs to is to take it out. Any that turn out to be backing off go
+     * straight back, because handing one over would have the crawler hammer the domain that just told us to
+     * wait: a request deferred this way costs no retry, so nothing else would ever slow it down.
+     */
+    async #fetchFromInner<R extends Dictionary = Dictionary>(): Promise<Request<R> | null> {
+        if (Date.now() < this.#innerBlockedUntil) {
+            return null;
+        }
+
+        // Held for the length of the sweep rather than reclaimed one by one: a reclaimed request can be
+        // handed straight back by the very next fetch, which would make walking past it impossible.
+        const heldBack: Request[] = [];
+        let heldBackUntil = Infinity;
+        let dispatchable: Request<R> | null = null;
+
+        try {
+            while (heldBack.length < MAX_INNER_SWEEP) {
+                const request = await this.#inner.fetchNextRequest<R>();
+
+                if (request === null) {
+                    break;
+                }
+
+                const state = this.#getDomainState(request.url);
+                const until = state ? throttledUntil(state) : 0;
+
+                if (until > Date.now()) {
+                    state!.hasInnerBacklog = true;
+                    heldBackUntil = Math.min(heldBackUntil, until);
+                    heldBack.push(request);
+                    continue;
+                }
+
+                dispatchable = request;
+                break;
+            }
+        } finally {
+            // Backwards and to the front, so the sweep leaves the order it walked through as it found it.
+            for (const request of heldBack.reverse()) {
+                await this.#inner.reclaimRequest(request, { forefront: true });
+            }
+        }
+
+        // Nothing it offered could be dispatched, so sweeping it again before the first of those domains is
+        // due would only walk the same requests. `isEmpty` reports it empty meanwhile, so the crawler idles
+        // instead of spinning through the whole queue on every poll.
+        if (dispatchable === null && heldBackUntil !== Infinity) {
+            this.#innerBlockedUntil = heldBackUntil;
+        }
+
+        return dispatchable;
     }
 
     async *[Symbol.asyncIterator]() {

--- a/packages/core/src/storages/throttling_request_manager.ts
+++ b/packages/core/src/storages/throttling_request_manager.ts
@@ -311,6 +311,9 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
     /** Batches still being added in the background; keeps {@apilink ThrottlingRequestManager.checkReadiness} honest. */
     #inProgressBatchCount = 0;
 
+    /** Requests moved into a sub-queue, which both managers count. Subtracted below; not persisted. */
+    #migratedFromInner = 0;
+
     /** The latest {@link setExpectedRequestProcessingTimeSecs} hint, kept for a wrapped manager resolved later. */
     #expectedRequestProcessingSecs?: number;
 
@@ -891,7 +894,7 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
     }
 
     async getTotalCount(): Promise<number> {
-        return this.#sumOverManagers((manager) => manager.getTotalCount());
+        return (await this.#sumOverManagers((manager) => manager.getTotalCount())) - this.#migratedFromInner;
     }
 
     async getPendingCount(): Promise<number> {
@@ -899,7 +902,7 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
     }
 
     async getHandledCount(): Promise<number> {
-        return this.#sumOverManagers((manager) => manager.getHandledCount());
+        return (await this.#sumOverManagers((manager) => manager.getHandledCount())) - this.#migratedFromInner;
     }
 
     /**
@@ -1019,6 +1022,8 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
     async #purgeDomainQueues(): Promise<void> {
         const subManagers = await this.#getSubManagers();
         await Promise.all(subManagers.map(async (manager) => manager.purge?.()));
+
+        this.#migratedFromInner = 0;
 
         for (const state of this.domainStates.values()) {
             state.consecutive429Count = 0;
@@ -1162,6 +1167,7 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
         }
 
         await inner.markRequestAsHandled(request);
+        this.#migratedFromInner += 1;
     }
 
     async *[Symbol.asyncIterator]() {

--- a/test/core/crawlers/http_crawler.test.ts
+++ b/test/core/crawlers/http_crawler.test.ts
@@ -8,6 +8,7 @@ import {
     ConcurrencySystem,
     HttpCrawler,
     PersistentRateLimitError,
+    RequestList,
     RequestQueue,
     SessionPool,
     ThrottlingRequestManager,
@@ -678,6 +679,37 @@ test('a domain that never stops rate-limiting shuts the crawl down instead of ha
 
     // The request is deliberately left queued, so a later run can pick it up if the rate limit lifts.
     expect(await crawler.getRequestManager().then((manager) => manager.getPendingCount())).toBe(1);
+}, 30_000);
+
+test('a domain is paced even when its requests come from the wrapped manager', async () => {
+    let hits = 0;
+    router.set('/from-a-list', (req, res) => {
+        hits++;
+        res.statusCode = 429;
+        res.end();
+    });
+
+    // The documented way to crawl a list of URLs while still being able to enqueue new ones. Those requests
+    // live in the wrapped manager rather than in a per-domain sub-queue, and a 429 costs them no retry, so
+    // nothing but the backoff itself can hold them back.
+    const requestList = await RequestList.open(null, [`${url}/from-a-list`]);
+
+    const crawler = new HttpCrawler({
+        requestManager: new ThrottlingRequestManager({
+            inner: await requestList.toTandem(await RequestQueue.open()),
+            domains: ['127.0.0.1'],
+            baseDelaySecs: 0.5,
+            maxDelaySecs: 1,
+            maxDomainStallSecs: 1,
+        }),
+        maxRequestRetries: 0,
+        requestHandler: async () => {},
+    });
+
+    await expect(crawler.run()).rejects.toThrow(PersistentRateLimitError);
+
+    // A handful of paced attempts, rather than one per turn of the task loop for as long as the crawl lives.
+    expect(hits).toBeLessThan(10);
 }, 30_000);
 
 test('`keepAlive` outlives a domain that never stops rate-limiting', async () => {

--- a/test/core/crawlers/http_crawler.test.ts
+++ b/test/core/crawlers/http_crawler.test.ts
@@ -701,9 +701,6 @@ test('a domain is paced even when its requests come from the wrapped manager', a
         res.end();
     });
 
-    // The documented way to crawl a list of URLs while still being able to enqueue new ones. Those requests
-    // live in the wrapped manager rather than in a per-domain sub-queue, and a 429 costs them no retry, so
-    // nothing but the backoff itself can hold them back.
     const requestList = await RequestList.open(null, [`${url}/from-a-list`]);
 
     const crawler = new HttpCrawler({

--- a/test/core/storages/throttling_request_manager.test.ts
+++ b/test/core/storages/throttling_request_manager.test.ts
@@ -247,6 +247,46 @@ describe('ThrottlingRequestManager', () => {
         expect(await inner.getPendingCount()).toBe(0);
     });
 
+    test('a request the inner manager holds is paced by its domain like any other', async () => {
+        const inner = await createQueue();
+        const manager = new ThrottlingRequestManager({ inner, domains: ['example.com'], baseDelaySecs: 0.5 });
+
+        // The same bypass as above, so the request belongs to a throttled domain without being stored per domain.
+        await inner.addRequest({ url: 'https://example.com/1' });
+
+        const request = (await manager.fetchNextRequest())!;
+        expect(manager.recordDomainDelay(request.url)).toBe(true);
+        // What the crawler does with the `RequestThrottledError` a 429 raises: reclaim, no retry spent.
+        await manager.reclaimRequest(request);
+
+        // Handing it straight back would have the crawler hammer the domain that just turned it away, and
+        // nothing else would slow it down - a deferred request costs neither a retry nor session reputation.
+        expect(await manager.fetchNextRequest()).toBeNull();
+        expect(await manager.isEmpty()).toBe(true);
+        // ...while the request is still outstanding work rather than lost.
+        expect(await manager.isFinished()).toBe(false);
+
+        const start = Date.now();
+        const again = await pollForNextRequest(manager);
+
+        expect(Date.now() - start).toBeGreaterThanOrEqual(400);
+        expect(again.url).toBe('https://example.com/1');
+    });
+
+    test('a domain being held back does not stop the inner manager serving the others', async () => {
+        const inner = await createQueue();
+        const manager = new ThrottlingRequestManager({ inner, domains: ['example.com'], baseDelaySecs: 60 });
+
+        await inner.addRequest({ url: 'https://example.com/held-back' });
+        await inner.addRequest({ url: 'https://other.com/free' });
+
+        expect(manager.recordDomainDelay('https://example.com/held-back')).toBe(true);
+
+        // The throttled one is at the head of the queue, and skipping it must not mean skipping the queue.
+        const request = await manager.fetchNextRequest();
+        expect(request!.url).toBe('https://other.com/free');
+    });
+
     test('recordDomainDelay enforces throttling and fair scheduling', async () => {
         const inner = await createQueue();
         const manager = new ThrottlingRequestManager({
@@ -421,6 +461,24 @@ describe('ThrottlingRequestManager', () => {
             await manager.markRequestAsHandled((await pollForNextRequest(manager))!);
 
             await expect(manager.assertNoStalledDomains()).resolves.toBeUndefined();
+        });
+
+        test('work the inner manager holds keeps a stalling domain in view', async () => {
+            const manager = await stallingManager();
+            const inner = manager.innerManager;
+
+            // Its sub-queue stays empty, so this request is the only sign the domain still has work left.
+            await inner.addRequest({ url: 'https://example.com/1' });
+
+            const request = (await manager.fetchNextRequest())!;
+            manager.recordDomainDelay(request.url);
+            await manager.reclaimRequest(request);
+            stallFor(manager, 'example.com');
+
+            // Sweeping it is what finds the request; without it the crawl would wait on the domain forever.
+            await manager.fetchNextRequest();
+
+            await expect(manager.assertNoStalledDomains()).rejects.toThrow(PersistentRateLimitError);
         });
 
         test('a domain that has run out of work is finished, not stalled', async () => {

--- a/test/core/storages/throttling_request_manager.test.ts
+++ b/test/core/storages/throttling_request_manager.test.ts
@@ -288,6 +288,61 @@ describe('ThrottlingRequestManager', () => {
         expect(request!.url).toBe('https://other.com/free');
     });
 
+    test('the backlog a throttled domain has in the inner manager is moved out of it, not walked again', async () => {
+        const inner = await createQueue();
+        const manager = new ThrottlingRequestManager({ inner, domains: ['example.com'], baseDelaySecs: 60 });
+
+        // The same bypass as above, at the size that makes the cost visible.
+        for (let i = 0; i < 20; i++) {
+            await inner.addRequest({ url: `https://example.com/${i}` });
+        }
+        await inner.addRequest({ url: 'https://other.com/free' });
+
+        manager.recordPacingSignal({ url: 'https://example.com/0', reason: 'rateLimited' });
+
+        const fetchedFromInner = vitest.spyOn(inner, 'fetchNextRequest');
+        const reclaimedToInner = vitest.spyOn(inner, 'reclaimRequest');
+
+        expect((await manager.fetchNextRequest())!.url).toBe('https://other.com/free');
+
+        expect(fetchedFromInner).toHaveBeenCalledTimes(21);
+        expect(reclaimedToInner).not.toHaveBeenCalled();
+        // Nothing lost on the way: the backlog waits in the sub-queue, the dispatched one is still outstanding.
+        expect(await manager.getPendingCount()).toBe(21);
+
+        fetchedFromInner.mockClear();
+        await manager.addRequest({ url: 'https://other.com/behind-it' });
+
+        // The point of moving it: enqueuing no longer re-arms a walk over the backlog, which on a queue whose
+        // every read is a round trip is the whole cost.
+        expect((await manager.fetchNextRequest())!.url).toBe('https://other.com/behind-it');
+        expect(fetchedFromInner).toHaveBeenCalledTimes(1);
+    });
+
+    test('a request whose migration fails goes back to the inner manager instead of being stranded', async () => {
+        const inner = await createQueue();
+        const manager = new ThrottlingRequestManager({
+            inner,
+            domains: ['example.com'],
+            baseDelaySecs: 60,
+            requestManagerOpener: async (identifier, options) => {
+                const queue = await RequestQueue.open(identifier, options);
+                queue.addRequest = async () => {
+                    throw new Error('sub-queue unavailable');
+                };
+                return queue;
+            },
+        });
+
+        await inner.addRequest({ url: 'https://example.com/held-back' });
+        manager.recordPacingSignal({ url: 'https://example.com/held-back', reason: 'rateLimited' });
+
+        await expect(manager.fetchNextRequest()).rejects.toThrow('sub-queue unavailable');
+
+        // Left in progress in a manager nobody will hand it back to, it would be lost for the rest of the run.
+        expect((await inner.fetchNextRequest())!.url).toBe('https://example.com/held-back');
+    });
+
     describe('a lazily-opened inner manager', () => {
         const throttling = { domains: ['example.com'] } satisfies Omit<
             ThrottlingRequestManagerOptions<RequestQueue>,

--- a/test/core/storages/throttling_request_manager.test.ts
+++ b/test/core/storages/throttling_request_manager.test.ts
@@ -307,8 +307,11 @@ describe('ThrottlingRequestManager', () => {
 
         expect(fetchedFromInner).toHaveBeenCalledTimes(21);
         expect(reclaimedToInner).not.toHaveBeenCalled();
-        // Nothing lost on the way: the backlog waits in the sub-queue, the dispatched one is still outstanding.
+        // Nothing lost on the way, and nothing counted twice: moving a request marks it handled where it came
+        // from, so both managers hold a record of it.
         expect(await manager.getPendingCount()).toBe(21);
+        expect(await manager.getTotalCount()).toBe(21);
+        expect(await manager.getHandledCount()).toBe(0);
 
         fetchedFromInner.mockClear();
         await manager.addRequest({ url: 'https://other.com/behind-it' });

--- a/test/core/storages/throttling_request_manager.test.ts
+++ b/test/core/storages/throttling_request_manager.test.ts
@@ -278,9 +278,12 @@ describe('ThrottlingRequestManager', () => {
         await inner.addRequest({ url: 'https://example.com/held-back' });
         await inner.addRequest({ url: 'https://other.com/free' });
 
-        expect(manager.recordPacingSignal({ url: 'https://example.com/held-back', reason: 'rateLimited' })).toBe(true);
+        const held = (await manager.fetchNextRequest())!;
+        expect(held.url).toBe('https://example.com/held-back');
+        manager.recordPacingSignal({ url: held.url, reason: 'rateLimited' });
+        await manager.reclaimRequest(held);
 
-        // The throttled one is at the head of the queue, and skipping it must not mean skipping the queue.
+        // The reclaimed request is still ahead of the other one, and skipping it must not mean skipping the queue.
         const request = await manager.fetchNextRequest();
         expect(request!.url).toBe('https://other.com/free');
     });


### PR DESCRIPTION
`ThrottlingRequestManager` checks its backoff clocks while walking its per-domain sub-queues, and then takes whatever the wrapped manager offers without looking at it. Requests that were never routed by domain therefore ignore the backoff their own 429s set.

They get there through documented use. `requestManager` cannot be combined with `requestList`, so the way to crawl a list of URLs while still enqueuing new ones is `requestList.toTandem(queue)`, and the result goes in as `inner`. Sitemap loaders and `requestsFromUrl` end up in the same place. The `innerNotThrottled` warning already describes these requests, but it only fires under `domains: 'all'`, and it reads as "they will not be paced" rather than what actually happens.

Nothing else slows them down. A 429 raises `RequestThrottledError`, which is deliberately free of retries and session reputation, so the crawler reclaims the request and has it back in the same turn of the task loop. `assertNoStalledDomains()` cannot end the crawl either, because it looks for a non-empty sub-queue and the domain's is empty the whole time.

Against a server answering 429 to everything, with `maxDomainStallSecs: 1`:

| | before | after |
|---|---|---|
| requests in 4s | 649 | 2 |
| outcome | runs forever | `PersistentRateLimitError` |
| `requestsTotal` | 0 | 1 |

The backoff is calculated and logged correctly throughout. Nothing reads it.

## The fix

A sweep of the wrapped manager walks past requests whose domain is being held back and hands over the first one that can be dispatched, so a domain queued behind a throttled one is still served.

Held-back requests are kept out of the manager for the length of the sweep instead of being reclaimed one at a time: a reclaimed request is handed straight back by the next `fetchNextRequest()`, so there is no walking past it. They go back in the order they were found, and the sweep is bounded by `MAX_INNER_SWEEP` so a queue holding a million URLs of one throttled domain is not pulled into memory.

When a sweep finds nothing dispatchable, the manager leaves the wrapped one alone until the earliest of those domains is due and reports itself empty meanwhile, so the crawler idles rather than walking the queue on every poll. Stall detection counts requests the wrapped manager holds, so a domain that never lets one through ends the crawl the way it already does for routed requests.

Four tests, all of which fail on `v4` as it stands - the crawler one by timing out, since the crawl never ends.

Closes #4039.
