### PR TITLE
feat: replace idcac-playwright with @duckduckgo/autoconsent

### DIFF
--- a/docs/public-api/crawlee-browser.api.md
+++ b/docs/public-api/crawlee-browser.api.md
@@ -12,6 +12,7 @@ import type { BrowserPluginOptions } from '@crawlee/browser-pool';
 import type { BrowserPoolHooks } from '@crawlee/browser-pool';
 import type { BrowserPoolOptions } from '@crawlee/browser-pool';
 import type { CommonPage } from '@crawlee/browser-pool';
+import type { Config } from '@duckduckgo/autoconsent';
 import { ContextPipeline } from '@crawlee/basic';
 import type { CrawlerRemoteBrowserOptions } from '@crawlee/browser-pool';
 import type { CrawlingContext } from '@crawlee/basic';
@@ -101,6 +102,11 @@ export interface BrowserLaunchContext<TOptions, Launcher> extends BrowserPluginO
     useIncognitoPages?: boolean;
     userAgent?: string;
     userDataDir?: string;
+}
+
+// @public
+export interface CloseCookieModalsOptions extends Partial<Omit<Config, 'enabled' | 'isMainWorld'>> {
+    timeoutMillis?: number;
 }
 
 // @public

--- a/docs/public-api/crawlee-playwright.api.md
+++ b/docs/public-api/crawlee-playwright.api.md
@@ -21,6 +21,7 @@ import type { BrowserPoolOptions } from '@crawlee/browser-pool';
 import type { BrowserType } from 'playwright';
 import { Cheerio } from 'cheerio';
 import { CheerioAPI } from 'cheerio';
+import { CloseCookieModalsOptions } from '@crawlee/browser';
 import { Configuration } from '@crawlee/browser';
 import type { ContextPipeline } from '@crawlee/browser';
 import type { ContextPipeline as ContextPipeline_2 } from '@crawlee/core';
@@ -147,7 +148,7 @@ interface BlockRequestsOptions {
 type ClickOptions = Parameters<Page['click']>[1];
 
 // @public (undocumented)
-function closeCookieModals(page: Page): Promise<void>;
+function closeCookieModals(page: Page, options?: CloseCookieModalsOptions): Promise<void>;
 
 // @public (undocumented)
 type CompiledScriptFunction = (params: CompiledScriptParams) => Promise<unknown>;
@@ -296,7 +297,7 @@ declare namespace playwrightClickElements {
 // @public (undocumented)
 interface PlaywrightContextUtils {
     blockRequests(options?: BlockRequestsOptions): Promise<void>;
-    closeCookieModals(): Promise<void>;
+    closeCookieModals(options?: CloseCookieModalsOptions): Promise<void>;
     compileScript(scriptString: string, ctx?: Dictionary): CompiledScriptFunction;
     enqueueLinksByClickingElements(options: Omit<EnqueueLinksByClickingElementsOptions, 'page' | 'requestManager'>): Promise<BatchAddRequestsResult>;
     handleCloudflareChallenge(options?: HandleCloudflareChallengeOptions): Promise<Response_2 | undefined>;
@@ -374,6 +375,7 @@ declare namespace playwrightUtils {
         SaveSnapshotOptions,
         HandleCloudflareChallengeOptions,
         PlaywrightContextUtils,
+        CloseCookieModalsOptions,
         enqueueLinksByClickingElements,
         playwrightUtils_2 as playwrightUtils
     }

--- a/docs/public-api/crawlee-puppeteer.api.md
+++ b/docs/public-api/crawlee-puppeteer.api.md
@@ -16,6 +16,7 @@ import type { BrowserPoolHooks } from '@crawlee/browser-pool';
 import type { BrowserPoolOptions } from '@crawlee/browser-pool';
 import type { CheerioAPI } from 'cheerio';
 import type { ClickOptions } from 'puppeteer';
+import type { CloseCookieModalsOptions } from '@crawlee/browser';
 import { Configuration } from '@crawlee/browser';
 import type { ContextPipeline } from '@crawlee/browser';
 import type { CrawlingContext } from '@crawlee/browser';
@@ -59,7 +60,7 @@ const blockResources: (page: Page, resourceTypes?: string[]) => Promise<void>;
 function cacheResponses(page: Page, cache: Dictionary<Partial<ResponseForRequest>>, responseUrlRules: (string | RegExp)[]): Promise<void>;
 
 // @public (undocumented)
-function closeCookieModals(page: Page): Promise<void>;
+function closeCookieModals(page: Page, options?: CloseCookieModalsOptions): Promise<void>;
 
 // @public (undocumented)
 export type CompiledScriptFunction = (params: CompiledScriptParams) => Promise<unknown>;
@@ -175,7 +176,7 @@ declare namespace puppeteerClickElements {
 interface PuppeteerContextUtils {
     addInterceptRequestHandler(handler: InterceptHandler): Promise<void>;
     blockRequests(options?: BlockRequestsOptions): Promise<void>;
-    closeCookieModals(): Promise<void>;
+    closeCookieModals(options?: CloseCookieModalsOptions): Promise<void>;
     compileScript(scriptString: string, ctx?: Dictionary): CompiledScriptFunction;
     enqueueLinksByClickingElements(options: Omit<EnqueueLinksByClickingElementsOptions, 'page' | 'requestManager'>): Promise<BatchAddRequestsResult>;
     infiniteScroll(options?: InfiniteScrollOptions): Promise<void>;
@@ -260,6 +261,7 @@ declare namespace puppeteerUtils {
         InfiniteScrollOptions,
         SaveSnapshotOptions,
         PuppeteerContextUtils,
+        CloseCookieModalsOptions,
         enqueueLinksByClickingElements,
         addInterceptRequestHandler,
         removeInterceptRequestHandler,

--- a/packages/browser-crawler/package.json
+++ b/packages/browser-crawler/package.json
@@ -52,6 +52,7 @@
         "@crawlee/browser-pool": "workspace:*",
         "@crawlee/types": "workspace:*",
         "@crawlee/utils": "workspace:*",
+        "@duckduckgo/autoconsent": "^16.22.0",
         "tslib": "^2.8.1",
         "type-fest": "^4.41.0",
         "zod": "catalog:"

--- a/packages/browser-crawler/src/index.ts
+++ b/packages/browser-crawler/src/index.ts
@@ -1,3 +1,4 @@
 export * from '@crawlee/basic';
 export * from './internals/browser-crawler.js';
 export * from './internals/browser-launcher.js';
+export * from './internals/cookie-consent.js';

--- a/packages/browser-crawler/src/internals/cookie-consent.ts
+++ b/packages/browser-crawler/src/internals/cookie-consent.ts
@@ -1,0 +1,135 @@
+import { readFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+
+import { serviceLocator } from '@crawlee/basic';
+import type { Config, ContentScriptMessage, IndexedCMPRuleset, RuleBundle } from '@duckduckgo/autoconsent';
+
+// `require.resolve` picks the CommonJS bundle, which - unlike the ESM one - can be injected into a page as is.
+const require = createRequire(import.meta.url);
+
+/**
+ * The [autoconsent configuration](https://github.com/duckduckgo/autoconsent/blob/main/docs/api.md), passed
+ * through as is. `enabled` and `isMainWorld` are managed by Crawlee and are therefore not accepted.
+ */
+export interface CloseCookieModalsOptions extends Partial<Omit<Config, 'enabled' | 'isMainWorld'>> {
+    /**
+     * How long to wait for the consent flow to finish, in milliseconds. On pages without a cookie modal,
+     * the detection keeps retrying until this timeout is reached.
+     * @default 10_000
+     */
+    timeoutMillis?: number;
+}
+
+/**
+ * The subset of the Playwright and Puppeteer `Frame` APIs needed to run autoconsent.
+ * @internal
+ */
+export interface EvaluableFrame {
+    url(): string;
+    evaluate(pageFunction: any, arg?: any): Promise<any>;
+}
+
+/**
+ * The subset of the Playwright and Puppeteer `Page` APIs needed to run autoconsent.
+ * @internal
+ */
+export interface EvaluablePage extends EvaluableFrame {
+    frames(): EvaluableFrame[];
+    mainFrame(): EvaluableFrame;
+}
+
+let injectableScript: string | undefined;
+let compactRules: IndexedCMPRuleset | undefined;
+let fullRules: RuleBundle['autoconsent'] | undefined;
+
+async function getInjectableScript() {
+    injectableScript ??= `(() => {
+        const module = { exports: {} };
+        const exports = module.exports;
+        ${await readFile(require.resolve('@duckduckgo/autoconsent'), 'utf8')}
+        globalThis.crawleeAutoconsent = module.exports;
+    })()`;
+
+    return injectableScript;
+}
+
+async function getCompactRules() {
+    compactRules ??= JSON.parse(
+        await readFile(require.resolve('@duckduckgo/autoconsent/rules/compact-rules.json'), 'utf8'),
+    ) as IndexedCMPRuleset;
+
+    return compactRules;
+}
+
+/** The compact ruleset omits the opt-in steps, so opting in needs the (much larger) full ruleset. */
+async function getFullRules() {
+    fullRules ??= (
+        JSON.parse(await readFile(require.resolve('@duckduckgo/autoconsent/rules/rules.json'), 'utf8')) as RuleBundle
+    ).autoconsent;
+
+    return fullRules;
+}
+
+/**
+ * Runs the autoconsent content script in the given frame and waits until it handles a consent popup,
+ * reports that there is none, or times out.
+ */
+async function closeCookieModalsInFrame(
+    frame: EvaluableFrame,
+    mainFrame: boolean,
+    timeoutMillis: number,
+    config: Partial<Config>,
+) {
+    const { filterCompactRules } = await import('@duckduckgo/autoconsent');
+
+    const rules: RuleBundle =
+        config.autoAction === 'optIn'
+            ? { autoconsent: await getFullRules() }
+            : {
+                  autoconsent: [],
+                  compact: filterCompactRules(await getCompactRules(), { url: frame.url(), mainFrame }),
+              };
+
+    await frame.evaluate(await getInjectableScript());
+    await frame.evaluate(
+        async ({ rules, timeoutMillis, config }: any) => {
+            const AutoConsent = (globalThis as any).crawleeAutoconsent.default;
+
+            await new Promise<void>((resolve) => {
+                const timeout = setTimeout(resolve, timeoutMillis);
+                const finish = () => {
+                    clearTimeout(timeout);
+                    resolve();
+                };
+
+                const consent = new AutoConsent((message: ContentScriptMessage) => {
+                    if (message.type === 'autoconsentDone') finish();
+                    if (message.type === 'report' && message.state.lifecycle === 'nothingDetected') finish();
+                });
+
+                // We drive autoconsent from the page itself, so it has to evaluate its snippets there too.
+                consent.initialize({ ...config, isMainWorld: true }, rules);
+            });
+        },
+        { rules, timeoutMillis, config },
+    );
+}
+
+/**
+ * Tries to close cookie consent modals on the page using [autoconsent](https://github.com/duckduckgo/autoconsent).
+ * @internal
+ */
+export async function closeCookieModals(page: EvaluablePage, options: CloseCookieModalsOptions = {}): Promise<void> {
+    const { timeoutMillis = 10_000, ...config } = options;
+    const mainFrame = page.mainFrame();
+
+    // Some consent popups (e.g. Sourcepoint) live in an iframe and can only be handled from inside it.
+    await Promise.all(
+        page.frames().map(async (frame) => {
+            // Frames that navigate or detach mid-flight reject the evaluation, there is nothing to act on.
+            await closeCookieModalsInFrame(frame, frame === mainFrame, timeoutMillis, config).catch((error) =>
+                serviceLocator.getChildLog('Cookie Consent').debug('Failed to handle cookie modals', { error }),
+            );
+        }),
+    );
+}

--- a/packages/crawlee/package.json
+++ b/packages/crawlee/package.json
@@ -66,14 +66,10 @@
         "tslib": "^2.8.1"
     },
     "peerDependencies": {
-        "idcac-playwright": "*",
         "playwright": "*",
         "puppeteer": "*"
     },
     "peerDependenciesMeta": {
-        "idcac-playwright": {
-            "optional": true
-        },
         "playwright": {
             "optional": true
         },

--- a/packages/playwright-crawler/package.json
+++ b/packages/playwright-crawler/package.json
@@ -66,13 +66,9 @@
         "zod": "catalog:"
     },
     "peerDependencies": {
-        "idcac-playwright": "^0.2.0",
         "playwright": "*"
     },
     "peerDependenciesMeta": {
-        "idcac-playwright": {
-            "optional": true
-        },
         "playwright": {
             "optional": true
         }

--- a/packages/playwright-crawler/src/internals/playwright-crawler.ts
+++ b/packages/playwright-crawler/src/internals/playwright-crawler.ts
@@ -22,6 +22,7 @@ import { playwrightBrowserPool, remotePlaywrightBrowserPool } from './playwright
 import type { PlaywrightLaunchContext } from './playwright-launcher.js';
 import type {
     BlockRequestsOptions,
+    CloseCookieModalsOptions,
     DirectNavigationOptions,
     HandleCloudflareChallengeOptions,
     InfiniteScrollOptions,
@@ -334,7 +335,8 @@ export class PlaywrightCrawler<
                     requestManager: this.requestManager!,
                 }),
             compileScript: (scriptString: string, ctx?: Dictionary) => playwrightUtils.compileScript(scriptString, ctx),
-            closeCookieModals: async () => playwrightUtils.closeCookieModals(context.page),
+            closeCookieModals: async (options?: CloseCookieModalsOptions) =>
+                playwrightUtils.closeCookieModals(context.page, options),
             handleCloudflareChallenge: async (options?: HandleCloudflareChallengeOptions) => {
                 return playwrightUtils.handleCloudflareChallenge(context.page, context.request.url, options);
             },

--- a/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
+++ b/packages/playwright-crawler/src/internals/utils/playwright-utils.ts
@@ -22,7 +22,16 @@ import { readFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import vm from 'node:vm';
 
-import { Configuration, KeyValueStore, type Request, serviceLocator, SessionError, validators } from '@crawlee/browser';
+import {
+    closeCookieModals as closeCookieModalsHelper,
+    type CloseCookieModalsOptions,
+    Configuration,
+    KeyValueStore,
+    type Request,
+    serviceLocator,
+    SessionError,
+    validators,
+} from '@crawlee/browser';
 import type { BatchAddRequestsResult, Dictionary } from '@crawlee/types';
 import type { CheerioAPI } from 'cheerio';
 import { expandShadowRoots, sleep } from '@crawlee/utils';
@@ -632,35 +641,10 @@ export async function parseWithCheerio(
     return $;
 }
 
-let idcacPlaywright: null | { getInjectableScript: () => string } = null;
-async function getIdcacPlaywright() {
-    if (idcacPlaywright) return idcacPlaywright;
-
-    try {
-        idcacPlaywright = await import('idcac-playwright');
-    } catch (error: any) {
-        getLog().warning(`Failed to import 'idcac-playwright'.
-
-We recently made idcac-playwright an optional dependency due to licensing issues.
-To use this feature, please install it manually by running
-
-npm install idcac-playwright
-
-Original error message follows:
-
-${error.message}
-`);
-    }
-    return idcacPlaywright;
-}
-
-export async function closeCookieModals(page: Page): Promise<void> {
+export async function closeCookieModals(page: Page, options: CloseCookieModalsOptions = {}): Promise<void> {
     parseArgument(page, validators.browserPage);
-    const idcac = await getIdcacPlaywright();
 
-    if (idcac?.getInjectableScript()) {
-        await page.evaluate(idcac.getInjectableScript());
-    }
+    await closeCookieModalsHelper(page, options);
 }
 
 export interface HandleCloudflareChallengeOptions {
@@ -1007,18 +991,10 @@ export interface PlaywrightContextUtils {
     compileScript(scriptString: string, ctx?: Dictionary): CompiledScriptFunction;
 
     /**
-     * Tries to close cookie consent modals on the page. Based on the I Don't Care About Cookies browser extension.
-     *
-     * Note that this method requires the idcac-playwright package to be installed.
-     * Crawlee does not include it by default due to licensing issues.
-     *
-     * To use this method, please install the package manually by running:
-     *
-     * ```bash
-     * npm install idcac-playwright
-     * ```
+     * Tries to close cookie consent modals on the page, using the
+     * [autoconsent](https://github.com/duckduckgo/autoconsent) rules. Opts out of the consent by default.
      */
-    closeCookieModals(): Promise<void>;
+    closeCookieModals(options?: CloseCookieModalsOptions): Promise<void>;
 
     /**
      * This helper tries to solve the Cloudflare challenge automatically by clicking on the checkbox.
@@ -1066,6 +1042,8 @@ export interface PlaywrightContextUtils {
      */
     listDownloads(): Promise<Download[]>;
 }
+
+export type { CloseCookieModalsOptions };
 
 export { enqueueLinksByClickingElements };
 

--- a/packages/puppeteer-crawler/package.json
+++ b/packages/puppeteer-crawler/package.json
@@ -60,13 +60,9 @@
         "zod": "catalog:"
     },
     "peerDependencies": {
-        "idcac-playwright": "^0.2.0",
         "puppeteer": "*"
     },
     "peerDependenciesMeta": {
-        "idcac-playwright": {
-            "optional": true
-        },
         "puppeteer": {
             "optional": true
         }

--- a/packages/puppeteer-crawler/src/internals/puppeteer-crawler.ts
+++ b/packages/puppeteer-crawler/src/internals/puppeteer-crawler.ts
@@ -24,6 +24,7 @@ import type { PuppeteerLaunchContext } from './puppeteer-launcher.js';
 import type { InterceptHandler } from './utils/puppeteer_request_interception.js';
 import type {
     BlockRequestsOptions,
+    CloseCookieModalsOptions,
     DirectNavigationOptions,
     InfiniteScrollOptions,
     InjectFileOptions,
@@ -314,7 +315,8 @@ export class PuppeteerCrawler<
                     ...options,
                     configuration: serviceLocator.getConfiguration(),
                 }),
-            closeCookieModals: async () => puppeteerUtils.closeCookieModals(context.page),
+            closeCookieModals: async (options?: CloseCookieModalsOptions) =>
+                puppeteerUtils.closeCookieModals(context.page, options),
         };
     }
 

--- a/packages/puppeteer-crawler/src/internals/utils/puppeteer_utils.ts
+++ b/packages/puppeteer-crawler/src/internals/utils/puppeteer_utils.ts
@@ -22,8 +22,14 @@ import { readFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import vm from 'node:vm';
 
-import type { Request } from '@crawlee/browser';
-import { Configuration, KeyValueStore, serviceLocator, validators } from '@crawlee/browser';
+import type { CloseCookieModalsOptions, Request } from '@crawlee/browser';
+import {
+    closeCookieModals as closeCookieModalsHelper,
+    Configuration,
+    KeyValueStore,
+    serviceLocator,
+    validators,
+} from '@crawlee/browser';
 import type { BatchAddRequestsResult, Dictionary } from '@crawlee/types';
 import type { CheerioAPI } from 'cheerio';
 import { expandShadowRoots, sleep } from '@crawlee/utils';
@@ -778,35 +784,10 @@ export async function saveSnapshot(page: Page, options: SaveSnapshotOptions = {}
     }
 }
 
-let idcacPlaywright: null | { getInjectableScript: () => string } = null;
-async function getIdcacPlaywright() {
-    if (idcacPlaywright) return idcacPlaywright;
-
-    try {
-        idcacPlaywright = await import('idcac-playwright');
-    } catch (error: any) {
-        getLog().warning(`Failed to import 'idcac-playwright'.
-
-We recently made idcac-playwright an optional dependency due to licensing issues.
-To use this feature, please install it manually by running
-
-npm install idcac-playwright
-
-Original error message follows:
-
-${error.message}
-`);
-    }
-    return idcacPlaywright;
-}
-
-export async function closeCookieModals(page: Page): Promise<void> {
+export async function closeCookieModals(page: Page, options: CloseCookieModalsOptions = {}): Promise<void> {
     parseArgument(page, validators.browserPage);
-    const idcac = await getIdcacPlaywright();
 
-    if (idcac?.getInjectableScript()) {
-        await page.evaluate(idcac.getInjectableScript());
-    }
+    await closeCookieModalsHelper(page, options);
 }
 
 export interface PuppeteerContextUtils {
@@ -1055,19 +1036,13 @@ export interface PuppeteerContextUtils {
     saveSnapshot(options?: SaveSnapshotOptions): Promise<void>;
 
     /**
-     * Tries to close cookie consent modals on the page. Based on the I Don't Care About Cookies browser extension.
-     *
-     * Note that this method requires the idcac-playwright package to be installed.
-     * Crawlee does not include it by default due to licensing issues.
-     *
-     * To use this method, please install the package manually by running:
-     *
-     * ```bash
-     * npm install idcac-playwright
-     * ```
+     * Tries to close cookie consent modals on the page, using the
+     * [autoconsent](https://github.com/duckduckgo/autoconsent) rules. Opts out of the consent by default.
      */
-    closeCookieModals(): Promise<void>;
+    closeCookieModals(options?: CloseCookieModalsOptions): Promise<void>;
 }
+
+export type { CloseCookieModalsOptions };
 
 export { enqueueLinksByClickingElements, addInterceptRequestHandler, removeInterceptRequestHandler };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -571,6 +571,9 @@ importers:
       '@crawlee/utils':
         specifier: workspace:*
         version: link:../utils
+      '@duckduckgo/autoconsent':
+        specifier: ^16.22.0
+        version: 16.25.0
       playwright:
         specifier: '*'
         version: 1.61.1
@@ -793,9 +796,6 @@ importers:
       '@crawlee/utils':
         specifier: workspace:*
         version: link:../utils
-      idcac-playwright:
-        specifier: '*'
-        version: 0.2.0
       import-local:
         specifier: ^3.2.0
         version: 3.2.0
@@ -1000,9 +1000,6 @@ importers:
       cheerio:
         specifier: ^1.0.0
         version: 1.2.0
-      idcac-playwright:
-        specifier: ^0.2.0
-        version: 0.2.0
       jquery:
         specifier: ^3.7.1
         version: 3.7.1
@@ -1054,9 +1051,6 @@ importers:
       devtools-protocol:
         specifier: '*'
         version: 0.0.1666840
-      idcac-playwright:
-        specifier: ^0.2.0
-        version: 0.2.0
       jquery:
         specifier: ^3.7.1
         version: 3.7.1
@@ -2852,6 +2846,9 @@ packages:
   '@docusaurus/utils@3.10.2':
     resolution: {integrity: sha512-xx0W3eav2uW1NRIpuHJWNwLTC15xPNjU4Uxi9NSnd3swYC96BE3vFiT93SD8s24kmAAWNwgZwfZ2fghGZ01Lcw==}
     engines: {node: '>=20.0'}
+
+  '@duckduckgo/autoconsent@16.25.0':
+    resolution: {integrity: sha512-nKell5fyadl5xXCUofZ2Tc7/W+AugY8U6cIm9DXQW3K7OyoB5yIv21b0GakhxpxWQHLfztRB7cRTTo+K4Mk6gQ==}
 
   '@emnapi/core@1.11.3':
     resolution: {integrity: sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==}
@@ -8367,9 +8364,6 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
-  idcac-playwright@0.2.0:
-    resolution: {integrity: sha512-qJH7vQgq3TKnhea/3Z3jlEJL7NC9vK9BkLClAzQHVRepBtq1fWfSI4fSuMKcPq7nDUTTlIEIS+vU+GRwwR1BXw==}
-
   identifier-regex@1.0.1:
     resolution: {integrity: sha512-ZrYyM0sozNPZlvBvE7Oq9Bn44n0qKGrYu5sQ0JzMUnjIhpgWYE2JB6aBoFwEYdPjqj7jPyxXTMJiHDOxDfd8yw==}
     engines: {node: '>=18'}
@@ -12236,6 +12230,12 @@ packages:
   tldts-core@7.0.28:
     resolution: {integrity: sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==}
 
+  tldts-core@7.4.10:
+    resolution: {integrity: sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==}
+
+  tldts-experimental@7.4.10:
+    resolution: {integrity: sha512-l+FUGTqw3cYLnM6uL45IhdIG1ue9N7ZnMe9ZFC0S3/ROTL6xkJrUFQvsjfqSD9YzywDvgWj9uRZTXib3v3bnHw==}
+
   tldts@6.1.86:
     resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
     hasBin: true
@@ -15696,6 +15696,10 @@ snapshots:
       - supports-color
       - uglify-js
       - webpack-cli
+
+  '@duckduckgo/autoconsent@16.25.0':
+    dependencies:
+      tldts-experimental: 7.4.10
 
   '@emnapi/core@1.11.3':
     dependencies:
@@ -22074,8 +22078,6 @@ snapshots:
     dependencies:
       postcss: 8.5.26
 
-  idcac-playwright@0.2.0: {}
-
   identifier-regex@1.0.1:
     dependencies:
       reserved-identifiers: 1.2.0
@@ -26928,6 +26930,12 @@ snapshots:
   tldts-core@6.1.86: {}
 
   tldts-core@7.0.28: {}
+
+  tldts-core@7.4.10: {}
+
+  tldts-experimental@7.4.10:
+    dependencies:
+      tldts-core: 7.4.10
 
   tldts@6.1.86:
     dependencies:

--- a/test/core/playwright_utils.test.ts
+++ b/test/core/playwright_utils.test.ts
@@ -332,6 +332,41 @@ describe('playwrightUtils', () => {
         });
     });
 
+    describe('closeCookieModals()', () => {
+        let browser: Browser;
+        beforeAll(async () => {
+            browser = await launchPlaywright(launchContext);
+        });
+        afterAll(async () => {
+            await browser.close();
+        });
+
+        test('opts out of the cookie consent', async () => {
+            const page = await browser.newPage();
+            await page.goto(`${serverAddress}/special/cookie-modal`);
+            await playwrightUtils.closeCookieModals(page);
+
+            expect(await page.locator('._brlbs-bar-wrap').count()).toBe(0);
+            expect(await page.evaluate(() => (window as any).consentChoice)).toBe('essential');
+        }, 60_000);
+
+        test('opts in when asked to', async () => {
+            const page = await browser.newPage();
+            await page.goto(`${serverAddress}/special/cookie-modal`);
+            await playwrightUtils.closeCookieModals(page, { autoAction: 'optIn' });
+
+            expect(await page.evaluate(() => (window as any).consentChoice)).toBe('all');
+        }, 60_000);
+
+        test('gives up on pages without a cookie modal', async () => {
+            const page = await browser.newPage();
+            await page.goto(serverAddress);
+            await playwrightUtils.closeCookieModals(page, { timeoutMillis: 2_000 });
+
+            expect(await page.evaluate(() => (window as any).consentChoice)).toBeUndefined();
+        }, 60_000);
+    });
+
     describe('infiniteScroll()', () => {
         function isAtBottom() {
             return window.innerHeight + window.pageYOffset >= document.body.offsetHeight;

--- a/test/core/puppeteer_utils.test.ts
+++ b/test/core/puppeteer_utils.test.ts
@@ -228,6 +228,33 @@ describe('puppeteerUtils', () => {
             });
         });
 
+        describe('closeCookieModals()', () => {
+            let browser: Browser;
+            beforeAll(async () => {
+                browser = await launchPuppeteer(launchContext);
+            });
+            afterAll(async () => {
+                await browser.close();
+            });
+
+            test('opts out of the cookie consent', async () => {
+                const page = await browser.newPage();
+                await page.goto(`${serverAddress}/special/cookie-modal`);
+                await puppeteerUtils.closeCookieModals(page);
+
+                expect(await page.$('._brlbs-bar-wrap')).toBeNull();
+                expect(await page.evaluate(() => (window as any).consentChoice)).toBe('essential');
+            }, 60_000);
+
+            test('opts in when asked to', async () => {
+                const page = await browser.newPage();
+                await page.goto(`${serverAddress}/special/cookie-modal`);
+                await puppeteerUtils.closeCookieModals(page, { autoAction: 'optIn' });
+
+                expect(await page.evaluate(() => (window as any).consentChoice)).toBe('all');
+            }, 60_000);
+        });
+
         describe('blockRequests()', () => {
             let browser: Browser = null as any;
             beforeAll(async () => {

--- a/test/e2e/playwright-enqueue-links/actor/package.json
+++ b/test/e2e/playwright-enqueue-links/actor/package.json
@@ -11,7 +11,6 @@
         "@crawlee/playwright": "file:./packages/playwright-crawler",
         "@crawlee/types": "file:./packages/types",
         "@crawlee/utils": "file:./packages/utils",
-        "idcac-playwright": "^0.2.0",
         "playwright": "1.58.2"
     },
     "overrides": {

--- a/test/e2e/puppeteer-enqueue-links/actor/package.json
+++ b/test/e2e/puppeteer-enqueue-links/actor/package.json
@@ -11,7 +11,6 @@
         "@crawlee/puppeteer": "file:./packages/puppeteer-crawler",
         "@crawlee/types": "file:./packages/types",
         "@crawlee/utils": "file:./packages/utils",
-        "idcac-playwright": "^0.2.0",
         "puppeteer": "*"
     },
     "overrides": {

--- a/test/shared/_helper.ts
+++ b/test/shared/_helper.ts
@@ -196,6 +196,20 @@ console.log('Hello world!');
             <p>Some content from inside of an iframe.</p>
         </body>
     </html>`,
+    // Markup of a cookie consent modal matching the "borlabs" autoconsent rule.
+    cookieModal: `
+    <html>
+    <body>
+        <h1>Hello world</h1>
+        <div class="_brlbs-bar-wrap">
+            <div class="_brlbs-block-content">
+                <p>We use cookies</p>
+                <button class="brlbs-btn-accept-all" onclick="window.consentChoice = 'all'; this.closest('._brlbs-bar-wrap').remove()">Accept all</button>
+                <button class="brlbs-btn-accept-only-essential" onclick="window.consentChoice = 'essential'; this.closest('._brlbs-bar-wrap').remove()">Only essential</button>
+            </div>
+        </div>
+    </body>
+    </html>`,
     shadowRoots: `
     <html>
     <body>
@@ -329,6 +343,10 @@ export async function runExampleComServer(): Promise<[Server, number]> {
 
         special.get('/inside-iframe', (_req, res) => {
             res.type('html').send(responseSamples.insideIframe);
+        });
+
+        special.get('/cookie-modal', (_req, res) => {
+            res.type('html').send(responseSamples.cookieModal);
         });
 
         special.get('/shadow-root', (_req, res) => {


### PR DESCRIPTION
Replaces the unmaintained, GPL-licensed `idcac-playwright` optional peer dependency in `closeCookieModals` with the actively maintained, MPL-2.0 (Apache-2.0 compatible) [autoconsent](https://github.com/duckduckgo/autoconsent), which goes through the consent flow instead of just hiding the modal. Closes #3987.