### PR TITLE
chore(deps): bump pnpm to 11.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,16 +140,16 @@
             "oxfmt --write --no-error-on-unmatched-pattern"
         ]
     },
-    "packageManager": "pnpm@11.0.9",
+    "packageManager": "pnpm@11.22.0",
     "devEngines": {
         "packageManager": {
             "name": "pnpm",
-            "version": "11.0.9",
+            "version": "11.22.0",
             "onFail": "error"
         }
     },
     "volta": {
         "node": "24.18.0",
-        "pnpm": "11.0.9"
+        "pnpm": "11.22.0"
     }
 }


### PR DESCRIPTION
Bumps the pinned `pnpm` from 11.0.9 to 11.22.0, keeping all three pins in sync: `packageManager`, `devEngines.packageManager.version`, and `volta.pnpm` (Renovate's packageManager update typically bumps only the first, which leaves corepack failing on a version mismatch).

Routine dependency-manager hygiene; no lockfile or source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)