### PR TITLE
ci: pin third-party actions to commit SHAs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,10 +17,10 @@ jobs:
         runs-on: ubuntu-22.04
 
         steps:
-            -   uses: actions/checkout@v7
+            -   uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             -   name: Use Node.js 24
-                uses: actions/setup-node@v7
+                uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
                 with:
                     node-version: 24
                     package-manager-cache: false
@@ -36,15 +36,15 @@ jobs:
                     SEGMENT_TOKEN: ${{ secrets.SEGMENT_TOKEN }}
 
             -   name: Set up GitHub Pages
-                uses: actions/configure-pages@v6
+                uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
             -   name: Upload GitHub Pages artifact
-                uses: actions/upload-pages-artifact@v5
+                uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
                 with:
                     path: ./website/build
 
             -   name: Deploy artifact to GitHub Pages
-                uses: actions/deploy-pages@v5
+                uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
 
             -   name: Invalidate CloudFront cache
                 run: |

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -37,21 +37,21 @@ jobs:
         name: Publish to NPM (${{ inputs.dist-tag }})
         runs-on: ubuntu-22.04
         steps:
-            - uses: actions/checkout@v7
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   ref: ${{ inputs.ref }}
                   token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
                   fetch-depth: 0
 
             - name: Use Node.js 24
-              uses: actions/setup-node@v7
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
                   node-version: 24
                   package-manager-cache: false
 
             - name: Turbo cache
               id: turbo-cache
-              uses: actions/cache@v6
+              uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
               with:
                   path: .turbo
                   key: turbo-${{ github.job }}-${{ github.ref_name }}-${{ github.sha }}
@@ -70,7 +70,7 @@ jobs:
 
             - name: Commit changes
               if: inputs.dist-tag != 'prod'
-              uses: EndBug/add-and-commit@v11
+              uses: EndBug/add-and-commit@645ecc0dd0a57f4d86d26c0aa5fc42c0a856fbca # v11.0.0
               id: commit
               with:
                 author_name: Apify Release Bot
@@ -80,7 +80,7 @@ jobs:
 
             - name: Publish to NPM (@latest)
               if: inputs.dist-tag == 'prod'
-              uses: nick-fields/retry@v4
+              uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
               with:
                   timeout_minutes: 10
                   max_attempts: 5
@@ -91,7 +91,7 @@ jobs:
 
             - name: Publish to NPM (@next)
               if: inputs.dist-tag != 'prod' && inputs.dist-tag != 'rc'
-              uses: nick-fields/retry@v4
+              uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
               with:
                   timeout_minutes: 10
                   max_attempts: 5
@@ -102,7 +102,7 @@ jobs:
 
             - name: Publish to NPM (@rc)
               if: inputs.dist-tag == 'rc'
-              uses: nick-fields/retry@v4
+              uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
               with:
                   timeout_minutes: 10
                   max_attempts: 5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,17 +42,17 @@ jobs:
 
         steps:
             -   name: Checkout repository
-                uses: actions/checkout@v7
+                uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             -   name: Use Node.js ${{ matrix.node-version }}
-                uses: actions/setup-node@v7
+                uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
                 with:
                     node-version: ${{ matrix.node-version }}
                     package-manager-cache: false
 
             -   name: Turbo cache
                 id: turbo-cache
-                uses: actions/cache@v6
+                uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
                 with:
                     path: .turbo
                     key: turbo-${{ github.job }}-${{ github.ref_name }}-${{ github.sha }}
@@ -78,20 +78,20 @@ jobs:
 
         steps:
             -   name: Checkout repository
-                uses: actions/checkout@v7
+                uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
                 with:
                     token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
                     fetch-depth: 0
 
             -   name: Use Node.js 24
-                uses: actions/setup-node@v7
+                uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
                 with:
                     node-version: 24
                     package-manager-cache: false
 
             -   name: Turbo cache
                 id: turbo-cache
-                uses: actions/cache@v6
+                uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
                 with:
                     path: .turbo
                     key: turbo-${{ github.job }}-${{ github.ref_name }}-${{ github.sha }}
@@ -130,7 +130,7 @@ jobs:
 
             -   name: Commit changes
                 id: commit
-                uses: EndBug/add-and-commit@v11
+                uses: EndBug/add-and-commit@645ecc0dd0a57f4d86d26c0aa5fc42c0a856fbca # v11.0.0
                 with:
                   author_name: Apify Release Bot
                   author_email: noreply@apify.com
@@ -148,7 +148,7 @@ jobs:
                       }
 
             -   name: Trigger Docker image builds
-                uses: peter-evans/repository-dispatch@v4
+                uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
                 with:
                     token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
                     repository: apify/apify-actor-docker
@@ -162,14 +162,14 @@ jobs:
 
         steps:
             -   name: Checkout repository
-                uses: actions/checkout@v7
+                uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
                 with:
                     ref: ${{ github.event.repository.default_branch }}
                     token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
                     fetch-depth: 0
 
             -   name: Use Node.js 24
-                uses: actions/setup-node@v7
+                uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
                 with:
                     node-version: 24
                     package-manager-cache: false
@@ -193,7 +193,7 @@ jobs:
                     pnpm docusaurus api:version $MAJOR_MINOR
 
             -   name: Commit and push the version snapshot
-                uses: EndBug/add-and-commit@v11
+                uses: EndBug/add-and-commit@645ecc0dd0a57f4d86d26c0aa5fc42c0a856fbca # v11.0.0
                 with:
                     author_name: Apify Release Bot
                     author_email: noreply@apify.com

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -29,17 +29,17 @@ jobs:
 
         steps:
             -   name: Checkout repository
-                uses: actions/checkout@v7
+                uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             -   name: Use Node.js ${{ matrix.node-version }}
-                uses: actions/setup-node@v7
+                uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
                 with:
                     node-version: ${{ matrix.node-version }}
                     package-manager-cache: false
 
             -   name: Turbo cache
                 id: turbo-cache
-                uses: actions/cache@v6
+                uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
                 with:
                     path: .turbo
                     key: turbo-${{ github.job }}-${{ matrix.node-version }}-${{ github.ref_name }}-${{ github.sha }}
@@ -73,17 +73,17 @@ jobs:
 
         steps:
             -   name: Checkout repository
-                uses: actions/checkout@v6
+                uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
             -   name: Use Node.js 24
-                uses: actions/setup-node@v6
+                uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
                 with:
                     node-version: 24
                     package-manager-cache: false
 
             -   name: Turbo cache
                 id: turbo-cache
-                uses: actions/cache@v5
+                uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
                 with:
                     path: .turbo
                     key: turbo-${{ github.job }}-${{ github.ref_name }}-${{ github.sha }}
@@ -104,17 +104,17 @@ jobs:
         runs-on: ubuntu-22.04
         steps:
             -   name: Checkout Source code
-                uses: actions/checkout@v7
+                uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             -   name: Use Node.js 24
-                uses: actions/setup-node@v7
+                uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
                 with:
                     node-version: 24
                     package-manager-cache: false
 
             -   name: Turbo cache
                 id: turbo-cache
-                uses: actions/cache@v6
+                uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
                 with:
                     path: .turbo
                     key: turbo-${{ github.job }}-${{ github.ref_name }}-${{ github.sha }}
@@ -234,17 +234,17 @@ jobs:
 
         steps:
             -   name: Checkout repository
-                uses: actions/checkout@v7
+                uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             -   name: Use Node.js 24
-                uses: actions/setup-node@v7
+                uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
                 with:
                     node-version: 24
                     package-manager-cache: false
 
             -   name: Turbo cache
                 id: turbo-cache
-                uses: actions/cache@v6
+                uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
                 with:
                     path: .turbo
                     key: turbo-${{ github.job }}-${{ github.ref_name }}-${{ github.sha }}
@@ -267,20 +267,20 @@ jobs:
 
         steps:
             -   name: Checkout repository
-                uses: actions/checkout@v7
+                uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
                 with:
                     token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
                     fetch-depth: 0
 
             -   name: Use Node.js 24
-                uses: actions/setup-node@v7
+                uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
                 with:
                     node-version: 24
                     package-manager-cache: false
 
             -   name: Turbo cache
                 id: turbo-cache
-                uses: actions/cache@v6
+                uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
                 with:
                     path: .turbo
                     key: turbo-${{ github.job }}-${{ github.ref_name }}-${{ github.sha }}
@@ -328,7 +328,7 @@ jobs:
                     echo "crawlee=$crawlee" | tee -a $GITHUB_OUTPUT
 
             -   name: Trigger Docker image builds
-                uses: peter-evans/repository-dispatch@v4
+                uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
                 # Trigger next images only if we have something new pushed
                 if: github.ref == 'refs/heads/master' && steps.changed-packages.outputs.changed_packages != '0'
                 with:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -23,17 +23,17 @@ jobs:
 
         steps:
             -   name: Checkout repository
-                uses: actions/checkout@v7
+                uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             -   name: Use Node.js 24
-                uses: actions/setup-node@v7
+                uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
                 with:
                     node-version: 24
                     package-manager-cache: false
 
             -   name: Turbo cache
                 id: turbo-cache
-                uses: actions/cache@v6
+                uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
                 with:
                     path: .turbo
                     key: turbo-${{ github.job }}-${{ github.ref_name }}-${{ github.sha }}
@@ -54,7 +54,7 @@ jobs:
 
             -   name: Cache Playwright browsers
                 if: (matrix.storage != 'PLATFORM')
-                uses: actions/cache@v6
+                uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
                 with:
                     path: ~/.cache/ms-playwright
                     key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -37,16 +37,16 @@ jobs:
 
         steps:
             -   name: Checkout repository
-                uses: actions/checkout@v6
+                uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
             -   name: Use Node.js 24
-                uses: actions/setup-node@v6
+                uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
                 with:
                     node-version: 24
                     package-manager-cache: false
 
             -   name: Turbo cache
-                uses: actions/cache@v5
+                uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
                 with:
                     path: .turbo
                     key: turbo-${{ github.job }}-${{ github.ref_name }}-${{ github.sha }}

--- a/.github/workflows/update_new_issue.yml
+++ b/.github/workflows/update_new_issue.yml
@@ -14,7 +14,7 @@ jobs:
 
         steps:
             # Add the "t-tooling" label to all new issues
-            -   uses: actions/github-script@v9
+            -   uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
                 with:
                     script: |
                         github.rest.issues.addLabels({


### PR DESCRIPTION
This pins every third-party action in our workflows to a full commit SHA, keeping the resolved version tag as a trailing comment. Renovate understands that convention and updates the SHA and comment together.

The trigger: yesterday the `v11` tag of `EndBug/add-and-commit` moved to the broken v11.1.0 release, whose `action.yml` fails to load (`Unrecognized named-value: 'github'`), which killed our publish workflow ([failed run](https://github.com/apify/crawlee/actions/runs/32255557318)). With SHA pins, a tag moving under us, by accident or by compromise, can't break or hijack CI anymore. `EndBug/add-and-commit` is pinned to v11.0.0, the last working release; the upstream fix is pending in EndBug/add-and-commit#783.

Own-org references (`apify/workflows`, `apify/actions`, `apify/setup-apify-cli-action`) stay on floating refs on purpose, since we control those repos.
