### PR TITLE
fix: Deflake tests under high concurrency

### DIFF
--- a/packages/core/src/session_pool/session.ts
+++ b/packages/core/src/session_pool/session.ts
@@ -4,7 +4,6 @@ import { z } from 'zod';
 
 import { cryptoRandomObjectId } from '@apify/utilities';
 
-import { getDefaultCookieExpirationDate } from '../cookie_utils.js';
 import type { CrawleeLogger } from '../log.js';
 import { serviceLocator } from '../service_locator.js';
 import { parseArgument, schemas, validators } from '../validators.js';
@@ -62,7 +61,10 @@ export interface SessionOptions {
     /** Date of creation. */
     createdAt?: Date;
 
-    /** Date of expiration. */
+    /**
+     * Date of expiration.
+     * @default createdAt + maxAgeSecs
+     */
     expiresAt?: Date;
 
     /**
@@ -191,7 +193,8 @@ export class Session implements ISession {
             retired,
             log,
             fingerprint,
-            expiresAt = getDefaultCookieExpirationDate(maxAgeSecs),
+            // Anchored to `createdAt` rather than to "now", so the documented `createdAt + maxAgeSecs` holds.
+            expiresAt = new Date(createdAt.getTime() + maxAgeSecs * 1000),
         } = parseArgument(options, sessionOptionsSchema);
 
         this.#log = log.child({ prefix: 'Session' });

--- a/packages/utils/test/robots.test.ts
+++ b/packages/utils/test/robots.test.ts
@@ -6,6 +6,9 @@ import { RobotsTxtFile } from '../src/internals/robots.js';
 
 const httpClient = new FetchHttpClient();
 
+// Never replies within the lifetime of a test, so only the timeout/abort can settle the promise.
+const neverReplies = 'http://never-replies.com';
+
 describe('RobotsTxtFile', () => {
     beforeEach(() => {
         nock.disableNetConnect();
@@ -33,6 +36,8 @@ describe('RobotsTxtFile', () => {
             )
             .get('*')
             .reply(404);
+
+        nock(neverReplies).persist().get('/robots.txt').delay(30_000).reply(200, 'User-agent: *');
     });
 
     afterEach(() => {
@@ -63,44 +68,44 @@ describe('RobotsTxtFile', () => {
     });
 
     it('respects user-set timeout', async () => {
-        const start = +Date.now();
-        const robots = RobotsTxtFile.find('http://not-exists.com/robots.txt', { timeoutMillis: 200 });
+        const start = Date.now();
+        const robots = RobotsTxtFile.find(`${neverReplies}/robots.txt`, { timeoutMillis: 200 });
 
         await expect(robots).rejects.toThrow(/timeout/i);
-        const end = +Date.now();
 
-        expect(end - start).toBeGreaterThanOrEqual(200);
-        expect(end - start).toBeLessThanOrEqual(500);
+        const elapsed = Date.now() - start;
+        expect(elapsed).toBeGreaterThanOrEqual(200);
+        expect(elapsed).toBeLessThan(10_000);
     });
 
     it('respects AbortSignal parameter', async () => {
         const controller = new AbortController();
         setTimeout(() => controller.abort(), 200);
 
-        const start = +Date.now();
-        const robots = RobotsTxtFile.find('http://not-exists.com/robots.txt', { signal: controller.signal });
+        const start = Date.now();
+        const robots = RobotsTxtFile.find(`${neverReplies}/robots.txt`, { signal: controller.signal });
 
         await expect(robots).rejects.toThrow(/aborted/i);
-        const end = +Date.now();
 
-        expect(end - start).toBeGreaterThanOrEqual(200);
-        expect(end - start).toBeLessThanOrEqual(500);
+        const elapsed = Date.now() - start;
+        expect(elapsed).toBeGreaterThanOrEqual(200);
+        expect(elapsed).toBeLessThan(10_000);
     });
 
     it('respects AbortSignal parameter and timeout together', async () => {
         const controller = new AbortController();
 
-        const start = +Date.now();
-        const robots = RobotsTxtFile.find('http://not-exists.com/robots.txt', {
+        const start = Date.now();
+        const robots = RobotsTxtFile.find(`${neverReplies}/robots.txt`, {
             signal: controller.signal,
             timeoutMillis: 200,
         });
 
         await expect(robots).rejects.toThrow(/timeout/i);
-        const end = +Date.now();
 
-        expect(end - start).toBeGreaterThanOrEqual(200);
-        expect(end - start).toBeLessThanOrEqual(500);
+        const elapsed = Date.now() - start;
+        expect(elapsed).toBeGreaterThanOrEqual(200);
+        expect(elapsed).toBeLessThan(10_000);
     });
 
     it('drops cross-host and non-http(s) sitemap directives under the default same-hostname strategy', () => {

--- a/test/core/crawlers/browser_crawler.test.ts
+++ b/test/core/crawlers/browser_crawler.test.ts
@@ -692,6 +692,9 @@ describe('BrowserCrawler', () => {
             },
             requestList,
             saveResponseCookies: true,
+            // The handoff only happens between requests: cookies set in a handler are flushed to the
+            // session jar after it returns, so cookie-2 must not start before cookie-1 has finished.
+            maxConcurrency: 1,
             sessionPool: new SessionPool({
                 maxPoolSize: 1,
             }),

--- a/test/core/crawlers/browser_crawler.test.ts
+++ b/test/core/crawlers/browser_crawler.test.ts
@@ -921,6 +921,9 @@ describe('BrowserCrawler', () => {
             sessionPool: new SessionPool({
                 maxPoolSize: 1,
             }),
+            // A strictly serial [0..5] is only well-defined one request at a time: two handlers running
+            // together read the same `usageCount` before either marks the session good.
+            maxConcurrency: 1,
             requestHandler: async ({ session }) => {
                 sessionUsageHistory.push((session as Session).usageCount);
             },

--- a/test/core/crawlers/playwright_crawler.test.ts
+++ b/test/core/crawlers/playwright_crawler.test.ts
@@ -2,7 +2,7 @@ import type { Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import os from 'node:os';
 
-import type { PlaywrightCrawlingContext, PlaywrightGotoOptions, Request } from '@crawlee/playwright';
+import type { PlaywrightCrawlingContext, Request } from '@crawlee/playwright';
 import { type ConcurrencySystem, MemoryStorageBackend, serviceLocator } from '@crawlee/core';
 import {
     createPlaywrightRouter,
@@ -169,7 +169,8 @@ describe('PlaywrightCrawler', () => {
 
     test('should override goto timeout with navigationTimeoutSecs', async () => {
         const timeoutSecs = 10;
-        let options: PlaywrightGotoOptions;
+        // Captured by value: `navigate()` narrows the live `gotoOptions` down to the remaining navigation window.
+        let gotoTimeout: number | undefined;
         const playwrightCrawler = new PlaywrightCrawler({
             requestList,
             maxRequestRetries: 0,
@@ -177,14 +178,14 @@ describe('PlaywrightCrawler', () => {
             requestHandler: () => {},
             preNavigationHooks: [
                 ({ gotoOptions }) => {
-                    options = gotoOptions;
+                    gotoTimeout = gotoOptions.timeout;
                 },
             ],
             navigationTimeoutSecs: timeoutSecs,
         });
 
         await playwrightCrawler.run();
-        expect(options!.timeout).toEqual(timeoutSecs * 1000);
+        expect(gotoTimeout).toEqual(timeoutSecs * 1000);
     });
 
     test('does not mutate the launchContext it was given', () => {

--- a/test/core/crawlers/puppeteer_crawler.test.ts
+++ b/test/core/crawlers/puppeteer_crawler.test.ts
@@ -5,7 +5,7 @@ import type { AddressInfo } from 'node:net';
 import os from 'node:os';
 import { promisify } from 'node:util';
 
-import type { PuppeteerCrawlingContext, PuppeteerGoToOptions, Request } from '@crawlee/puppeteer';
+import type { PuppeteerCrawlingContext, Request } from '@crawlee/puppeteer';
 import type { Cheerio, CheerioAPI } from 'cheerio';
 import type { Element } from 'domhandler';
 import {
@@ -137,7 +137,8 @@ describe('PuppeteerCrawler', () => {
 
     test('should override goto timeout with navigationTimeoutSecs', async () => {
         const timeoutSecs = 10;
-        let options: PuppeteerGoToOptions;
+        // Captured by value: `navigate()` narrows the live `gotoOptions` down to the remaining navigation window.
+        let gotoTimeout: number | undefined;
         const puppeteerCrawler = new PuppeteerCrawler({
             requestList,
             maxRequestRetries: 0,
@@ -145,14 +146,14 @@ describe('PuppeteerCrawler', () => {
             requestHandler: () => {},
             preNavigationHooks: [
                 ({ gotoOptions }) => {
-                    options = gotoOptions;
+                    gotoTimeout = gotoOptions.timeout;
                 },
             ],
             navigationTimeoutSecs: timeoutSecs,
         });
 
         await puppeteerCrawler.run();
-        expect(options!.timeout).toEqual(timeoutSecs * 1000);
+        expect(gotoTimeout).toEqual(timeoutSecs * 1000);
     });
 
     test('should throw if launchOptions.proxyUrl is supplied', async () => {

--- a/test/core/sitemap_request_loader.test.ts
+++ b/test/core/sitemap_request_loader.test.ts
@@ -148,7 +148,11 @@ beforeAll(async () => {
         res.end();
     });
 
+    // `?linger=<ms>` (default 200) holds the response open after the two URL entries, so a test can act
+    // while this sub-sitemap is still loading.
     app.get('/sitemap-stream-linger.xml', async (req, res) => {
+        const lingerMillis = Number(req.query.linger ?? 200);
+
         async function* stream() {
             yield [
                 '<?xml version="1.0" encoding="UTF-8"?>',
@@ -161,7 +165,7 @@ beforeAll(async () => {
                 '</url>',
             ].join('\n');
 
-            await sleep(200);
+            await sleep(lingerMillis);
 
             yield '</urlset>';
         }
@@ -173,14 +177,17 @@ beforeAll(async () => {
         res.end();
     });
 
+    // Index over the lingering sub-sitemap (2 URLs) followed by a plain one (5 URLs).
     app.get('/sitemap-index.xml', async (req, res) => {
+        const linger = req.query.linger === undefined ? '' : `?linger=${Number(req.query.linger)}`;
+
         res.setHeader('content-type', 'text/xml');
         res.write(
             [
                 '<?xml version="1.0" encoding="UTF-8"?>',
                 '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
                 '<sitemap>',
-                `<loc>${url}/sitemap-stream-linger.xml</loc>`,
+                `<loc>${url}/sitemap-stream-linger.xml${linger}</loc>`,
                 '</sitemap>',
                 '<sitemap>',
                 `<loc>${url}/sitemap.xml</loc>`,
@@ -444,12 +451,17 @@ describe('SitemapRequestLoader', () => {
         const controller = new AbortController();
 
         const list = await SitemapRequestLoader.open({
-            sitemapUrls: [`${url}/sitemap-index.xml`],
+            // The first sub-sitemap stays open for 5s, so the abort below always lands mid-index.
+            sitemapUrls: [`${url}/sitemap-index.xml?linger=5000`],
             signal: controller.signal,
             enqueueStrategy: 'all',
         });
 
-        await sleep(50); // Loads the first sub-sitemap, but not the second
+        // Abort while the first sub-sitemap is still streaming - waiting for its URLs rather than for a fixed duration.
+        while (await list.isEmpty()) {
+            await sleep(10);
+        }
+
         controller.abort();
 
         for await (const request of list) {
@@ -463,8 +475,10 @@ describe('SitemapRequestLoader', () => {
 
     test('timeout option works', async () => {
         const list = await SitemapRequestLoader.open({
-            sitemapUrls: [`${url}/sitemap-index.xml`],
-            timeoutMillis: 50, // Loads the first sub-sitemap, but not the second
+            // The timeout has to fire after the first sub-sitemap streamed its URLs but before it closes;
+            // the test then runs for the whole linger, since the abort cannot interrupt an in-flight fetch.
+            sitemapUrls: [`${url}/sitemap-index.xml?linger=2000`],
+            timeoutMillis: 500,
             enqueueStrategy: 'all',
         });
 
@@ -479,21 +493,27 @@ describe('SitemapRequestLoader', () => {
 
     test('resurrection does not resume aborted loading', async () => {
         const options = {
-            sitemapUrls: [`${url}/sitemap-index.xml`],
+            sitemapUrls: [`${url}/sitemap-index.xml?linger=5000`],
             persistStateKey: 'resurrection-abort',
-            timeoutMillis: 50,
             enqueueStrategy: 'all' as const,
         };
 
         {
-            const list = await SitemapRequestLoader.open(options);
+            const controller = new AbortController();
+            const list = await SitemapRequestLoader.open({ ...options, signal: controller.signal });
 
-            await sleep(50);
+            // Abort while the first sub-sitemap is still streaming, so the state is persisted with the
+            // load aborted half-way through the index.
+            while (await list.isEmpty()) {
+                await sleep(10);
+            }
 
-            await expect(list.isEmpty()).resolves.toBe(false);
+            controller.abort();
             await list.persistState();
         }
 
+        // Deliberately no signal and no timeout here: only the restored abort flag can stop the second
+        // sub-sitemap from being fetched.
         const newList = await SitemapRequestLoader.open(options);
         for await (const request of newList) {
             await newList.markRequestAsHandled(request);


### PR DESCRIPTION
Five unrelated causes. All four pass in isolation.

- `Session` derived `expiresAt` from a second `Date.now()` call, milliseconds after the `createdAt` default — so `expiresAt - createdAt` came out a millisecond short of `maxAgeSecs`. Now anchored to `createdAt`, which is what `isExpired()` and the session management guide already document. The only behaviour change in here.
- `should override goto timeout with navigationTimeoutSecs` (playwright + puppeteer) saved a reference to the live `gotoOptions`, which `navigate()` then narrows to the remaining navigation window — so it read 9999, not 10000. Reads the value inside the hook instead.
- Three `SitemapRequestLoader` tests had to act inside the 200ms window where the first sub-sitemap has streamed its URLs but not closed; overshoot it and the handled count goes 2 → 7. The fixture now takes `?linger=<ms>` and the tests wait on the condition rather than a duration.
- Three `RobotsTxtFile` tests bounded elapsed time at `<= 500`, which was exactly the mock's reply delay — 300ms of headroom over a 200ms deadline. They now point at a host that never answers, so the bound can be generous.
- `should increment session usage correctly` asserted a serial `[0,1,2,3,4,5]` without pinning `maxConcurrency`, so any overlap made two handlers read the same `usageCount` before either marked the session good. Pinned to 1, like every other order-dependent test in the file.

`resurrection does not resume aborted loading` picks up a real assertion on the way past: it used to rely on a 50ms sleep racing a 50ms timeout to persist `abortLoading: true`. It now aborts through an `AbortSignal` and gives the resurrected loader no timeout of its own, so only the restored flag can stop it.
