### PR TITLE
refactor: keep same-domain filtering after an off-domain redirect

### DIFF
--- a/packages/core/src/enqueue_links/enqueue_links.ts
+++ b/packages/core/src/enqueue_links/enqueue_links.ts
@@ -179,8 +179,7 @@ export function resolveBaseUrlForEnqueueLinksFiltering({
     }
 
     // If the user wants to ensure the same domain is accessed, regardless of subdomains, we check to ensure the domains match
-    // Returning undefined here is intentional! If the domains don't match, having no baseUrl in enqueueLinks will cause it to not enqueue anything
-    // which is the intended behavior (since we went off domain)
+    // If they don't (we went off domain via a redirect), we keep filtering against the original domain - returning undefined would disable the filtering entirely
     if (enqueueStrategy === EnqueueStrategy.SameDomain) {
         const originalHostname = getDomain(originalUrlOrigin, { mixedInputs: false })!;
         const finalHostname = getDomain(finalUrlOrigin, { mixedInputs: false })!;
@@ -189,7 +188,7 @@ export function resolveBaseUrlForEnqueueLinksFiltering({
             return finalUrlOrigin;
         }
 
-        return undefined;
+        return originalUrlOrigin;
     }
 
     // Always enqueue urls that are from the same origin in all other cases, as the filtering happens on the original request url, even if there was a redirect

--- a/test/core/enqueue_links/enqueue_links.test.ts
+++ b/test/core/enqueue_links/enqueue_links.test.ts
@@ -72,7 +72,7 @@ async function createRequestQueueMock(seedUrl = 'https://example.com') {
 // `enqueueLinks()`'s hostname/domain-based strategies see whatever start URL a test navigates to,
 // regardless of where the content is actually served from.
 class FixtureHttpClient extends BaseHttpClient {
-    constructor(private readonly html: string) {
+    constructor(protected readonly html: string) {
         super();
     }
 
@@ -412,6 +412,36 @@ describe('enqueueLinks()', () => {
                 'http://www.absolute.com/x/absolutepath',
                 'http://www.absolute.com/removethis/y/relativepath',
                 'http://example.absolute.com/hello',
+            ]);
+        });
+
+        test('keeps filtering by the original domain with the strategy of same-domain after an off-domain redirect', async () => {
+            const { enqueued, requestQueue } = await createRequestQueueMock();
+            // Serves the fixture HTML while reporting the load as if it had redirected off-domain.
+            const redirectingHttpClient = new (class extends FixtureHttpClient {
+                override async sendRequest(): Promise<Response> {
+                    return new ResponseWithUrl(this.html, {
+                        url: 'https://another.com/',
+                        status: 200,
+                        headers: { 'content-type': 'text/html; charset=utf-8' },
+                    });
+                }
+            })(HTML);
+
+            const crawler = new CheerioCrawler({
+                requestManager: requestQueue,
+                httpClient: redirectingHttpClient,
+                requestHandler: async ({ request, enqueueLinks }) => {
+                    if (request.url !== 'https://example.com') return;
+                    await enqueueLinks({ strategy: EnqueueStrategy.SameDomain });
+                },
+            });
+            await crawler.run(['https://example.com']);
+
+            expect(enqueued.map((r) => r.url)).toEqual([
+                'https://example.com/a/b/first',
+                'https://example.com/a/second',
+                'https://example.com/a/b/third',
             ]);
         });
 

--- a/test/core/enqueue_links/enqueue_links.test.ts
+++ b/test/core/enqueue_links/enqueue_links.test.ts
@@ -445,6 +445,22 @@ describe('enqueueLinks()', () => {
             ]);
         });
 
+        test('ignores an explicitly undefined baseUrl and keeps the resolved one', async () => {
+            const { enqueued, requestQueue } = await createRequestQueueMock();
+            await runCheerioEnqueueLinks(
+                { strategy: EnqueueStrategy.SameDomain, baseUrl: undefined },
+                { requestManager: requestQueue },
+            );
+
+            expect(enqueued.map((r) => r.url)).toEqual([
+                'https://example.com/a/b/first',
+                'https://example.com/a/second',
+                'https://example.com/a/b/third',
+                'https://example.com/x/absolutepath',
+                'https://example.com/y/relativepath',
+            ]);
+        });
+
         test('correctly resolves relative URLs with the strategy of all', async () => {
             const { enqueued, requestQueue } = await createRequestQueueMock();
             await runCheerioEnqueueLinks(


### PR DESCRIPTION
Restores the #3923 fix that the v4 rebase silently reverted. The enqueueLinks split (#4010) predates #3923 and its diff carried a pre-fix copy of `resolveBaseUrlForEnqueueLinksFiltering`; when the rebase replayed it over the fixed base, the rerere cache (seeded from the old merge branch, which had resolved this exact conflict toward v4) applied that resolution again, so the fix disappeared without ever showing a conflict. The result: with `strategy: 'same-domain'` and a cross-domain redirect, the `undefined` baseUrl built no strategy patterns and every link on the redirected page got enqueued.

The regression test runs the real CheerioCrawler path with an http client that reports an off-domain load. An audit of all v3 fixes since 3.14 against master found no other fix dropped by the rebase.

Closes #4070