### PR TITLE
fix(basic): report skips from background add batches

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -2101,6 +2101,38 @@ export class BasicCrawler<
 
         const allSkipped: { url: string; reason: SkippedRequestReason }[] = [];
 
+        const reportSkippedRequests = async () => {
+            const skippedRequests = allSkipped.splice(0);
+            if (skippedRequests.length === 0) {
+                return;
+            }
+
+            const skippedRobotsUrls = skippedRequests.filter((s) => s.reason === 'robotsTxt').map((s) => s.url);
+            if (skippedRobotsUrls.length > 0) {
+                this.log.warning(
+                    `Some requests were skipped because they were disallowed based on the robots.txt file`,
+                    { skipped: skippedRobotsUrls },
+                );
+            }
+
+            // Only log the limit message when an explicit `limit` was passed (not the internal
+            // `maxRequestsPerCrawl`-derived one), and only once per call.
+            if (options.limit !== undefined && skippedRequests.some((s) => s.reason === 'limit')) {
+                this.log.info(
+                    requestLimit === options.limit
+                        ? `Skipping requests in this call due to the enqueueLinks limit of ${options.limit}.`
+                        : `Skipping requests in this call due to the remaining maxRequestsPerCrawl budget of ${requestLimit}, which is lower than the enqueueLinks limit of ${options.limit}.`,
+                );
+            }
+
+            await Promise.all(
+                skippedRequests.map(async ({ url, reason }) => {
+                    await this.#handleSkippedRequest({ url, reason });
+                    await options.onSkippedRequest?.({ url, reason });
+                }),
+            );
+        };
+
         async function* filteredRequests() {
             for await (const request of requests) {
                 const [requestOptions] = createRequestOptions(
@@ -2178,34 +2210,17 @@ export class BasicCrawler<
             allSkipped.push({ url: typeof request === 'string' ? request : request.url!, reason: 'limit' });
         }
 
-        if (allSkipped.length > 0) {
-            const skippedRobotsUrls = allSkipped.filter((s) => s.reason === 'robotsTxt').map((s) => s.url);
-            if (skippedRobotsUrls.length > 0) {
-                this.log.warning(
-                    `Some requests were skipped because they were disallowed based on the robots.txt file`,
-                    { skipped: skippedRobotsUrls },
-                );
-            }
+        await reportSkippedRequests();
 
-            // Only log the limit message when an explicit `limit` was passed (not the internal
-            // `maxRequestsPerCrawl`-derived one), and only once per call.
-            if (options.limit !== undefined && allSkipped.some((s) => s.reason === 'limit')) {
-                this.log.info(
-                    requestLimit === options.limit
-                        ? `Skipping requests in this call due to the enqueueLinks limit of ${options.limit}.`
-                        : `Skipping requests in this call due to the remaining maxRequestsPerCrawl budget of ${requestLimit}, which is lower than the enqueueLinks limit of ${options.limit}.`,
-                );
-            }
+        const waitForAllRequestsToBeAdded = result.waitForAllRequestsToBeAdded.then(async (addedRequests) => {
+            await reportSkippedRequests();
+            return addedRequests;
+        });
+        // Keep callback failures observable to callers that await this promise without emitting an unhandled rejection
+        // when callers intentionally leave background additions running, matching `drainRequestBatches` behavior.
+        void waitForAllRequestsToBeAdded.catch(() => {});
 
-            await Promise.all(
-                allSkipped.map(async ({ url, reason }) => {
-                    await this.#handleSkippedRequest({ url, reason });
-                    await options.onSkippedRequest?.({ url, reason });
-                }),
-            );
-        }
-
-        return result;
+        return { ...result, waitForAllRequestsToBeAdded };
     }
 
     /**

--- a/test/core/crawlers/basic_crawler.test.ts
+++ b/test/core/crawlers/basic_crawler.test.ts
@@ -588,6 +588,95 @@ describe('BasicCrawler', () => {
             expect(skippedRequests[0]).toStrictEqual({ url: 'https://example.com/1/', reason: 'depth' });
             expect(skippedRequests[1]).toStrictEqual({ url: 'https://example.com/2/', reason: 'depth' });
         });
+
+        test('reports filtered requests discovered in background batches', async () => {
+            const onSkippedRequest = vitest.fn();
+            const crawler = new BasicCrawler({
+                requestHandler: async () => {},
+                onSkippedRequest,
+            });
+
+            const inScope = Array.from({ length: 2_000 }, (_, i) => `https://example.com/ok/${i}`);
+            const outOfScope = Array.from({ length: 50 }, (_, i) => `https://other.com/no/${i}`);
+
+            const { addedRequests, waitForAllRequestsToBeAdded } = await crawler.addRequests(
+                [...inScope, ...outOfScope],
+                {
+                    include: ['https://example.com/**'],
+                },
+            );
+            const backgroundAddedRequests = await waitForAllRequestsToBeAdded;
+
+            expect(addedRequests).toHaveLength(1_000);
+            expect(backgroundAddedRequests).toHaveLength(1_000);
+            expect(onSkippedRequest.mock.calls.map(([skipped]) => skipped)).toEqual(
+                outOfScope.map((url) => ({ url, reason: 'filters' })),
+            );
+        });
+
+        test('background onSkippedRequest rejection rejects the background completion promise', async () => {
+            const crawler = new BasicCrawler({
+                requestHandler: async () => {},
+                onSkippedRequest: async () => {
+                    throw new Error('onSkippedRequest failed');
+                },
+            });
+
+            const { addedRequests, waitForAllRequestsToBeAdded } = await crawler.addRequests(
+                [
+                    'https://example.com/1',
+                    'https://example.com/2',
+                    'https://example.com/3',
+                    'https://example.com/4',
+                    'https://other.com/no',
+                ],
+                {
+                    batchSize: 2,
+                    waitBetweenBatchesMillis: 0,
+                    include: ['https://example.com/**'],
+                },
+            );
+
+            expect(addedRequests).toHaveLength(2);
+            await expect(waitForAllRequestsToBeAdded).rejects.toThrow('onSkippedRequest failed');
+        });
+
+        test('drains foreground and background robots.txt skips exactly once', async () => {
+            const onSkippedRequest = vitest.fn();
+            const crawler = new BasicCrawler({
+                requestHandler: async () => {},
+                onSkippedRequest,
+            });
+            vitest
+                .spyOn(crawler as any, 'isAllowedBasedOnRobotsTxtFile')
+                .mockImplementation(async (url: unknown) => !String(url).includes('/denied'));
+            const warningSpy = vitest.spyOn(crawler.log, 'warning');
+
+            const foregroundDenied = 'https://example.com/denied/foreground';
+            const backgroundDenied = 'https://example.com/denied/background';
+            const { waitForAllRequestsToBeAdded } = await crawler.addRequests(
+                [
+                    foregroundDenied,
+                    'https://example.com/1',
+                    'https://example.com/2',
+                    'https://example.com/3',
+                    'https://example.com/4',
+                    backgroundDenied,
+                ],
+                { batchSize: 2, waitBetweenBatchesMillis: 0 },
+            );
+            await waitForAllRequestsToBeAdded;
+
+            expect(onSkippedRequest.mock.calls.map(([skipped]) => skipped)).toEqual([
+                { url: foregroundDenied, reason: 'robotsTxt' },
+                { url: backgroundDenied, reason: 'robotsTxt' },
+            ]);
+            expect(
+                warningSpy.mock.calls
+                    .filter(([message]) => message.includes('robots.txt'))
+                    .map(([, details]) => details),
+            ).toEqual([{ skipped: [foregroundDenied] }, { skipped: [backgroundDenied] }]);
+        });
     });
 
     it('addCrawlDepthRequestGenerator() should generate requests with maxCrawlDepth', async () => {

--- a/test/core/crawlers/basic_crawler.test.ts
+++ b/test/core/crawlers/basic_crawler.test.ts
@@ -619,9 +619,9 @@ describe('BasicCrawler', () => {
 
             expect(addedRequests).toHaveLength(1_000);
             expect(backgroundAddedRequests).toHaveLength(1_000);
-            expect(
-                onSkippedRequest.mock.calls.map(([{ request, reason }]) => ({ url: request.url, reason })),
-            ).toEqual(outOfScope.map((url) => ({ url, reason: 'filters' })));
+            expect(onSkippedRequest.mock.calls.map(([{ request, reason }]) => ({ url: request.url, reason }))).toEqual(
+                outOfScope.map((url) => ({ url, reason: 'filters' })),
+            );
         });
 
         test('background onSkippedRequest rejection rejects the background completion promise', async () => {
@@ -677,9 +677,7 @@ describe('BasicCrawler', () => {
             );
             await waitForAllRequestsToBeAdded;
 
-            expect(
-                onSkippedRequest.mock.calls.map(([{ request, reason }]) => ({ url: request.url, reason })),
-            ).toEqual([
+            expect(onSkippedRequest.mock.calls.map(([{ request, reason }]) => ({ url: request.url, reason }))).toEqual([
                 { url: foregroundDenied, reason: 'robotsTxt' },
                 { url: backgroundDenied, reason: 'robotsTxt' },
             ]);

--- a/test/core/crawlers/basic_crawler.test.ts
+++ b/test/core/crawlers/basic_crawler.test.ts
@@ -654,6 +654,50 @@ describe('BasicCrawler', () => {
             await expect(waitForAllRequestsToBeAdded).rejects.toThrow('onSkippedRequest failed');
         });
 
+        test('a background onSkippedRequest rejection stays handled when nobody awaits the addition', async () => {
+            const reportStarted = Promise.withResolvers<void>();
+            const crawler = new BasicCrawler({
+                requestHandler: async () => {},
+                onSkippedRequest: async () => {
+                    reportStarted.resolve();
+                    throw new Error('onSkippedRequest failed');
+                },
+            });
+
+            const unhandled: unknown[] = [];
+            const collectUnhandled = (reason: unknown) => unhandled.push(reason);
+            process.on('unhandledRejection', collectUnhandled);
+
+            try {
+                // Deliberately dropping `waitForAllRequestsToBeAdded`: that is the default way to call
+                // `addRequests`, and the background skip report rejecting there must not take the process down.
+                await crawler.addRequests(
+                    [
+                        'https://example.com/1',
+                        'https://example.com/2',
+                        'https://example.com/3',
+                        'https://example.com/4',
+                        'https://other.com/no',
+                    ],
+                    {
+                        batchSize: 2,
+                        waitBetweenBatchesMillis: 0,
+                        include: ['https://example.com/**'],
+                    },
+                );
+
+                await reportStarted.promise;
+                // Node only flags a rejection as unhandled once the tick's microtasks have drained.
+                const nextTick = Promise.withResolvers<void>();
+                setImmediate(nextTick.resolve);
+                await nextTick.promise;
+            } finally {
+                process.off('unhandledRejection', collectUnhandled);
+            }
+
+            expect(unhandled).toEqual([]);
+        });
+
         test('drains foreground and background robots.txt skips exactly once', async () => {
             const onSkippedRequest = vitest.fn();
             const crawler = new BasicCrawler({

--- a/test/core/crawlers/basic_crawler.test.ts
+++ b/test/core/crawlers/basic_crawler.test.ts
@@ -598,7 +598,9 @@ describe('BasicCrawler', () => {
             expect(skippedRequests[1].request).toBeInstanceOf(Request);
             expect(skippedRequests[1].request.url).toBe('https://example.com/2/');
         });
+    });
 
+    describe('addRequests() background skip reporting', () => {
         test('reports filtered requests discovered in background batches', async () => {
             const onSkippedRequest = vitest.fn();
             const crawler = new BasicCrawler({
@@ -612,6 +614,7 @@ describe('BasicCrawler', () => {
             const { addedRequests, waitForAllRequestsToBeAdded } = await crawler.addRequests(
                 [...inScope, ...outOfScope],
                 {
+                    waitBetweenBatchesMillis: 0,
                     include: ['https://example.com/**'],
                 },
             );


### PR DESCRIPTION
BasicCrawler now reports requests skipped while addRequests continues beyond the foreground batch. The skipped-request accumulator was previously drained before the background iterator finished, leaving later filtered URLs unreported.

Regression coverage exercises the exact #4072 scenario with 2,000 accepted and 50 filtered URLs, preserves the 1,000-request foreground/background result split, and covers exactly-once ordering, background callback rejection, and robots.txt skips across both drains.

Validated with the full BasicCrawler unit file (154 tests), the @crawlee/basic dependency build closure and standalone compile, and targeted formatting.

Closes #4072