### PR TITLE
docs: document slim Docker images and package manager setup

### DIFF
--- a/docs/guides/docker_browser_js.txt
+++ b/docs/guides/docker_browser_js.txt
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://crawlee.dev/js/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node-playwright-chrome:20
+FROM apify/actor-node-playwright-chrome:24
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.

--- a/docs/guides/docker_browser_ts.txt
+++ b/docs/guides/docker_browser_ts.txt
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://crawlee.dev/js/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node-playwright-chrome:20 AS builder
+FROM apify/actor-node-playwright-chrome:24 AS builder
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.
@@ -19,7 +19,7 @@ COPY --chown=myuser . ./
 RUN npm run build
 
 # Create final image
-FROM apify/actor-node-playwright-chrome:20
+FROM apify/actor-node-playwright-chrome:24
 
 # Copy only built JS files from builder image
 COPY --from=builder --chown=myuser /home/myuser/dist ./dist

--- a/docs/guides/docker_images.mdx
+++ b/docs/guides/docker_images.mdx
@@ -38,7 +38,7 @@ Each image is tagged with up to 2 version tags, depending on the type of the ima
 
 ### Node.js versioning
 
-Our images are built with multiple Node.js versions to ensure backwards compatibility. Currently, Node.js **versions 20, 22, and 24 are supported** (legacy versions still exist, see DockerHub). To select the preferred version, use the appropriate number as the image tag.
+Our images are built with multiple Node.js versions to ensure backwards compatibility. Currently, Node.js **versions 22, 24, and 26 are supported** (legacy versions still exist, see DockerHub). To select the preferred version, use the appropriate number as the image tag.
 
 ```dockerfile
 # Use Node.js 24

--- a/docs/guides/docker_images.mdx
+++ b/docs/guides/docker_images.mdx
@@ -129,17 +129,15 @@ FROM apify/actor-node-playwright-chrome:24
 
 This makes sure the pre-installed version of Puppeteer or Playwright is not re-installed on build. However, this approach is less predictable because you'll get whatever version was latest when the Docker image was built.
 
-### Start with the full image, switch to slim when done
+### Prefer slim images
 
-While developing, use the full image. It comes with `apify`, `crawlee` and `typescript` preinstalled, so you can iterate without worrying about which dependencies your Dockerfile needs to install. Once the crawler is stable and your `package.json` lists everything it needs, switch the tag to the [`-slim` variant](#slim-variants) for a smaller image and faster builds.
+Use the [`-slim` variant](#slim-variants) unless you have a reason not to. Your `package.json` already lists the dependencies your crawler needs, so the preinstalled `apify`, `crawlee` and `typescript` in the full image are redundant and only make it larger and slower to pull.
 
 ```dockerfile
-# Development
-FROM apify/actor-node-playwright-chrome:24-1.60.0
-
-# Production
 FROM apify/actor-node-playwright-chrome:24-1.60.0-slim
 ```
+
+Reach for the full image when you want to run something quickly without maintaining a `package.json`, or when you rely on the exact preinstalled versions of `apify` and `crawlee`.
 
 ## Finding available tags
 

--- a/docs/guides/docker_images.mdx
+++ b/docs/guides/docker_images.mdx
@@ -98,6 +98,17 @@ The images preconfigure the package managers so that:
 - pnpm and yarn install a flat, npm-style `node_modules` (`node-linker=hoisted` for pnpm, `nodeLinker: node-modules` for yarn) instead of a symlinked store or Plug'n'Play, so dependencies resolve without extra loaders.
 - All caches (`NPM_CONFIG_CACHE`, `YARN_CACHE_FOLDER`, pnpm store and cache, `COREPACK_HOME`) live under `/pkg-cache` instead of `$HOME`. The directory only holds throwaway data, so you can `rm -rf /pkg-cache/*` at the end of your `Dockerfile` to reclaim space without touching installed dependencies.
 
+:::note Overriding the linker
+
+These settings are applied through environment variables (`PNPM_CONFIG_NODE_LINKER`, `YARN_NODE_LINKER`), and both pnpm and yarn give environment variables precedence over `.npmrc` / `.yarnrc.yml`. To use a different linker, override the variable in your `Dockerfile` instead of the config file:
+
+```dockerfile
+ENV YARN_NODE_LINKER=pnp
+```
+
+:::
+
+
 ## Best practices
 
 For production crawlers, we recommend pinning both the Node.js version **and** the automation library version in your Dockerfile tag. This ensures reproducible builds and prevents unexpected behavior when new versions are released.

--- a/docs/guides/docker_images.mdx
+++ b/docs/guides/docker_images.mdx
@@ -83,6 +83,21 @@ FROM apify/actor-node-playwright-chrome:24-1.60.0-slim
 
 Since nothing but the automation library is preinstalled, make sure `crawlee` and any other runtime dependencies are listed in your `package.json` and installed in your `Dockerfile`. The [version matching](#recommended-approach-pin-both-versions) rules for the automation library still apply.
 
+## Package managers
+
+All Node.js images ship with npm, and [Corepack](https://github.com/nodejs/corepack) enabled with the latest pnpm preinstalled, so you can use npm, yarn or pnpm out of the box. Add a [`packageManager`](https://nodejs.org/api/packages.html#packagemanager) field to your `package.json` and Corepack will provision the exact version you pin.
+
+```json
+{
+    "packageManager": "pnpm@10.24.0"
+}
+```
+
+The images preconfigure the package managers so that:
+
+- pnpm and yarn install a flat, npm-style `node_modules` (`node-linker=hoisted` for pnpm, `nodeLinker: node-modules` for yarn) instead of a symlinked store or Plug'n'Play, so dependencies resolve without extra loaders.
+- All caches (`NPM_CONFIG_CACHE`, `YARN_CACHE_FOLDER`, pnpm store and cache, `COREPACK_HOME`) live under `/pkg-cache` instead of `$HOME`. The directory only holds throwaway data, so you can `rm -rf /pkg-cache/*` at the end of your `Dockerfile` to reclaim space without touching installed dependencies.
+
 ## Best practices
 
 For production crawlers, we recommend pinning both the Node.js version **and** the automation library version in your Dockerfile tag. This ensures reproducible builds and prevents unexpected behavior when new versions are released.

--- a/docs/guides/docker_images.mdx
+++ b/docs/guides/docker_images.mdx
@@ -103,6 +103,9 @@ The images preconfigure the package managers so that:
 These settings are applied through environment variables (`PNPM_CONFIG_NODE_LINKER`, `YARN_NODE_LINKER`), and both pnpm and yarn give environment variables precedence over `.npmrc` / `.yarnrc.yml`. To use a different linker, override the variable in your `Dockerfile` instead of the config file:
 
 ```dockerfile
+# https://pnpm.io/settings#nodelinker
+ENV PNPM_CONFIG_NODE_LINKER=isolated
+# https://yarnpkg.com/configuration/yarnrc#nodeLinker
 ENV YARN_NODE_LINKER=pnp
 ```
 

--- a/docs/guides/docker_images.mdx
+++ b/docs/guides/docker_images.mdx
@@ -129,6 +129,18 @@ FROM apify/actor-node-playwright-chrome:24
 
 This makes sure the pre-installed version of Puppeteer or Playwright is not re-installed on build. However, this approach is less predictable because you'll get whatever version was latest when the Docker image was built.
 
+### Start with the full image, switch to slim when done
+
+While developing, use the full image. It comes with `apify`, `crawlee` and `typescript` preinstalled, so you can iterate without worrying about which dependencies your Dockerfile needs to install. Once the crawler is stable and your `package.json` lists everything it needs, switch the tag to the [`-slim` variant](#slim-variants) for a smaller image and faster builds.
+
+```dockerfile
+# Development
+FROM apify/actor-node-playwright-chrome:24-1.60.0
+
+# Production
+FROM apify/actor-node-playwright-chrome:24-1.60.0-slim
+```
+
 ## Finding available tags
 
 To see all available tags for each image, you can visit Docker Hub directly:

--- a/docs/guides/docker_images.mdx
+++ b/docs/guides/docker_images.mdx
@@ -69,7 +69,7 @@ FROM apify/actor-node-playwright-chrome:24-1.60.0-beta
 
 ### Slim variants
 
-Every Node.js image is also published as a slim variant, with a `-slim` suffix appended to the tag (e.g. `24-slim`, `24-1.60.0-slim`, `24-beta-slim`). Slim images do not preinstall `apify`, `crawlee` or `typescript`. They only ship the browser automation library the image is built around (for example `puppeteer`, `playwright-chromium`, or `camoufox-js` with `impit`), and `apify/actor-node:24-slim` ships no npm packages at all. This makes them smaller and faster to pull, and your project's `package.json` is the single source of truth for dependency versions.
+Every Node.js image is also published as a slim variant, with a `-slim` suffix appended to the tag (e.g. `24-slim`, `24-1.60.0-slim`, `24-beta-slim`). Slim images do not preinstall `apify`, `crawlee` or `typescript`. They only ship the browser automation library the image is built around (for example `puppeteer`, `playwright`, or `camoufox-js` with `impit`), and `apify/actor-node:24-slim` ships no npm packages at all. This makes them smaller and faster to pull, and your project's `package.json` is the single source of truth for dependency versions.
 
 ```dockerfile
 # No preinstalled packages, bring your own dependencies.

--- a/docs/guides/docker_images.mdx
+++ b/docs/guides/docker_images.mdx
@@ -67,6 +67,22 @@ FROM apify/actor-node:24-beta
 FROM apify/actor-node-playwright-chrome:24-1.60.0-beta
 ```
 
+### Slim variants
+
+Every Node.js image is also published as a slim variant, with a `-slim` suffix appended to the tag (e.g. `24-slim`, `24-1.60.0-slim`, `24-beta-slim`). Slim images do not preinstall `apify`, `crawlee` or `typescript`. They only ship the browser automation library the image is built around (for example `puppeteer`, `playwright-chromium`, or `camoufox-js` with `impit`), and `apify/actor-node:24-slim` ships no npm packages at all. This makes them smaller and faster to pull, and your project's `package.json` is the single source of truth for dependency versions.
+
+```dockerfile
+# No preinstalled packages, bring your own dependencies.
+FROM apify/actor-node:24-slim
+```
+
+```dockerfile
+# Only Playwright (Chromium) is preinstalled, pinned to match the bundled browser.
+FROM apify/actor-node-playwright-chrome:24-1.60.0-slim
+```
+
+Since nothing but the automation library is preinstalled, make sure `crawlee` and any other runtime dependencies are listed in your `package.json` and installed in your `Dockerfile`. The [version matching](#recommended-approach-pin-both-versions) rules for the automation library still apply.
+
 ## Best practices
 
 For production crawlers, we recommend pinning both the Node.js version **and** the automation library version in your Dockerfile tag. This ensures reproducible builds and prevents unexpected behavior when new versions are released.
@@ -132,7 +148,7 @@ curl -s "https://registry.hub.docker.com/v2/repositories/apify/actor-node-playwr
 
 ### Warning about image size
 
-Browsers are huge. If you don't need them all in your image, it's better to use a smaller image with only the one browser you need.
+Browsers are huge. If you don't need them all in your image, it's better to use a smaller image with only the one browser you need. If you don't need the preinstalled `apify` and `crawlee` packages either, use the [`-slim` variant](#slim-variants).
 
 You should also be careful when installing new dependencies. Nothing prevents you from installing Playwright into the`actor-node-puppeteer-chrome` image, but the resulting image will be about 3 times larger and extremely slow to download and build.
 

--- a/docs/guides/docker_images.mdx
+++ b/docs/guides/docker_images.mdx
@@ -85,7 +85,7 @@ Since nothing but the automation library is preinstalled, make sure `crawlee` an
 
 ## Package managers
 
-All Node.js images ship with npm, and [Corepack](https://github.com/nodejs/corepack) enabled with the latest pnpm preinstalled, so you can use npm, yarn or pnpm out of the box. Add a [`packageManager`](https://nodejs.org/api/packages.html#packagemanager) field to your `package.json` and Corepack will provision the exact version you pin.
+All Node.js images ship with npm and have [Corepack](https://github.com/nodejs/corepack) enabled, so you can use yarn or pnpm as well. Neither is preinstalled: add a [`packageManager`](https://nodejs.org/api/packages.html#packagemanager) field to your `package.json` and Corepack downloads and uses the exact version you pin.
 
 ```json
 {

--- a/docs/guides/docker_images.mdx
+++ b/docs/guides/docker_images.mdx
@@ -30,6 +30,22 @@ Browsers are pretty big, so we try to provide a wide variety of images to suit t
 - [`apify/actor-node-playwright-firefox`](#actor-node-playwright-firefox)
 - [`apify/actor-node-playwright-webkit`](#actor-node-playwright-webkit)
 
+Every image is published in two flavours. The full image preinstalls `apify`, `crawlee` and `typescript`. The `-slim` variant (e.g. `24-slim`, `24-1.60.0-slim`, `24-beta-slim`) only ships the browser automation library the image is built around (for example `puppeteer`, `playwright`, or `camoufox-js` with `impit`), and `apify/actor-node:24-slim` ships no npm packages at all. Slim images are smaller and faster to pull, and your `package.json` is the single source of truth for dependency versions.
+
+Use the slim variant unless you have a reason not to. Reach for the full image when you want to run something quickly without maintaining a `package.json`, or when you rely on the exact preinstalled versions of `apify` and `crawlee`.
+
+```dockerfile
+# No preinstalled packages, bring your own dependencies.
+FROM apify/actor-node:24-slim
+```
+
+```dockerfile
+# Only Playwright (Chromium) is preinstalled, pinned to match the bundled browser.
+FROM apify/actor-node-playwright-chrome:24-1.60.0-slim
+```
+
+Since nothing but the automation library is preinstalled, make sure `crawlee` and any other runtime dependencies are listed in your `package.json` and installed in your `Dockerfile`. The [version matching](#recommended-approach-pin-both-versions) rules for the automation library still apply.
+
 ## Versioning
 
 Each image is tagged with up to 2 version tags, depending on the type of the image. One for Node.js version and second for pre-installed web automation library version. If you use the image name without a version tag, you'll always get the latest available version.
@@ -67,23 +83,7 @@ FROM apify/actor-node:24-beta
 FROM apify/actor-node-playwright-chrome:24-1.60.0-beta
 ```
 
-### Slim variants
-
-Every Node.js image is also published as a slim variant, with a `-slim` suffix appended to the tag (e.g. `24-slim`, `24-1.60.0-slim`, `24-beta-slim`). Slim images do not preinstall `apify`, `crawlee` or `typescript`. They only ship the browser automation library the image is built around (for example `puppeteer`, `playwright`, or `camoufox-js` with `impit`), and `apify/actor-node:24-slim` ships no npm packages at all. This makes them smaller and faster to pull, and your project's `package.json` is the single source of truth for dependency versions.
-
-```dockerfile
-# No preinstalled packages, bring your own dependencies.
-FROM apify/actor-node:24-slim
-```
-
-```dockerfile
-# Only Playwright (Chromium) is preinstalled, pinned to match the bundled browser.
-FROM apify/actor-node-playwright-chrome:24-1.60.0-slim
-```
-
-Since nothing but the automation library is preinstalled, make sure `crawlee` and any other runtime dependencies are listed in your `package.json` and installed in your `Dockerfile`. The [version matching](#recommended-approach-pin-both-versions) rules for the automation library still apply.
-
-## Package managers
+## Node.js package managers
 
 All Node.js images ship with npm and have [Corepack](https://github.com/nodejs/corepack) enabled, so you can use yarn or pnpm as well. Neither is preinstalled: add a [`packageManager`](https://nodejs.org/api/packages.html#packagemanager) field to your `package.json` and Corepack downloads and uses the exact version you pin.
 
@@ -96,11 +96,11 @@ All Node.js images ship with npm and have [Corepack](https://github.com/nodejs/c
 The images preconfigure the package managers so that:
 
 - pnpm and yarn install a flat, npm-style `node_modules` (`node-linker=hoisted` for pnpm, `nodeLinker: node-modules` for yarn) instead of a symlinked store or Plug'n'Play, so dependencies resolve without extra loaders.
-- All caches (`NPM_CONFIG_CACHE`, `YARN_CACHE_FOLDER`, pnpm store and cache, `COREPACK_HOME`) live under `/pkg-cache` instead of `$HOME`. The directory only holds throwaway data, so you can `rm -rf /pkg-cache/*` at the end of your `Dockerfile` to reclaim space without touching installed dependencies.
+- The yarn and pnpm caches (`YARN_CACHE_FOLDER`, `YARN_GLOBAL_FOLDER`, `PNPM_CONFIG_STORE_DIR`, `PNPM_CONFIG_CACHE_DIR`) and the Corepack cache (`COREPACK_HOME`) live under `/pkg-cache`. npm keeps its default `~/.npm` cache. Both directories only hold throwaway data, so you can `rm -rf /pkg-cache/* ~/.npm` at the end of your `Dockerfile` to reclaim space without touching installed dependencies.
 
 :::note Overriding the linker
 
-These settings are applied through environment variables (`PNPM_CONFIG_NODE_LINKER`, `YARN_NODE_LINKER`), and both pnpm and yarn give environment variables precedence over `.npmrc` / `.yarnrc.yml`. To use a different linker, override the variable in your `Dockerfile` instead of the config file:
+The images set the linker through the `PNPM_CONFIG_NODE_LINKER` and `YARN_NODE_LINKER` environment variables. Both pnpm and yarn give environment variables precedence over `.npmrc` or `.yarnrc.yml`, so a config file alone does not change the linker. To use a different one, override the variable in your `Dockerfile`:
 
 ```dockerfile
 # https://pnpm.io/settings#nodelinker
@@ -158,16 +158,6 @@ FROM apify/actor-node-playwright-chrome:24
 
 This makes sure the pre-installed version of Puppeteer or Playwright is not re-installed on build. However, this approach is less predictable because you'll get whatever version was latest when the Docker image was built.
 
-### Prefer slim images
-
-Use the [`-slim` variant](#slim-variants) unless you have a reason not to. Your `package.json` already lists the dependencies your crawler needs, so the preinstalled `apify`, `crawlee` and `typescript` in the full image are redundant and only make it larger and slower to pull.
-
-```dockerfile
-FROM apify/actor-node-playwright-chrome:24-1.60.0-slim
-```
-
-Reach for the full image when you want to run something quickly without maintaining a `package.json`, or when you rely on the exact preinstalled versions of `apify` and `crawlee`.
-
 ## Finding available tags
 
 To see all available tags for each image, you can visit Docker Hub directly:
@@ -187,7 +177,7 @@ curl -s "https://registry.hub.docker.com/v2/repositories/apify/actor-node-playwr
 
 ### Warning about image size
 
-Browsers are huge. If you don't need them all in your image, it's better to use a smaller image with only the one browser you need. If you don't need the preinstalled `apify` and `crawlee` packages either, use the [`-slim` variant](#slim-variants).
+Browsers are huge. If you don't need them all in your image, it's better to use a smaller image with only the one browser you need. If you don't need the preinstalled `apify` and `crawlee` packages either, use the [`-slim` variant](#overview).
 
 You should also be careful when installing new dependencies. Nothing prevents you from installing Playwright into the`actor-node-puppeteer-chrome` image, but the resulting image will be about 3 times larger and extremely slow to download and build.
 

--- a/docs/guides/docker_images.mdx
+++ b/docs/guides/docker_images.mdx
@@ -29,6 +29,7 @@ Browsers are pretty big, so we try to provide a wide variety of images to suit t
 - [`apify/actor-node-playwright-chrome`](#actor-node-playwright-chrome)
 - [`apify/actor-node-playwright-firefox`](#actor-node-playwright-firefox)
 - [`apify/actor-node-playwright-webkit`](#actor-node-playwright-webkit)
+- [`apify/actor-node-playwright-camoufox`](#actor-node-playwright-camoufox)
 
 Every image is published in two flavours. The full image preinstalls `apify`, `crawlee` and `typescript`. The `-slim` variant (e.g. `24-slim`, `24-1.60.0-slim`, `24-beta-slim`) only ships the browser automation library the image is built around (for example `puppeteer`, `playwright`, or `camoufox-js` with `impit`), and `apify/actor-node:24-slim` ships no npm packages at all. Slim images are smaller and faster to pull, and your `package.json` is the single source of truth for dependency versions.
 
@@ -241,6 +242,14 @@ pre-installed.
 
 ```dockerfile
 FROM apify/actor-node-playwright-webkit:24
+```
+
+### actor-node-playwright-camoufox
+
+Same idea as [`actor-node-playwright-firefox`](#actor-node-playwright-firefox), but with [Camoufox](https://camoufox.com/), a Firefox fork hardened against bot detection, pre-installed instead of Firefox. The image also ships the [`camoufox-js`](https://github.com/apify/camoufox-js) and [`impit`](https://github.com/apify/impit) packages.
+
+```dockerfile
+FROM apify/actor-node-playwright-camoufox:24
 ```
 
 ## Example Dockerfile

--- a/docs/guides/docker_node_js.txt
+++ b/docs/guides/docker_node_js.txt
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://crawlee.dev/js/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node:20
+FROM apify/actor-node:24
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.

--- a/docs/guides/docker_node_ts.txt
+++ b/docs/guides/docker_node_ts.txt
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://crawlee.dev/js/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node:20 AS builder
+FROM apify/actor-node:24 AS builder
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.
@@ -19,7 +19,7 @@ COPY . ./
 RUN npm run build
 
 # Create final image
-FROM apify/actor-node:20
+FROM apify/actor-node:24
 
 # Copy only built JS files from builder image
 COPY --from=builder /usr/src/app/dist ./dist

--- a/website/versioned_docs/version-3.18/guides/docker_browser_js.txt
+++ b/website/versioned_docs/version-3.18/guides/docker_browser_js.txt
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://crawlee.dev/js/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node-playwright-chrome:20
+FROM apify/actor-node-playwright-chrome:24
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.

--- a/website/versioned_docs/version-3.18/guides/docker_browser_ts.txt
+++ b/website/versioned_docs/version-3.18/guides/docker_browser_ts.txt
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://crawlee.dev/js/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node-playwright-chrome:20 AS builder
+FROM apify/actor-node-playwright-chrome:24 AS builder
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.
@@ -19,7 +19,7 @@ COPY --chown=myuser . ./
 RUN npm run build
 
 # Create final image
-FROM apify/actor-node-playwright-chrome:20
+FROM apify/actor-node-playwright-chrome:24
 
 # Copy only built JS files from builder image
 COPY --from=builder --chown=myuser /home/myuser/dist ./dist

--- a/website/versioned_docs/version-3.18/guides/docker_images.mdx
+++ b/website/versioned_docs/version-3.18/guides/docker_images.mdx
@@ -38,7 +38,7 @@ Each image is tagged with up to 2 version tags, depending on the type of the ima
 
 ### Node.js versioning
 
-Our images are built with multiple Node.js versions to ensure backwards compatibility. Currently, Node.js **versions 20, 22, and 24 are supported** (legacy versions still exist, see DockerHub). To select the preferred version, use the appropriate number as the image tag.
+Our images are built with multiple Node.js versions to ensure backwards compatibility. Currently, Node.js **versions 22, 24, and 26 are supported** (legacy versions still exist, see DockerHub). To select the preferred version, use the appropriate number as the image tag.
 
 ```dockerfile
 # Use Node.js 24
@@ -66,6 +66,51 @@ FROM apify/actor-node:24-beta
 # With library version.
 FROM apify/actor-node-playwright-chrome:24-1.60.0-beta
 ```
+
+### Slim variants
+
+Every Node.js image is also published as a slim variant, with a `-slim` suffix appended to the tag (e.g. `24-slim`, `24-1.60.0-slim`, `24-beta-slim`). Slim images do not preinstall `apify`, `crawlee` or `typescript`. They only ship the browser automation library the image is built around (for example `puppeteer`, `playwright`, or `camoufox-js` with `impit`), and `apify/actor-node:24-slim` ships no npm packages at all. This makes them smaller and faster to pull, and your project's `package.json` is the single source of truth for dependency versions.
+
+```dockerfile
+# No preinstalled packages, bring your own dependencies.
+FROM apify/actor-node:24-slim
+```
+
+```dockerfile
+# Only Playwright (Chromium) is preinstalled, pinned to match the bundled browser.
+FROM apify/actor-node-playwright-chrome:24-1.60.0-slim
+```
+
+Since nothing but the automation library is preinstalled, make sure `crawlee` and any other runtime dependencies are listed in your `package.json` and installed in your `Dockerfile`. The [version matching](#recommended-approach-pin-both-versions) rules for the automation library still apply.
+
+## Package managers
+
+All Node.js images ship with npm, and [Corepack](https://github.com/nodejs/corepack) enabled with the latest pnpm preinstalled, so you can use npm, yarn or pnpm out of the box. Add a [`packageManager`](https://nodejs.org/api/packages.html#packagemanager) field to your `package.json` and Corepack will provision the exact version you pin.
+
+```json
+{
+    "packageManager": "pnpm@10.24.0"
+}
+```
+
+The images preconfigure the package managers so that:
+
+- pnpm and yarn install a flat, npm-style `node_modules` (`node-linker=hoisted` for pnpm, `nodeLinker: node-modules` for yarn) instead of a symlinked store or Plug'n'Play, so dependencies resolve without extra loaders.
+- All caches (`NPM_CONFIG_CACHE`, `YARN_CACHE_FOLDER`, pnpm store and cache, `COREPACK_HOME`) live under `/pkg-cache` instead of `$HOME`. The directory only holds throwaway data, so you can `rm -rf /pkg-cache/*` at the end of your `Dockerfile` to reclaim space without touching installed dependencies.
+
+:::note Overriding the linker
+
+These settings are applied through environment variables (`PNPM_CONFIG_NODE_LINKER`, `YARN_NODE_LINKER`), and both pnpm and yarn give environment variables precedence over `.npmrc` / `.yarnrc.yml`. To use a different linker, override the variable in your `Dockerfile` instead of the config file:
+
+```dockerfile
+# https://pnpm.io/settings#nodelinker
+ENV PNPM_CONFIG_NODE_LINKER=isolated
+# https://yarnpkg.com/configuration/yarnrc#nodeLinker
+ENV YARN_NODE_LINKER=pnp
+```
+
+:::
+
 
 ## Best practices
 
@@ -113,6 +158,16 @@ FROM apify/actor-node-playwright-chrome:24
 
 This makes sure the pre-installed version of Puppeteer or Playwright is not re-installed on build. However, this approach is less predictable because you'll get whatever version was latest when the Docker image was built.
 
+### Prefer slim images
+
+Use the [`-slim` variant](#slim-variants) unless you have a reason not to. Your `package.json` already lists the dependencies your crawler needs, so the preinstalled `apify`, `crawlee` and `typescript` in the full image are redundant and only make it larger and slower to pull.
+
+```dockerfile
+FROM apify/actor-node-playwright-chrome:24-1.60.0-slim
+```
+
+Reach for the full image when you want to run something quickly without maintaining a `package.json`, or when you rely on the exact preinstalled versions of `apify` and `crawlee`.
+
 ## Finding available tags
 
 To see all available tags for each image, you can visit Docker Hub directly:
@@ -132,7 +187,7 @@ curl -s "https://registry.hub.docker.com/v2/repositories/apify/actor-node-playwr
 
 ### Warning about image size
 
-Browsers are huge. If you don't need them all in your image, it's better to use a smaller image with only the one browser you need.
+Browsers are huge. If you don't need them all in your image, it's better to use a smaller image with only the one browser you need. If you don't need the preinstalled `apify` and `crawlee` packages either, use the [`-slim` variant](#slim-variants).
 
 You should also be careful when installing new dependencies. Nothing prevents you from installing Playwright into the`actor-node-puppeteer-chrome` image, but the resulting image will be about 3 times larger and extremely slow to download and build.
 

--- a/website/versioned_docs/version-3.18/guides/docker_images.mdx
+++ b/website/versioned_docs/version-3.18/guides/docker_images.mdx
@@ -85,7 +85,7 @@ Since nothing but the automation library is preinstalled, make sure `crawlee` an
 
 ## Package managers
 
-All Node.js images ship with npm, and [Corepack](https://github.com/nodejs/corepack) enabled with the latest pnpm preinstalled, so you can use npm, yarn or pnpm out of the box. Add a [`packageManager`](https://nodejs.org/api/packages.html#packagemanager) field to your `package.json` and Corepack will provision the exact version you pin.
+All Node.js images ship with npm and have [Corepack](https://github.com/nodejs/corepack) enabled, so you can use yarn or pnpm as well. Neither is preinstalled: add a [`packageManager`](https://nodejs.org/api/packages.html#packagemanager) field to your `package.json` and Corepack downloads and uses the exact version you pin.
 
 ```json
 {

--- a/website/versioned_docs/version-3.18/guides/docker_images.mdx
+++ b/website/versioned_docs/version-3.18/guides/docker_images.mdx
@@ -30,6 +30,22 @@ Browsers are pretty big, so we try to provide a wide variety of images to suit t
 - [`apify/actor-node-playwright-firefox`](#actor-node-playwright-firefox)
 - [`apify/actor-node-playwright-webkit`](#actor-node-playwright-webkit)
 
+Every image is published in two flavours. The full image preinstalls `apify`, `crawlee` and `typescript`. The `-slim` variant (e.g. `24-slim`, `24-1.60.0-slim`, `24-beta-slim`) only ships the browser automation library the image is built around (for example `puppeteer`, `playwright`, or `camoufox-js` with `impit`), and `apify/actor-node:24-slim` ships no npm packages at all. Slim images are smaller and faster to pull, and your `package.json` is the single source of truth for dependency versions.
+
+Use the slim variant unless you have a reason not to. Reach for the full image when you want to run something quickly without maintaining a `package.json`, or when you rely on the exact preinstalled versions of `apify` and `crawlee`.
+
+```dockerfile
+# No preinstalled packages, bring your own dependencies.
+FROM apify/actor-node:24-slim
+```
+
+```dockerfile
+# Only Playwright (Chromium) is preinstalled, pinned to match the bundled browser.
+FROM apify/actor-node-playwright-chrome:24-1.60.0-slim
+```
+
+Since nothing but the automation library is preinstalled, make sure `crawlee` and any other runtime dependencies are listed in your `package.json` and installed in your `Dockerfile`. The [version matching](#recommended-approach-pin-both-versions) rules for the automation library still apply.
+
 ## Versioning
 
 Each image is tagged with up to 2 version tags, depending on the type of the image. One for Node.js version and second for pre-installed web automation library version. If you use the image name without a version tag, you'll always get the latest available version.
@@ -67,23 +83,7 @@ FROM apify/actor-node:24-beta
 FROM apify/actor-node-playwright-chrome:24-1.60.0-beta
 ```
 
-### Slim variants
-
-Every Node.js image is also published as a slim variant, with a `-slim` suffix appended to the tag (e.g. `24-slim`, `24-1.60.0-slim`, `24-beta-slim`). Slim images do not preinstall `apify`, `crawlee` or `typescript`. They only ship the browser automation library the image is built around (for example `puppeteer`, `playwright`, or `camoufox-js` with `impit`), and `apify/actor-node:24-slim` ships no npm packages at all. This makes them smaller and faster to pull, and your project's `package.json` is the single source of truth for dependency versions.
-
-```dockerfile
-# No preinstalled packages, bring your own dependencies.
-FROM apify/actor-node:24-slim
-```
-
-```dockerfile
-# Only Playwright (Chromium) is preinstalled, pinned to match the bundled browser.
-FROM apify/actor-node-playwright-chrome:24-1.60.0-slim
-```
-
-Since nothing but the automation library is preinstalled, make sure `crawlee` and any other runtime dependencies are listed in your `package.json` and installed in your `Dockerfile`. The [version matching](#recommended-approach-pin-both-versions) rules for the automation library still apply.
-
-## Package managers
+## Node.js package managers
 
 All Node.js images ship with npm and have [Corepack](https://github.com/nodejs/corepack) enabled, so you can use yarn or pnpm as well. Neither is preinstalled: add a [`packageManager`](https://nodejs.org/api/packages.html#packagemanager) field to your `package.json` and Corepack downloads and uses the exact version you pin.
 
@@ -96,11 +96,11 @@ All Node.js images ship with npm and have [Corepack](https://github.com/nodejs/c
 The images preconfigure the package managers so that:
 
 - pnpm and yarn install a flat, npm-style `node_modules` (`node-linker=hoisted` for pnpm, `nodeLinker: node-modules` for yarn) instead of a symlinked store or Plug'n'Play, so dependencies resolve without extra loaders.
-- All caches (`NPM_CONFIG_CACHE`, `YARN_CACHE_FOLDER`, pnpm store and cache, `COREPACK_HOME`) live under `/pkg-cache` instead of `$HOME`. The directory only holds throwaway data, so you can `rm -rf /pkg-cache/*` at the end of your `Dockerfile` to reclaim space without touching installed dependencies.
+- The yarn and pnpm caches (`YARN_CACHE_FOLDER`, `YARN_GLOBAL_FOLDER`, `PNPM_CONFIG_STORE_DIR`, `PNPM_CONFIG_CACHE_DIR`) and the Corepack cache (`COREPACK_HOME`) live under `/pkg-cache`. npm keeps its default `~/.npm` cache. Both directories only hold throwaway data, so you can `rm -rf /pkg-cache/* ~/.npm` at the end of your `Dockerfile` to reclaim space without touching installed dependencies.
 
 :::note Overriding the linker
 
-These settings are applied through environment variables (`PNPM_CONFIG_NODE_LINKER`, `YARN_NODE_LINKER`), and both pnpm and yarn give environment variables precedence over `.npmrc` / `.yarnrc.yml`. To use a different linker, override the variable in your `Dockerfile` instead of the config file:
+The images set the linker through the `PNPM_CONFIG_NODE_LINKER` and `YARN_NODE_LINKER` environment variables. Both pnpm and yarn give environment variables precedence over `.npmrc` or `.yarnrc.yml`, so a config file alone does not change the linker. To use a different one, override the variable in your `Dockerfile`:
 
 ```dockerfile
 # https://pnpm.io/settings#nodelinker
@@ -158,16 +158,6 @@ FROM apify/actor-node-playwright-chrome:24
 
 This makes sure the pre-installed version of Puppeteer or Playwright is not re-installed on build. However, this approach is less predictable because you'll get whatever version was latest when the Docker image was built.
 
-### Prefer slim images
-
-Use the [`-slim` variant](#slim-variants) unless you have a reason not to. Your `package.json` already lists the dependencies your crawler needs, so the preinstalled `apify`, `crawlee` and `typescript` in the full image are redundant and only make it larger and slower to pull.
-
-```dockerfile
-FROM apify/actor-node-playwright-chrome:24-1.60.0-slim
-```
-
-Reach for the full image when you want to run something quickly without maintaining a `package.json`, or when you rely on the exact preinstalled versions of `apify` and `crawlee`.
-
 ## Finding available tags
 
 To see all available tags for each image, you can visit Docker Hub directly:
@@ -187,7 +177,7 @@ curl -s "https://registry.hub.docker.com/v2/repositories/apify/actor-node-playwr
 
 ### Warning about image size
 
-Browsers are huge. If you don't need them all in your image, it's better to use a smaller image with only the one browser you need. If you don't need the preinstalled `apify` and `crawlee` packages either, use the [`-slim` variant](#slim-variants).
+Browsers are huge. If you don't need them all in your image, it's better to use a smaller image with only the one browser you need. If you don't need the preinstalled `apify` and `crawlee` packages either, use the [`-slim` variant](#overview).
 
 You should also be careful when installing new dependencies. Nothing prevents you from installing Playwright into the`actor-node-puppeteer-chrome` image, but the resulting image will be about 3 times larger and extremely slow to download and build.
 

--- a/website/versioned_docs/version-3.18/guides/docker_images.mdx
+++ b/website/versioned_docs/version-3.18/guides/docker_images.mdx
@@ -29,6 +29,7 @@ Browsers are pretty big, so we try to provide a wide variety of images to suit t
 - [`apify/actor-node-playwright-chrome`](#actor-node-playwright-chrome)
 - [`apify/actor-node-playwright-firefox`](#actor-node-playwright-firefox)
 - [`apify/actor-node-playwright-webkit`](#actor-node-playwright-webkit)
+- [`apify/actor-node-playwright-camoufox`](#actor-node-playwright-camoufox)
 
 Every image is published in two flavours. The full image preinstalls `apify`, `crawlee` and `typescript`. The `-slim` variant (e.g. `24-slim`, `24-1.60.0-slim`, `24-beta-slim`) only ships the browser automation library the image is built around (for example `puppeteer`, `playwright`, or `camoufox-js` with `impit`), and `apify/actor-node:24-slim` ships no npm packages at all. Slim images are smaller and faster to pull, and your `package.json` is the single source of truth for dependency versions.
 
@@ -241,6 +242,14 @@ pre-installed.
 
 ```dockerfile
 FROM apify/actor-node-playwright-webkit:24
+```
+
+### actor-node-playwright-camoufox
+
+Same idea as [`actor-node-playwright-firefox`](#actor-node-playwright-firefox), but with [Camoufox](https://camoufox.com/), a Firefox fork hardened against bot detection, pre-installed instead of Firefox. The image also ships the [`camoufox-js`](https://github.com/apify/camoufox-js) and [`impit`](https://github.com/apify/impit) packages.
+
+```dockerfile
+FROM apify/actor-node-playwright-camoufox:24
 ```
 
 ## Example Dockerfile

--- a/website/versioned_docs/version-3.18/guides/docker_node_js.txt
+++ b/website/versioned_docs/version-3.18/guides/docker_node_js.txt
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://crawlee.dev/js/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node:20
+FROM apify/actor-node:24
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.

--- a/website/versioned_docs/version-3.18/guides/docker_node_ts.txt
+++ b/website/versioned_docs/version-3.18/guides/docker_node_ts.txt
@@ -1,7 +1,7 @@
 # Specify the base Docker image. You can read more about
 # the available images at https://crawlee.dev/js/docs/guides/docker-images
 # You can also use any other image from Docker Hub.
-FROM apify/actor-node:20 AS builder
+FROM apify/actor-node:24 AS builder
 
 # Copy just package.json and package-lock.json
 # to speed up the build using Docker layer cache.
@@ -19,7 +19,7 @@ COPY . ./
 RUN npm run build
 
 # Create final image
-FROM apify/actor-node:20
+FROM apify/actor-node:24
 
 # Copy only built JS files from builder image
 COPY --from=builder /usr/src/app/dist ./dist


### PR DESCRIPTION
Updates the *Running in Docker* guide to match the current `apify/apify-actor-docker` images:

- Document the `-slim` tag variants (no preinstalled `apify`/`crawlee`/`typescript`, only the automation library the image is built around) and recommend them by default.
- New *Package managers* section: Corepack enabled (no package manager besides npm preinstalled), `packageManager` support, flat `node_modules` linker config, and the shared `/pkg-cache` location, plus how to override the linker via `ENV` since env vars take precedence over `.npmrc`/`.yarnrc.yml`.
- Supported Node.js versions are now 22, 24 and 26; example Dockerfiles bumped to `:24`.

[🤖] Claude Code using Fable 5