### PR TITLE
feat(utils): add structured data extractor

### DIFF
--- a/packages/crawlee/src/index.ts
+++ b/packages/crawlee/src/index.ts
@@ -1,7 +1,7 @@
 import { log } from '@crawlee/core';
 import { playwrightUtils } from '@crawlee/playwright';
 import { puppeteerUtils } from '@crawlee/puppeteer';
-import { downloadListOfUrls, parseOpenGraph, sleep, social } from '@crawlee/utils';
+import { downloadListOfUrls, extractStructuredData, parseOpenGraph, sleep, social } from '@crawlee/utils';
 
 export * from '@crawlee/core';
 export * from '@crawlee/utils';
@@ -24,4 +24,5 @@ export const utils = {
     sleep,
     downloadListOfUrls,
     parseOpenGraph,
+    extractStructuredData,
 };

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -7,4 +7,5 @@ export * as social from './internals/social.js';
 export * from './internals/open_graph_parser.js';
 export * from './internals/robots.js';
 export * from './internals/sitemap.js';
+export * from './internals/structured-data.js';
 export * from './internals/validation.js';

--- a/packages/utils/src/internals/structured-data.ts
+++ b/packages/utils/src/internals/structured-data.ts
@@ -1,0 +1,206 @@
+import type { AnyNode, Element } from 'domhandler';
+import type { CheerioAPI } from 'cheerio';
+
+export type MicrodataValue = string | MicrodataItem;
+
+export interface MicrodataItem {
+    type?: string[];
+    id?: string;
+    properties: Record<string, MicrodataValue | MicrodataValue[]>;
+}
+
+export interface StructuredData {
+    jsonLd: unknown[];
+    microdata: MicrodataItem[];
+}
+
+const URL_VALUE_TAGS = new Set(['a', 'area', 'link']);
+const SRC_VALUE_TAGS = new Set(['audio', 'embed', 'iframe', 'img', 'source', 'track', 'video']);
+
+/**
+ * Extracts schema.org structured data from HTML.
+ *
+ * The helper reads JSON-LD scripts and microdata (`itemscope` / `itemprop`) from
+ * the same document. Pass an existing Cheerio object to avoid parsing HTML twice.
+ */
+export async function extractStructuredData(htmlOrCheerioElement: string | CheerioAPI): Promise<StructuredData> {
+    const { load } = await import('cheerio');
+    const $ = typeof htmlOrCheerioElement === 'function' ? htmlOrCheerioElement : load(htmlOrCheerioElement);
+
+    return {
+        jsonLd: extractJsonLd($),
+        microdata: extractMicrodata($),
+    };
+}
+
+function extractJsonLd($: CheerioAPI): unknown[] {
+    return $('script[type]')
+        .toArray()
+        .filter((element) => {
+            const type = ($(element).attr('type') ?? '').toLowerCase().split(';', 1)[0].trim();
+            return type === 'application/ld+json';
+        })
+        .flatMap((element) => {
+            const json = $(element).text().trim();
+
+            if (!json) {
+                return [];
+            }
+
+            try {
+                const parsed = JSON.parse(json) as unknown;
+                return Array.isArray(parsed) ? parsed : [parsed];
+            } catch {
+                return [];
+            }
+        });
+}
+
+function extractMicrodata($: CheerioAPI): MicrodataItem[] {
+    return $('[itemscope]')
+        .toArray()
+        .filter((element) => !$(element).is('[itemprop]'))
+        .map((element) => parseMicrodataItem($, element));
+}
+
+function parseMicrodataItem($: CheerioAPI, element: Element, seen = new Set<Element>()): MicrodataItem {
+    if (seen.has(element)) {
+        return { properties: {} };
+    }
+
+    seen.add(element);
+
+    return {
+        ...optionalArray('type', splitAttribute($(element).attr('itemtype'))),
+        ...optionalString('id', $(element).attr('itemid')),
+        properties: collectProperties($, element, seen),
+    };
+}
+
+function collectProperties(
+    $: CheerioAPI,
+    scopeElement: Element,
+    seen: Set<Element>,
+): Record<string, MicrodataValue | MicrodataValue[]> {
+    const properties: Record<string, MicrodataValue | MicrodataValue[]> = {};
+    const propertyElements = collectPropertyElements($, scopeElement);
+
+    for (const element of propertyElements) {
+        const names = splitAttribute($(element).attr('itemprop'));
+        const value = getPropertyValue($, element, seen);
+
+        for (const name of names) {
+            addProperty(properties, name, value);
+        }
+    }
+
+    return properties;
+}
+
+function collectPropertyElements($: CheerioAPI, scopeElement: Element): Element[] {
+    const elements: Element[] = [];
+    const itemRefs = splitAttribute($(scopeElement).attr('itemref'));
+
+    collectPropertyElementsFromNodes($, $(scopeElement).children().toArray(), elements);
+
+    for (const id of itemRefs) {
+        const referencedElement = $(`#${escapeSelector(id)}`).get(0);
+
+        if (referencedElement) {
+            collectPropertyElementsFromNodes($, [referencedElement], elements);
+        }
+    }
+
+    return elements;
+}
+
+function collectPropertyElementsFromNodes($: CheerioAPI, nodes: AnyNode[], elements: Element[]): void {
+    for (const node of nodes) {
+        if (node.type !== 'tag') {
+            continue;
+        }
+
+        const element = node;
+        const isItemScope = $(element).is('[itemscope]');
+
+        if ($(element).is('[itemprop]')) {
+            elements.push(element);
+        }
+
+        if (isItemScope) {
+            continue;
+        }
+
+        collectPropertyElementsFromNodes($, $(element).children().toArray(), elements);
+    }
+}
+
+function getPropertyValue($: CheerioAPI, element: Element, seen: Set<Element>): MicrodataValue {
+    const tagName = element.tagName.toLowerCase();
+
+    if ($(element).is('[itemscope]')) {
+        return parseMicrodataItem($, element, new Set(seen));
+    }
+
+    if (tagName === 'meta') {
+        return $(element).attr('content') ?? '';
+    }
+
+    if (SRC_VALUE_TAGS.has(tagName)) {
+        return $(element).attr('src') ?? '';
+    }
+
+    if (URL_VALUE_TAGS.has(tagName)) {
+        return $(element).attr('href') ?? '';
+    }
+
+    if (tagName === 'object') {
+        return $(element).attr('data') ?? '';
+    }
+
+    if (tagName === 'data' || tagName === 'meter') {
+        return $(element).attr('value') ?? '';
+    }
+
+    if (tagName === 'time') {
+        return $(element).attr('datetime') ?? normalizeText($(element).text());
+    }
+
+    return normalizeText($(element).text());
+}
+
+function addProperty(
+    properties: Record<string, MicrodataValue | MicrodataValue[]>,
+    name: string,
+    value: MicrodataValue,
+): void {
+    const existing = properties[name];
+
+    if (existing === undefined) {
+        properties[name] = value;
+    } else if (Array.isArray(existing)) {
+        existing.push(value);
+    } else {
+        properties[name] = [existing, value];
+    }
+}
+
+function splitAttribute(value: string | undefined): string[] {
+    return value?.trim().split(/\s+/).filter(Boolean) ?? [];
+}
+
+function normalizeText(value: string): string {
+    return value.trim().replace(/\s+/g, ' ');
+}
+
+function optionalArray(key: string, value: string[]): Record<string, string[]> {
+    return value.length > 0 ? { [key]: value } : {};
+}
+
+function optionalString(key: string, value: string | undefined): Record<string, string> {
+    return value ? { [key]: value } : {};
+}
+
+function escapeSelector(value: string): string {
+    return value.replace(/([ !"#$%&'()*+,./:;<=>?@[\\\]^`{|}~])/g, '\\$1');
+}

--- a/packages/utils/test/structured-data.test.ts
+++ b/packages/utils/test/structured-data.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import { load } from 'cheerio';
+
+import { extractStructuredData } from '../src/internals/structured-data';
+
+describe('extractStructuredData', () => {
+    it('extracts JSON-LD objects and arrays', async () => {
+        const result = await extractStructuredData(`
+            <script type="application/ld+json">
+                {"@context":"https://schema.org","@type":"Article","headline":"Hello"}
+            </script>
+            <script type="application/ld+json; charset=utf-8">
+                [{"@type":"BreadcrumbList"},{"@type":"WebPage","name":"Docs"}]
+            </script>
+        `);
+
+        expect(result.jsonLd).toEqual([
+            { '@context': 'https://schema.org', '@type': 'Article', headline: 'Hello' },
+            { '@type': 'BreadcrumbList' },
+            { '@type': 'WebPage', name: 'Docs' },
+        ]);
+    });
+
+    it('extracts microdata from text and element attributes', async () => {
+        const result = await extractStructuredData(`
+            <article itemscope itemtype="https://schema.org/Product" itemid="sku-1">
+                <h1 itemprop="name">Desk lamp</h1>
+                <img itemprop="image" src="/lamp.jpg" alt="Lamp">
+                <a itemprop="url" href="/products/lamp">View</a>
+                <time itemprop="releaseDate" datetime="2026-08-29">Today</time>
+                <meta itemprop="sku" content="LAMP-1">
+                <data itemprop="price" value="19.99">$19.99</data>
+            </article>
+        `);
+
+        expect(result.microdata).toEqual([
+            {
+                type: ['https://schema.org/Product'],
+                id: 'sku-1',
+                properties: {
+                    name: 'Desk lamp',
+                    image: '/lamp.jpg',
+                    url: '/products/lamp',
+                    releaseDate: '2026-08-29',
+                    sku: 'LAMP-1',
+                    price: '19.99',
+                },
+            },
+        ]);
+    });
+
+    it('keeps nested itemscopes as nested property values', async () => {
+        const result = await extractStructuredData(`
+            <div itemscope itemtype="https://schema.org/Product">
+                <span itemprop="name">Coffee</span>
+                <div itemprop="offers" itemscope itemtype="https://schema.org/Offer">
+                    <meta itemprop="priceCurrency" content="USD">
+                    <span itemprop="price">12</span>
+                </div>
+            </div>
+        `);
+
+        expect(result.microdata).toEqual([
+            {
+                type: ['https://schema.org/Product'],
+                properties: {
+                    name: 'Coffee',
+                    offers: {
+                        type: ['https://schema.org/Offer'],
+                        properties: {
+                            priceCurrency: 'USD',
+                            price: '12',
+                        },
+                    },
+                },
+            },
+        ]);
+    });
+
+    it('supports itemref properties outside of the item subtree', async () => {
+        const result = await extractStructuredData(`
+            <div itemscope itemtype="https://schema.org/Person" itemref="external-name external-url">
+                <span itemprop="jobTitle">Engineer</span>
+            </div>
+            <p id="external-name" itemprop="name">Ada Lovelace</p>
+            <a id="external-url" itemprop="url" href="https://example.com/ada">Profile</a>
+        `);
+
+        expect(result.microdata).toEqual([
+            {
+                type: ['https://schema.org/Person'],
+                properties: {
+                    jobTitle: 'Engineer',
+                    name: 'Ada Lovelace',
+                    url: 'https://example.com/ada',
+                },
+            },
+        ]);
+    });
+
+    it('accepts an existing Cheerio object', async () => {
+        const $ = load('<div itemscope><span itemprop="name">Existing DOM</span></div>');
+        const result = await extractStructuredData($);
+
+        expect(result.microdata).toEqual([
+            {
+                properties: {
+                    name: 'Existing DOM',
+                },
+            },
+        ]);
+    });
+});


### PR DESCRIPTION
Closes #276.

## Summary

Adds `extractStructuredData()` to `@crawlee/utils` for extracting schema.org structured data from either raw HTML or an existing Cheerio object.

The utility returns both common structured-data formats in one pass:

- `jsonLd`: parsed objects from `<script type="application/ld+json">`
- `microdata`: parsed `itemscope` / `itemprop` items

It is exported from `@crawlee/utils` and exposed on the top-level `crawlee` `utils` object as `utils.extractStructuredData`, alongside existing helpers such as `parseOpenGraph`.

## Implementation details

- Accepts `string | CheerioAPI`, so crawler users can reuse an already parsed DOM and avoid parsing HTML twice.
- Parses JSON-LD script tags, including content types with parameters such as `application/ld+json; charset=utf-8`.
- Supports top-level microdata items and nested `itemscope` values.
- Supports repeated properties by returning arrays for duplicate `itemprop` names.
- Supports `itemref`, including properties referenced outside the item subtree.
- Reads element-specific microdata values from the attributes defined by the microdata parsing model:
  - `meta[content]`
  - `img[src]`, `audio[src]`, `video[src]`, `source[src]`, etc.
  - `a[href]`, `area[href]`, `link[href]`
  - `object[data]`
  - `data[value]` and `meter[value]`
  - `time[datetime]`
- Falls back to normalized text content for regular elements.

## Why this approach

The issue thread noted that `Apify.utils` no longer exists and that `@crawlee/utils` is the right modern location for this helper. A recent comment also called out several common pitfalls in microdata extraction, especially `itemref`, nested item scopes, and attribute-based values. This implementation covers those cases while keeping the helper dependency-light by using Crawlee's existing Cheerio dependency.

I also checked the existing open attempts for this issue (#3233 and #3465). This PR keeps the public API small, includes focused tests, and includes JSON-LD extraction as the issue discussion suggested, since many modern pages expose schema.org through JSON-LD rather than microdata.

## Tests

Ran:

```bash
pnpm exec vitest run packages/utils/test
pnpm --filter @crawlee/utils compile
pnpm --filter @crawlee/utils build
pnpm exec oxlint packages/utils/src/internals/structured-data.ts packages/utils/test/structured-data.test.ts packages/crawlee/src/index.ts --tsconfig=tsconfig.json --type-aware
pnpm exec oxfmt packages/utils/src/internals/structured-data.ts packages/utils/test/structured-data.test.ts packages/crawlee/src/index.ts --check
```

Notes:

- `pnpm --filter @crawlee/utils build` passes in local 
- `pnpm --filter crawlee compile` requires the wider monorepo package build chain first; it stopped on missing built workspace package declarations unrelated to this change. The changed top-level `packages/crawlee/src/index.ts` import was linted successfully.
