### PR TITLE
docs: generate markdown versions for all documentation versions

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -225,7 +225,7 @@ module.exports = {
                 ],
                 content: {
                     excludeRoutes: ['/js/api/3.*/**', '/js/api/3.*', '/js/api/next/**', '/js/api/next'],
-                    includeVersionedDocs: false,
+                    includeVersionedDocs: true,
                     enableLlmsFullTxt: true,
                     includeBlog: true,
                     includePages: true,


### PR DESCRIPTION
Enables Markdown variants for all versioned documentation. Orthogonal to #4089 

[Related Slack thread](https://github.com/apify/crawlee/pull/4089)