### PR TITLE
docs: add a guide on dismissing cookie modals in Crawlee crawlers

### DIFF
--- a/docs/guides/cookie_modals.mdx
+++ b/docs/guides/cookie_modals.mdx
@@ -13,7 +13,7 @@ For a crawler this is a navigation problem. The page loads, but the parts worth 
 
 Crawlee ships no helper for dismissing them. The v3 `closeCookieModals` helper was removed in v4, as it wrapped `idcac-playwright` — an optional dependency licensed under GPL-3.0 and no longer actively maintained.
 
-The approaches below replace it, using either the crawler's own hooks or a third-party library. The first two target a single known site. The rest generalize across many.
+The approaches below replace it, using either the crawler's own hooks or a third-party library. The first two target a single known site, while the rest generalize across many.
 
 ## Set the consent cookie
 
@@ -50,7 +50,7 @@ The weakness of this approach is fragility. Consent cookie names are undocumente
 
 ## Click the button
 
-When the selector is known, clicking the accept button is the most direct option. It adds no dependency.
+When the selector is known, clicking the accept button is the most direct option, and it adds no dependency.
 
 A <ApiLink to="playwright-crawler/interface/PlaywrightCrawlerOptions#postNavigationHooks">`postNavigationHook`</ApiLink> applies it to every page in the crawl.
 
@@ -82,11 +82,9 @@ An unhandled locator timeout would fail the request and consume a retry. The exp
 
 [`@duckduckgo/autoconsent`](https://github.com/duckduckgo/autoconsent) is a rule set covering more than 300 consent management platforms. DuckDuckGo maintains it and ships it in their browser extensions, so the rules track platform changes.
 
-The license is MPL-2.0. This is a file-level copyleft, and it imposes no obligations on surrounding code — unlike the GPL-3.0 package it replaces.
+The license is MPL-2.0, a file-level copyleft that imposes no obligations on surrounding code — unlike the GPL-3.0 package it replaces.
 
-The package ships a standalone bundle. It embeds its own rules and needs no message-passing bridge between Node and the page.
-
-Injecting it is enough. It detects the consent manager and clicks through the opt-out flow on its own.
+The package ships a standalone bundle that embeds its own rules and needs no message-passing bridge between Node and the page. Injecting it is enough for it to detect the consent manager and click through the opt-out flow on its own.
 
 ```bash
 npm install @duckduckgo/autoconsent
@@ -161,7 +159,11 @@ Constructing the blocker downloads and parses the filter list. A single instance
 
 Blocking suppresses the banner without recording consent. Sites that gate their content behind an explicit consent click stay inaccessible by this route alone.
 
-In exchange, the same engine blocks ads and trackers. That reduces page weight and navigation time, which makes it worth combining with one of the approaches above.
+In exchange, the same engine blocks ads and trackers, which cuts the number of requests each page makes.
+
+Part of that saving is given back, because `enableBlockingInPage` installs a catch-all `page.route` handler and Playwright disables the browser's HTTP cache whenever routing is enabled. Crawlee shares one browser context across pages by default, so assets that would otherwise be cached are refetched on every page.
+
+The blocker is therefore most useful on ad-heavy sites, and least useful when many pages of a crawl share the same large assets.
 
 ## Delegate to an LLM
 
@@ -177,8 +179,8 @@ It also fails less predictably than a rule set, since the outcome depends on the
 
 ## Choosing between them
 
-For a single known site, setting the consent cookie or clicking the button is sufficient. Neither pulls in a dependency.
+For a single known site, setting the consent cookie or clicking the button is sufficient, and neither pulls in a dependency.
 
 For crawls spanning many sites, autoconsent gives the broadest coverage for the least configuration. It is the closest replacement for the removed v3 helper.
 
-The blocker composes with either, and additionally cuts page load time. The Stagehand route is best reserved for targets where no selector or rule is known ahead of time.
+The blocker composes with either, though its effect on load time depends on how ad-heavy the targets are. The Stagehand route is best reserved for targets where no selector or rule is known ahead of time.

--- a/docs/guides/cookie_modals.mdx
+++ b/docs/guides/cookie_modals.mdx
@@ -9,7 +9,7 @@ import ApiLink from '@site/src/components/ApiLink';
 
 Cookie consent banners overlay the page, intercept clicks aimed at the content beneath them, and on some sites withhold the content entirely until consent is recorded. For a crawler this is a navigation problem rather than a legal one: the page loads, but the parts worth extracting are covered or absent.
 
-Crawlee ships no helper for dismissing them. The v3 `closeCookieModals` helper was removed in v4 — it wrapped `idcac-playwright`, an optional, largely unmaintained dependency under GPL-3.0, and its bundled rule list decayed as sites changed. The approaches below replace it using either the crawler's own hooks or a maintained third-party library. The first two target a single known site, the rest generalize across many, and they are ordered by cost.
+Crawlee ships no helper for dismissing them. The v3 `closeCookieModals` helper was removed in v4 — it wrapped `idcac-playwright`, an optional dependency that is licensed under GPL-3.0 and no longer actively maintained. The approaches below replace it using either the crawler's own hooks or a maintained third-party library. The first two target a single known site, the rest generalize across many, and they are ordered by cost.
 
 ## Set the consent cookie
 

--- a/docs/guides/cookie_modals.mdx
+++ b/docs/guides/cookie_modals.mdx
@@ -1,0 +1,156 @@
+---
+id: cookie-modals
+title: "Dismissing cookie modals"
+sidebar_label: "Cookie modals"
+description: Ways to get past cookie consent banners in a Crawlee crawler.
+---
+
+import ApiLink from '@site/src/components/ApiLink';
+
+Cookie consent banners cover the page. They swallow clicks, and some of them hide the content you came for.
+
+Crawlee has no helper for this. The v3 `closeCookieModals` helper is gone in v4. It leaned on a rule list that went stale, and maintaining that list is a project of its own. Use one of the approaches below instead.
+
+The first two target a single site. The rest scale to many.
+
+## Set the consent cookie
+
+Most banners are a check for one cookie. Set it, and the banner never renders. Nothing loads and nothing gets clicked, so this is the fastest option here.
+
+Find the cookie once by hand. Open the site, accept the banner, then read the cookies in your browser devtools.
+
+```ts
+import { PlaywrightCrawler } from 'crawlee';
+
+const crawler = new PlaywrightCrawler({
+    preNavigationHooks: [
+        async ({ session, request }) => {
+            await session.setCookie('cookieconsent_status=dismiss', request.url);
+        },
+    ],
+    async requestHandler({ page, log }) {
+        log.info(await page.title());
+    },
+});
+
+await crawler.run(['https://example.com']);
+```
+
+Crawlee writes the session jar into the browser right before it navigates. A <ApiLink to="core/class/Session#setCookie">`session.setCookie`</ApiLink> call in a `preNavigationHook` therefore lands in time. The same hook works in `CheerioCrawler` and the other HTTP crawlers.
+
+The catch is that every site names the cookie differently. It can also change without warning. You will find out when the banner comes back.
+
+## Click the button
+
+If you know the selector, click it. A `postNavigationHook` runs it on every page.
+
+```ts
+import { PlaywrightCrawler } from 'crawlee';
+
+const crawler = new PlaywrightCrawler({
+    postNavigationHooks: [
+        async ({ page }) => {
+            await page
+                .locator('#onetrust-accept-btn-handler')
+                .click({ timeout: 5_000 })
+                .catch(() => {});
+        },
+    ],
+    async requestHandler({ page, log }) {
+        log.info(await page.title());
+    },
+});
+
+await crawler.run(['https://example.com']);
+```
+
+The `.catch()` is not optional. Plenty of pages show no banner. Without it, the click throws and fails the request.
+
+## Use autoconsent
+
+[`@duckduckgo/autoconsent`](https://github.com/duckduckgo/autoconsent) carries opt-out rules for roughly 300 consent managers. DuckDuckGo ships it in their own browser, so the rules stay current. It is MPL-2.0, which is safe to depend on.
+
+The package has a standalone bundle. It embeds its own rules and needs no wiring. Inject it, and it clicks through the banner on its own.
+
+```bash
+npm install @duckduckgo/autoconsent
+```
+
+```ts
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { PlaywrightCrawler } from 'crawlee';
+
+const require = createRequire(import.meta.url);
+
+// The package doesn't export the bundle path, so resolve the main entry and take its sibling.
+const bundlePath = join(dirname(require.resolve('@duckduckgo/autoconsent')), 'autoconsent.standalone.js');
+const autoconsent = readFileSync(bundlePath, 'utf8');
+
+const crawler = new PlaywrightCrawler({
+    preNavigationHooks: [
+        async ({ page }) => {
+            await page.addInitScript({ content: autoconsent });
+        },
+    ],
+    async requestHandler({ page, log }) {
+        log.info(await page.title());
+    },
+});
+
+await crawler.run(['https://example.com']);
+```
+
+Read the bundle once at startup, like above. It is around 400 kB, and reading it per request is wasted work.
+
+On `PuppeteerCrawler`, swap `page.addInitScript({ content: autoconsent })` for `page.evaluateOnNewDocument(autoconsent)`.
+
+Autoconsent does real clicks, so budget a second or two per page. It opts out rather than accepting. When a site matches no rule, nothing happens and the crawl carries on.
+
+## Block the banner instead
+
+You can stop the banner from ever loading. [`@ghostery/adblocker-playwright`](https://github.com/ghostery/adblocker) does it with the same filter lists ad blockers use.
+
+```bash
+npm install @ghostery/adblocker-playwright
+```
+
+```ts
+import { PlaywrightBlocker } from '@ghostery/adblocker-playwright';
+import { PlaywrightCrawler } from 'crawlee';
+
+// Build this once. `fromLists` downloads and parses the list, which is slow.
+const blocker = await PlaywrightBlocker.fromLists(fetch, [
+    'https://secure.fanboy.co.nz/fanboy-cookiemonster.txt',
+]);
+
+const crawler = new PlaywrightCrawler({
+    preNavigationHooks: [
+        async ({ page }) => {
+            await blocker.enableBlockingInPage(page);
+        },
+    ],
+    async requestHandler({ page, log }) {
+        log.info(await page.title());
+    },
+});
+
+await crawler.run(['https://example.com']);
+```
+
+This hides the banner without consenting to anything. Sites that gate their content behind a consent click will still gate it. The same blocker also kills ads and trackers, so pages load faster.
+
+## Ask an LLM
+
+<ApiLink to="stagehand-crawler/class/StagehandCrawler">`StagehandCrawler`</ApiLink> takes plain instructions. No selectors, no rule lists.
+
+```ts
+await page.act('Dismiss the cookie consent banner');
+```
+
+It is the slowest option, and every call costs money. It earns its place when the sites are unknown or change often. See the [Stagehand guide](./stagehand-crawler-guide) for setup.
+
+## Which one to pick
+
+Scraping one site? Set the cookie, or click the button. Scraping many? Reach for autoconsent. Add the blocker on top when you also want fewer ads and faster pages.

--- a/docs/guides/cookie_modals.mdx
+++ b/docs/guides/cookie_modals.mdx
@@ -11,9 +11,7 @@ Cookie consent banners overlay the page and intercept clicks. Some sites withhol
 
 For a crawler this is a navigation problem. The page loads, but the parts worth extracting are covered or missing.
 
-Crawlee ships no helper for dismissing them. The v3 `closeCookieModals` helper was removed in v4, as it wrapped `idcac-playwright` — an optional dependency licensed under GPL-3.0 and no longer actively maintained.
-
-The approaches below replace it, using either the crawler's own hooks or a third-party library. The first two target a single known site, while the rest generalize across many.
+The approaches below deal with this, using either the crawler's own hooks or a third-party library. The first two target a single known site, while the rest generalize across many.
 
 ## Set the consent cookie
 
@@ -81,8 +79,6 @@ An unhandled locator timeout would fail the request and consume a retry. The exp
 ## Use autoconsent
 
 [`@duckduckgo/autoconsent`](https://github.com/duckduckgo/autoconsent) is a rule set covering more than 300 consent management platforms. DuckDuckGo maintains it and ships it in their browser extensions, so the rules track platform changes.
-
-The license is MPL-2.0, a file-level copyleft that imposes no obligations on surrounding code — unlike the GPL-3.0 package it replaces.
 
 The package ships a standalone bundle that embeds its own rules and needs no message-passing bridge between Node and the page. Injecting it is enough for it to detect the consent manager and click through the opt-out flow on its own.
 
@@ -161,9 +157,11 @@ Blocking suppresses the banner without recording consent. Sites that gate their 
 
 In exchange, the same engine blocks ads and trackers, which cuts the number of requests each page makes.
 
-Part of that saving is given back, because `enableBlockingInPage` installs a catch-all `page.route` handler and Playwright disables the browser's HTTP cache whenever routing is enabled. Crawlee shares one browser context across pages by default, so assets that would otherwise be cached are refetched on every page.
+:::warning Routing disables the HTTP cache
 
-The blocker is therefore most useful on ad-heavy sites, and least useful when many pages of a crawl share the same large assets.
+`enableBlockingInPage` installs a catch-all `page.route` handler, and Playwright disables the browser's HTTP cache whenever routing is enabled. Crawlee shares one browser context across pages by default, so assets that would otherwise be cached are refetched on every page.
+
+:::
 
 ## Delegate to an LLM
 
@@ -181,6 +179,6 @@ It also fails less predictably than a rule set, since the outcome depends on the
 
 For a single known site, setting the consent cookie or clicking the button is sufficient, and neither pulls in a dependency.
 
-For crawls spanning many sites, autoconsent gives the broadest coverage for the least configuration. It is the closest replacement for the removed v3 helper.
+For crawls spanning many sites, autoconsent gives the broadest coverage for the least configuration.
 
-The blocker composes with either, though its effect on load time depends on how ad-heavy the targets are. The Stagehand route is best reserved for targets where no selector or rule is known ahead of time.
+The blocker composes with either of them, and removes ads and trackers along the way. The Stagehand route is best reserved for targets where no selector or rule is known ahead of time.

--- a/docs/guides/cookie_modals.mdx
+++ b/docs/guides/cookie_modals.mdx
@@ -7,13 +7,21 @@ description: Ways to get past cookie consent banners in a Crawlee crawler.
 
 import ApiLink from '@site/src/components/ApiLink';
 
-Cookie consent banners overlay the page, intercept clicks aimed at the content beneath them, and on some sites withhold the content entirely until consent is recorded. For a crawler this is a navigation problem rather than a legal one: the page loads, but the parts worth extracting are covered or absent.
+Cookie consent banners overlay the page and intercept clicks. Some sites withhold their content entirely until consent is recorded.
 
-Crawlee ships no helper for dismissing them. The v3 `closeCookieModals` helper was removed in v4 — it wrapped `idcac-playwright`, an optional dependency that is licensed under GPL-3.0 and no longer actively maintained. The approaches below replace it using either the crawler's own hooks or a maintained third-party library. The first two target a single known site, the rest generalize across many, and they are ordered by cost.
+For a crawler this is a navigation problem. The page loads, but the parts worth extracting are covered or missing.
+
+Crawlee ships no helper for dismissing them. The v3 `closeCookieModals` helper was removed in v4, as it wrapped `idcac-playwright` — an optional dependency licensed under GPL-3.0 and no longer actively maintained.
+
+The approaches below replace it, using either the crawler's own hooks or a third-party library. The first two target a single known site. The rest generalize across many.
 
 ## Set the consent cookie
 
-Most banners render only when a particular cookie is absent, so writing that cookie in advance suppresses the banner entirely. Nothing has to load, render, or be clicked, which makes this by far the cheapest option — and the only one that costs nothing at all per page. The trade-off is that the cookie is site-specific and must be identified once by hand, usually by accepting the banner in an ordinary browser session and reading back the resulting cookies in devtools.
+Most banners render only when a particular cookie is absent. Writing that cookie in advance suppresses the banner entirely.
+
+Nothing has to load, render, or be clicked, which makes this the cheapest option here.
+
+The trade-off is that the cookie is site-specific. It has to be identified once by hand — accepting the banner in an ordinary browser session, then reading the result in devtools.
 
 ```ts
 import { PlaywrightCrawler } from 'crawlee';
@@ -32,13 +40,19 @@ const crawler = new PlaywrightCrawler({
 await crawler.run(['https://example.com']);
 ```
 
-<ApiLink to="core/class/Session#setCookie">`session.setCookie`</ApiLink> writes into the session's <ApiLink to="core/class/Session#cookieJar">`cookieJar`</ApiLink>, and the crawler copies that jar into the browser immediately before navigating, so a call inside a <ApiLink to="playwright-crawler/interface/PlaywrightCrawlerOptions#preNavigationHooks">`preNavigationHook`</ApiLink> is applied in time for the first request. The same hook works unchanged in <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> and the other <ApiLink to="http-crawler/class/HttpCrawler">`HttpCrawler`</ApiLink> variants, where the jar is serialized into the `Cookie` header instead of being injected into a browser context. Cookies returned by the site are folded back into the same jar when <ApiLink to="browser-crawler/interface/BrowserCrawlerOptions#saveResponseCookies">`saveResponseCookies`</ApiLink> is enabled, which is the default; the [session management guide](./session-management) covers how the jar is populated, persisted, and rotated.
+<ApiLink to="core/class/Session#setCookie">`session.setCookie`</ApiLink> writes into the session's <ApiLink to="core/class/Session#cookieJar">`cookieJar`</ApiLink>. The crawler copies that jar into the browser just before navigating, so a call inside a <ApiLink to="playwright-crawler/interface/PlaywrightCrawlerOptions#preNavigationHooks">`preNavigationHook`</ApiLink> arrives in time.
 
-The weakness of this approach is fragility. Consent cookie names are undocumented implementation details, they differ on every site, and they can change without notice — at which point the banner silently returns and the crawler starts collecting empty pages.
+The same hook works unchanged in <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> and the other <ApiLink to="http-crawler/class/HttpCrawler">`HttpCrawler`</ApiLink> variants. There the jar is serialized into the `Cookie` header instead.
+
+Cookies returned by the site are folded back into the same jar when <ApiLink to="browser-crawler/interface/BrowserCrawlerOptions#saveResponseCookies">`saveResponseCookies`</ApiLink> is enabled, which is the default. The [session management guide](./session-management) covers how the jar is populated and persisted.
+
+The weakness of this approach is fragility. Consent cookie names are undocumented and differ on every site. They can change without notice, and the only symptom is the banner's return.
 
 ## Click the button
 
-When the selector is already known, clicking the accept button is the most direct option and adds no dependency. A <ApiLink to="playwright-crawler/interface/PlaywrightCrawlerOptions#postNavigationHooks">`postNavigationHook`</ApiLink> applies it to every page in the crawl without repeating the call in each request handler.
+When the selector is known, clicking the accept button is the most direct option. It adds no dependency.
+
+A <ApiLink to="playwright-crawler/interface/PlaywrightCrawlerOptions#postNavigationHooks">`postNavigationHook`</ApiLink> applies it to every page in the crawl.
 
 ```ts
 import { PlaywrightCrawler } from 'crawlee';
@@ -60,13 +74,19 @@ const crawler = new PlaywrightCrawler({
 await crawler.run(['https://example.com']);
 ```
 
-The trailing `.catch()` is required rather than merely defensive: many pages in a crawl render no banner at all, either because consent was already recorded in the session or because the visitor's region is unregulated, and an unhandled locator timeout would fail the request and consume a retry. The explicit timeout bounds the delay on those pages, since the default would otherwise block each one for the full navigation timeout.
+The trailing `.catch()` is required, not merely defensive. Many pages render no banner at all, either because consent was already recorded or because the region is unregulated.
+
+An unhandled locator timeout would fail the request and consume a retry. The explicit timeout bounds the delay on those pages.
 
 ## Use autoconsent
 
-[`@duckduckgo/autoconsent`](https://github.com/duckduckgo/autoconsent) is a rule set covering more than 300 consent management platforms. It is maintained by DuckDuckGo and shipped in their browser extensions, so the rules track changes to the major platforms without any effort on the crawler's side. The license is MPL-2.0, a file-level copyleft that imposes no obligations on surrounding code — unlike the GPL-3.0 package it replaces.
+[`@duckduckgo/autoconsent`](https://github.com/duckduckgo/autoconsent) is a rule set covering more than 300 consent management platforms. DuckDuckGo maintains it and ships it in their browser extensions, so the rules track platform changes.
 
-The package ships a standalone bundle that embeds its own rules and needs no message-passing bridge between Node and the page. Injecting it is sufficient: it detects the consent manager, walks its opt-out flow, and clicks through unattended.
+The license is MPL-2.0. This is a file-level copyleft, and it imposes no obligations on surrounding code — unlike the GPL-3.0 package it replaces.
+
+The package ships a standalone bundle. It embeds its own rules and needs no message-passing bridge between Node and the page.
+
+Injecting it is enough. It detects the consent manager and clicks through the opt-out flow on its own.
 
 ```bash
 npm install @duckduckgo/autoconsent
@@ -98,13 +118,17 @@ const crawler = new PlaywrightCrawler({
 await crawler.run(['https://example.com']);
 ```
 
-The bundle is around 400 kB and is therefore read once at startup rather than on every request. Its path is derived from the resolved main entry because the package's `exports` map does not expose the file directly. On <ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink> the equivalent injection is `page.evaluateOnNewDocument(autoconsent)`.
+The bundle is around 400 kB, so it is read once at startup rather than per request. Its path is derived from the resolved main entry, because the package's `exports` map does not expose the file directly.
 
-Because autoconsent performs real interactions rather than hiding elements, it costs roughly a second or two per page, and it opts out rather than accepting — which keeps tracking cookies out of the session and leaves the crawl in a defensible state. Pages matching no rule are left untouched and the crawl proceeds normally, so the hook is safe to apply across a heterogeneous set of targets.
+On <ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink> the equivalent injection is `page.evaluateOnNewDocument(autoconsent)`.
+
+Autoconsent performs real interactions rather than hiding elements, so it costs a second or two per page. It opts out rather than accepting, which keeps tracking cookies out of the session.
+
+Pages matching no rule are left untouched, and the crawl proceeds normally.
 
 ## Block the banner instead
 
-The opposite approach is to prevent the banner from loading at all. [`@ghostery/adblocker-playwright`](https://github.com/ghostery/adblocker) applies the same filter lists used by consumer ad blockers, of which Fanboy's Cookie List targets consent notices specifically.
+The opposite approach is to stop the banner from loading. [`@ghostery/adblocker-playwright`](https://github.com/ghostery/adblocker) applies the same filter lists used by consumer ad blockers. Fanboy's Cookie List targets consent notices specifically.
 
 ```bash
 npm install @ghostery/adblocker-playwright
@@ -133,18 +157,28 @@ const crawler = new PlaywrightCrawler({
 await crawler.run(['https://example.com']);
 ```
 
-Constructing the blocker downloads and parses the filter list, so a single instance is built at startup and shared across pages; rebuilding it per request would dominate the crawl's runtime. Blocking suppresses the banner without recording consent, so sites that gate their content behind an explicit consent click remain inaccessible by this route alone. In exchange, the same engine blocks ads and trackers, which reduces page weight and navigation time and makes it worth combining with one of the approaches above.
+Constructing the blocker downloads and parses the filter list. A single instance is therefore built at startup and shared across pages.
+
+Blocking suppresses the banner without recording consent. Sites that gate their content behind an explicit consent click stay inaccessible by this route alone.
+
+In exchange, the same engine blocks ads and trackers. That reduces page weight and navigation time, which makes it worth combining with one of the approaches above.
 
 ## Delegate to an LLM
 
-<ApiLink to="stagehand-crawler/class/StagehandCrawler">`StagehandCrawler`</ApiLink> accepts natural-language instructions and locates the control itself, so neither a selector nor a rule list is needed.
+<ApiLink to="stagehand-crawler/class/StagehandCrawler">`StagehandCrawler`</ApiLink> accepts natural-language instructions and locates the control itself. Neither a selector nor a rule list is needed.
 
 ```ts
 await page.act('Dismiss the cookie consent banner');
 ```
 
-This is the slowest option and the only one with a per-call model cost, which restricts it to crawls where the targets are not known in advance or change too often for a maintained selector. It also fails less predictably than a rule set, since the outcome depends on the model's reading of the page. Setup and model configuration are covered in the [StagehandCrawler guide](./stagehand-crawler-guide).
+This is the slowest option, and the only one with a per-call model cost. It suits crawls where the targets are unknown in advance, or change too often for a maintained selector.
+
+It also fails less predictably than a rule set, since the outcome depends on the model's reading of the page. Setup is covered in the [StagehandCrawler guide](./stagehand-crawler-guide).
 
 ## Choosing between them
 
-For a single known site, setting the consent cookie or clicking the accept button is sufficient and pulls in no dependency. For crawls spanning many sites, autoconsent offers the broadest coverage for the least configuration and is the closest replacement for the removed v3 helper. The blocker composes with either and additionally cuts page load time, while the Stagehand route is best reserved for targets where no selector or rule is known ahead of time.
+For a single known site, setting the consent cookie or clicking the button is sufficient. Neither pulls in a dependency.
+
+For crawls spanning many sites, autoconsent gives the broadest coverage for the least configuration. It is the closest replacement for the removed v3 helper.
+
+The blocker composes with either, and additionally cuts page load time. The Stagehand route is best reserved for targets where no selector or rule is known ahead of time.

--- a/docs/guides/cookie_modals.mdx
+++ b/docs/guides/cookie_modals.mdx
@@ -58,6 +58,7 @@ import { PlaywrightCrawler } from 'crawlee';
 const crawler = new PlaywrightCrawler({
     postNavigationHooks: [
         async ({ page }) => {
+            // A page with no banner always waits out the full timeout before giving up, so keep it short.
             await page
                 .locator('#onetrust-accept-btn-handler')
                 .click({ timeout: 5_000 })
@@ -74,7 +75,7 @@ await crawler.run(['https://example.com']);
 
 The trailing `.catch()` is required, not merely defensive. Many pages render no banner at all, either because consent was already recorded or because the region is unregulated.
 
-An unhandled locator timeout would fail the request and consume a retry. The explicit timeout bounds the delay on those pages.
+An unhandled locator timeout would fail the request and consume a retry. Every page without a banner spends that timeout in full, so a short value is preferable.
 
 ## Use autoconsent
 

--- a/docs/guides/cookie_modals.mdx
+++ b/docs/guides/cookie_modals.mdx
@@ -7,17 +7,13 @@ description: Ways to get past cookie consent banners in a Crawlee crawler.
 
 import ApiLink from '@site/src/components/ApiLink';
 
-Cookie consent banners cover the page. They swallow clicks, and some of them hide the content you came for.
+Cookie consent banners overlay the page, intercept clicks aimed at the content beneath them, and on some sites withhold the content entirely until consent is recorded. For a crawler this is a navigation problem rather than a legal one: the page loads, but the parts worth extracting are covered or absent.
 
-Crawlee has no helper for this. The v3 `closeCookieModals` helper is gone in v4. It leaned on a rule list that went stale, and maintaining that list is a project of its own. Use one of the approaches below instead.
-
-The first two target a single site. The rest scale to many.
+Crawlee ships no helper for dismissing them. The v3 `closeCookieModals` helper was removed in v4 — it wrapped `idcac-playwright`, an optional, largely unmaintained dependency under GPL-3.0, and its bundled rule list decayed as sites changed. The approaches below replace it using either the crawler's own hooks or a maintained third-party library. The first two target a single known site, the rest generalize across many, and they are ordered by cost.
 
 ## Set the consent cookie
 
-Most banners are a check for one cookie. Set it, and the banner never renders. Nothing loads and nothing gets clicked, so this is the fastest option here.
-
-Find the cookie once by hand. Open the site, accept the banner, then read the cookies in your browser devtools.
+Most banners render only when a particular cookie is absent, so writing that cookie in advance suppresses the banner entirely. Nothing has to load, render, or be clicked, which makes this by far the cheapest option — and the only one that costs nothing at all per page. The trade-off is that the cookie is site-specific and must be identified once by hand, usually by accepting the banner in an ordinary browser session and reading back the resulting cookies in devtools.
 
 ```ts
 import { PlaywrightCrawler } from 'crawlee';
@@ -36,13 +32,13 @@ const crawler = new PlaywrightCrawler({
 await crawler.run(['https://example.com']);
 ```
 
-Crawlee writes the session jar into the browser right before it navigates. A <ApiLink to="core/class/Session#setCookie">`session.setCookie`</ApiLink> call in a `preNavigationHook` therefore lands in time. The same hook works in `CheerioCrawler` and the other HTTP crawlers.
+<ApiLink to="core/class/Session#setCookie">`session.setCookie`</ApiLink> writes into the session's <ApiLink to="core/class/Session#cookieJar">`cookieJar`</ApiLink>, and the crawler copies that jar into the browser immediately before navigating, so a call inside a <ApiLink to="playwright-crawler/interface/PlaywrightCrawlerOptions#preNavigationHooks">`preNavigationHook`</ApiLink> is applied in time for the first request. The same hook works unchanged in <ApiLink to="cheerio-crawler/class/CheerioCrawler">`CheerioCrawler`</ApiLink> and the other <ApiLink to="http-crawler/class/HttpCrawler">`HttpCrawler`</ApiLink> variants, where the jar is serialized into the `Cookie` header instead of being injected into a browser context. Cookies returned by the site are folded back into the same jar when <ApiLink to="browser-crawler/interface/BrowserCrawlerOptions#saveResponseCookies">`saveResponseCookies`</ApiLink> is enabled, which is the default; the [session management guide](./session-management) covers how the jar is populated, persisted, and rotated.
 
-The catch is that every site names the cookie differently. It can also change without warning. You will find out when the banner comes back.
+The weakness of this approach is fragility. Consent cookie names are undocumented implementation details, they differ on every site, and they can change without notice — at which point the banner silently returns and the crawler starts collecting empty pages.
 
 ## Click the button
 
-If you know the selector, click it. A `postNavigationHook` runs it on every page.
+When the selector is already known, clicking the accept button is the most direct option and adds no dependency. A <ApiLink to="playwright-crawler/interface/PlaywrightCrawlerOptions#postNavigationHooks">`postNavigationHook`</ApiLink> applies it to every page in the crawl without repeating the call in each request handler.
 
 ```ts
 import { PlaywrightCrawler } from 'crawlee';
@@ -64,13 +60,13 @@ const crawler = new PlaywrightCrawler({
 await crawler.run(['https://example.com']);
 ```
 
-The `.catch()` is not optional. Plenty of pages show no banner. Without it, the click throws and fails the request.
+The trailing `.catch()` is required rather than merely defensive: many pages in a crawl render no banner at all, either because consent was already recorded in the session or because the visitor's region is unregulated, and an unhandled locator timeout would fail the request and consume a retry. The explicit timeout bounds the delay on those pages, since the default would otherwise block each one for the full navigation timeout.
 
 ## Use autoconsent
 
-[`@duckduckgo/autoconsent`](https://github.com/duckduckgo/autoconsent) carries opt-out rules for roughly 300 consent managers. DuckDuckGo ships it in their own browser, so the rules stay current. It is MPL-2.0, which is safe to depend on.
+[`@duckduckgo/autoconsent`](https://github.com/duckduckgo/autoconsent) is a rule set covering more than 300 consent management platforms. It is maintained by DuckDuckGo and shipped in their browser extensions, so the rules track changes to the major platforms without any effort on the crawler's side. The license is MPL-2.0, a file-level copyleft that imposes no obligations on surrounding code — unlike the GPL-3.0 package it replaces.
 
-The package has a standalone bundle. It embeds its own rules and needs no wiring. Inject it, and it clicks through the banner on its own.
+The package ships a standalone bundle that embeds its own rules and needs no message-passing bridge between Node and the page. Injecting it is sufficient: it detects the consent manager, walks its opt-out flow, and clicks through unattended.
 
 ```bash
 npm install @duckduckgo/autoconsent
@@ -102,15 +98,13 @@ const crawler = new PlaywrightCrawler({
 await crawler.run(['https://example.com']);
 ```
 
-Read the bundle once at startup, like above. It is around 400 kB, and reading it per request is wasted work.
+The bundle is around 400 kB and is therefore read once at startup rather than on every request. Its path is derived from the resolved main entry because the package's `exports` map does not expose the file directly. On <ApiLink to="puppeteer-crawler/class/PuppeteerCrawler">`PuppeteerCrawler`</ApiLink> the equivalent injection is `page.evaluateOnNewDocument(autoconsent)`.
 
-On `PuppeteerCrawler`, swap `page.addInitScript({ content: autoconsent })` for `page.evaluateOnNewDocument(autoconsent)`.
-
-Autoconsent does real clicks, so budget a second or two per page. It opts out rather than accepting. When a site matches no rule, nothing happens and the crawl carries on.
+Because autoconsent performs real interactions rather than hiding elements, it costs roughly a second or two per page, and it opts out rather than accepting — which keeps tracking cookies out of the session and leaves the crawl in a defensible state. Pages matching no rule are left untouched and the crawl proceeds normally, so the hook is safe to apply across a heterogeneous set of targets.
 
 ## Block the banner instead
 
-You can stop the banner from ever loading. [`@ghostery/adblocker-playwright`](https://github.com/ghostery/adblocker) does it with the same filter lists ad blockers use.
+The opposite approach is to prevent the banner from loading at all. [`@ghostery/adblocker-playwright`](https://github.com/ghostery/adblocker) applies the same filter lists used by consumer ad blockers, of which Fanboy's Cookie List targets consent notices specifically.
 
 ```bash
 npm install @ghostery/adblocker-playwright
@@ -139,18 +133,18 @@ const crawler = new PlaywrightCrawler({
 await crawler.run(['https://example.com']);
 ```
 
-This hides the banner without consenting to anything. Sites that gate their content behind a consent click will still gate it. The same blocker also kills ads and trackers, so pages load faster.
+Constructing the blocker downloads and parses the filter list, so a single instance is built at startup and shared across pages; rebuilding it per request would dominate the crawl's runtime. Blocking suppresses the banner without recording consent, so sites that gate their content behind an explicit consent click remain inaccessible by this route alone. In exchange, the same engine blocks ads and trackers, which reduces page weight and navigation time and makes it worth combining with one of the approaches above.
 
-## Ask an LLM
+## Delegate to an LLM
 
-<ApiLink to="stagehand-crawler/class/StagehandCrawler">`StagehandCrawler`</ApiLink> takes plain instructions. No selectors, no rule lists.
+<ApiLink to="stagehand-crawler/class/StagehandCrawler">`StagehandCrawler`</ApiLink> accepts natural-language instructions and locates the control itself, so neither a selector nor a rule list is needed.
 
 ```ts
 await page.act('Dismiss the cookie consent banner');
 ```
 
-It is the slowest option, and every call costs money. It earns its place when the sites are unknown or change often. See the [Stagehand guide](./stagehand-crawler-guide) for setup.
+This is the slowest option and the only one with a per-call model cost, which restricts it to crawls where the targets are not known in advance or change too often for a maintained selector. It also fails less predictably than a rule set, since the outcome depends on the model's reading of the page. Setup and model configuration are covered in the [StagehandCrawler guide](./stagehand-crawler-guide).
 
-## Which one to pick
+## Choosing between them
 
-Scraping one site? Set the cookie, or click the button. Scraping many? Reach for autoconsent. Add the blocker on top when you also want fewer ads and faster pages.
+For a single known site, setting the consent cookie or clicking the accept button is sufficient and pulls in no dependency. For crawls spanning many sites, autoconsent offers the broadest coverage for the least configuration and is the closest replacement for the removed v3 helper. The blocker composes with either and additionally cuts page load time, while the Stagehand route is best reserved for targets where no selector or rule is known ahead of time.

--- a/docs/upgrading/upgrading_v4.md
+++ b/docs/upgrading/upgrading_v4.md
@@ -560,6 +560,8 @@ const crawler = new CheerioCrawler({
 
 The `closeCookieModals` context helper is removed from the Playwright and Puppeteer crawlers, along with the `playwrightUtils.closeCookieModals` / `puppeteerUtils.closeCookieModals` functions and the optional `idcac-playwright` peer dependency they were built on.
 
+See the [cookie modals guide](../guides/cookie-modals) for the replacements, including a drop-in `preNavigationHook` built on `@duckduckgo/autoconsent`.
+
 ### Crawling context is strictly typed
 
 Previously, the crawling context extended a `Record` type, allowing to access any property. This was changed to a strict type, which means that you can only access properties that are defined in the context.
@@ -2131,7 +2133,7 @@ The full list of removed exports and members, for ctrl-F purposes. Where a repla
 - `FileDownloadOptions.streamHandler` - streaming should now be handled directly in the `requestHandler` instead
 - `playwrightUtils.registerUtilsToContext` and `puppeteerUtils.registerUtilsToContext` - this is now added to the context via `ContextPipeline` composition
 - `context.blockResources` and `context.cacheResponses` — no longer attached to the crawling context. The functionality is still available as deprecated functions, accessible both via the `puppeteerUtils` namespace (`puppeteerUtils.blockResources`, `puppeteerUtils.cacheResponses`) and as top-level exports from `@crawlee/puppeteer` (`import { blockResources, cacheResponses } from '@crawlee/puppeteer'`). Unlike the old context helpers, these take an explicit `page` argument — e.g. `await blockResources(page)`. Both are `@deprecated` and will be removed in a future release, so migrate away from them.
-- `context.closeCookieModals`, `playwrightUtils.closeCookieModals` and `puppeteerUtils.closeCookieModals` — removed along with the optional `idcac-playwright` peer dependency (see [Crawling context no longer includes `closeCookieModals`](#crawling-context-no-longer-includes-closecookiemodals))
+- `context.closeCookieModals`, `playwrightUtils.closeCookieModals` and `puppeteerUtils.closeCookieModals` — removed along with the optional `idcac-playwright` peer dependency (see [Crawling context no longer includes `closeCookieModals`](#crawling-context-no-longer-includes-closecookiemodals) and the [cookie modals guide](../guides/cookie-modals))
 - `Configuration.systemInfoV2` / `CRAWLEE_SYSTEM_INFO_V2` environment variable — the v2 behavior is now the default (see [Available resource detection](#available-resource-detection))
 - `checkAndSerialize` and `chunkBySize` functions (from `@crawlee/core`) — value (de)serialization now lives in the `KeyValueStore` frontend; use `serializeValue` / `parseValue` (see [`maybeStringify` is removed](#maybestringify-is-removed))
 - `BASIC_CRAWLER_TIMEOUT_BUFFER_SECS` constant (from `@crawlee/basic`) — was an internal timeout buffer, no longer exported

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -43,6 +43,7 @@ module.exports = {
                 'guides/session-management',
                 'guides/scaling-crawlers',
                 'guides/avoid-blocking',
+                'guides/cookie-modals',
                 'guides/jsdom-crawler-guide',
                 'guides/impit-http-client/impit-http-client',
                 'guides/got-scraping',


### PR DESCRIPTION
Follow-up for #4073 . Since there is no exported helper for dismissing cookie modals, this PR adds a guide describing several other options and libraries.

Closes #3987 