### PR TITLE
fix(core): preserve request error messages without stacks

### DIFF
--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -453,7 +453,7 @@ class CrawleeRequest<UserData extends Dictionary = Dictionary> {
                 message = omitStack
                     ? errorOrMessage.message
                     : // .stack includes the message
-                      errorOrMessage.stack;
+                      (errorOrMessage.stack ?? errorOrMessage.message);
             } else if (Reflect.has(Object(errorOrMessage), 'message')) {
                 message = Reflect.get(Object(errorOrMessage), 'message');
             } else if ((errorOrMessage as string).toString() !== '[object Object]') {

--- a/test/core/request.test.ts
+++ b/test/core/request.test.ts
@@ -1,0 +1,13 @@
+import { Request } from '../../packages/core/src/request.js';
+
+describe('Request#pushErrorMessage', () => {
+    test.each([null, undefined])('falls back to the error message when the stack is %s', (stack) => {
+        const error = new Error('response stream failed');
+        Object.defineProperty(error, 'stack', { value: stack });
+        const request = new Request({ url: 'https://example.com' });
+
+        request.pushErrorMessage(error);
+
+        expect(request.errorMessages).toEqual(['response stream failed']);
+    });
+});


### PR DESCRIPTION
## What does this PR do?

`Request.pushErrorMessage()` can append `null` or `undefined` when an `Error` has no stack. `errorMessages` is a persisted `string[]`, so the invalid entry can make request reconstruction/persistence fail.

When a stack is unavailable, preserve the existing message as the fallback. This keeps stack-rich errors unchanged and prevents malformed error-message arrays.

Fixes #4087

## Testing

- `corepack pnpm exec vitest run test/core/request.test.ts --coverage.enabled=false`
- `corepack pnpm exec oxfmt --check packages/core/src/request.ts test/core/request.test.ts`
- `corepack pnpm exec oxlint packages/core/src/request.ts test/core/request.test.ts --tsconfig=tsconfig.json --type-aware`

The full test TypeScript check was also attempted; it is currently blocked in a pristine checkout by pre-existing missing generated `@crawlee/*/dist` declarations and unrelated strictness errors.