### PR TITLE
fix(core): notify() no longer leaks a timed-out task's context into the pool loop

### DIFF
--- a/packages/core/src/autoscaling/autoscaled_pool.ts
+++ b/packages/core/src/autoscaling/autoscaled_pool.ts
@@ -1,7 +1,7 @@
 import ow from 'ow';
 
 import type { Log } from '@apify/log';
-import { addTimeoutToPromise } from '@apify/timeout';
+import { addTimeoutToPromise, storage as timeoutStorage } from '@apify/timeout';
 import type { BetterIntervalID } from '@apify/utilities';
 import { betterClearInterval, betterSetInterval } from '@apify/utilities';
 
@@ -469,7 +469,10 @@ export class AutoscaledPool {
      * every `maybeRunIntervalSecs` seconds. If you want to trigger the processing immediately, use this method.
      */
     async notify(): Promise<void> {
-        setImmediate(this._maybeRunTask);
+        // `notify()` can be called from within a running task (e.g. a request handler), in which case
+        // `@apify/timeout`'s AsyncLocalStorage context of that task - possibly already timed out - would
+        // otherwise leak into the deferred `_maybeRunTask()` call and abort unrelated tasks it starts.
+        timeoutStorage.exit(() => setImmediate(this._maybeRunTask));
     }
 
     /**

--- a/test/core/crawlers/basic_crawler.test.ts
+++ b/test/core/crawlers/basic_crawler.test.ts
@@ -1070,6 +1070,41 @@ describe('BasicCrawler', () => {
         vitest.restoreAllMocks();
     });
 
+    test('notify() called from a stalled request handler does not abort the whole crawl (GH #4081)', async () => {
+        const processed: string[] = [];
+        const failed: string[] = [];
+
+        const crawler = new BasicCrawler({
+            keepAlive: true,
+            maxRequestRetries: 0,
+            requestHandlerTimeoutSecs: 1,
+            requestHandler: async ({ request, crawler: c }) => {
+                if (request.url.endsWith('/orphan')) {
+                    // Overrun requestHandlerTimeoutSecs, then reach for the pool from the
+                    // already-aborted `@apify/timeout` context, as described in the issue.
+                    await sleep(2000);
+                    await c.addRequests(['https://example.com/never-crawled']);
+                    await c.autoscaledPool!.notify();
+                    return;
+                }
+
+                processed.push(request.url);
+            },
+            failedRequestHandler: async ({ request }) => {
+                failed.push(request.url);
+            },
+        });
+
+        setTimeout(() => {
+            void crawler.teardown();
+        }, 4000);
+
+        await crawler.run(['https://example.com/orphan']);
+
+        expect(failed).toEqual(['https://example.com/orphan']);
+        expect(processed).toEqual(['https://example.com/never-crawled']);
+    }, 10_000);
+
     test('should support maxRequestsPerCrawl parameter', async () => {
         const sources = [
             { url: 'http://example.com/1' },


### PR DESCRIPTION
`notify()` deferred the pool loop with `setImmediate()`, which inherited the calling request handler's already-aborted `@apify/timeout` context and rejected the whole crawl instead of just the overrun request.

Fixes #4081.