### PR TITLE
chore: test apify-shared v3 betas

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,6 +210,11 @@ catalogs:
       version: 4.4.3
 
 overrides:
+  '@apify/consts': 3.0.0-beta.2
+  '@apify/datastructures': 3.0.0-beta.2
+  '@apify/log': 3.0.0-beta.2
+  '@apify/timeout': 1.0.0-beta.2
+  '@apify/utilities': 3.0.0-beta.2
   minimatch: ^9.0.0
   '@puppeteer/browsers': ^3.0.4
   tar: ^7.5.16
@@ -230,8 +235,8 @@ importers:
   .:
     devDependencies:
       '@apify/log':
-        specifier: ^2.5.18
-        version: 2.5.35
+        specifier: 3.0.0-beta.2
+        version: 3.0.0-beta.2
       '@apify/oxlint-config':
         specifier: ^0.2.5
         version: 0.2.5(oxlint@1.62.0(oxlint-tsgolint@7.0.2001))
@@ -555,14 +560,14 @@ importers:
   packages/basic-crawler:
     dependencies:
       '@apify/datastructures':
-        specifier: ^2.0.0
-        version: 2.0.4
+        specifier: 3.0.0-beta.2
+        version: 3.0.0-beta.2
       '@apify/timeout':
-        specifier: ^0.4.4
-        version: 0.4.4
+        specifier: 1.0.0-beta.2
+        version: 1.0.0-beta.2
       '@apify/utilities':
-        specifier: ^2.15.5
-        version: 2.27.0
+        specifier: 3.0.0-beta.2
+        version: 3.0.0-beta.2
       '@crawlee/core':
         specifier: workspace:*
         version: link:../core
@@ -598,8 +603,8 @@ importers:
   packages/browser-crawler:
     dependencies:
       '@apify/timeout':
-        specifier: ^0.4.4
-        version: 0.4.4
+        specifier: 1.0.0-beta.2
+        version: 1.0.0-beta.2
       '@crawlee/basic':
         specifier: workspace:*
         version: link:../basic-crawler
@@ -631,8 +636,8 @@ importers:
   packages/browser-pool:
     dependencies:
       '@apify/timeout':
-        specifier: ^0.4.4
-        version: 0.4.4
+        specifier: 1.0.0-beta.2
+        version: 1.0.0-beta.2
       '@crawlee/core':
         specifier: workspace:*
         version: link:../core
@@ -721,20 +726,20 @@ importers:
   packages/core:
     dependencies:
       '@apify/consts':
-        specifier: ^2.41.0
-        version: 2.52.1
+        specifier: 3.0.0-beta.2
+        version: 3.0.0-beta.2
       '@apify/datastructures':
-        specifier: ^2.0.3
-        version: 2.0.4
+        specifier: 3.0.0-beta.2
+        version: 3.0.0-beta.2
       '@apify/log':
-        specifier: ^2.5.18
-        version: 2.5.35
+        specifier: 3.0.0-beta.2
+        version: 3.0.0-beta.2
       '@apify/timeout':
-        specifier: ^0.4.4
-        version: 0.4.4
+        specifier: 1.0.0-beta.2
+        version: 1.0.0-beta.2
       '@apify/utilities':
-        specifier: ^2.15.5
-        version: 2.27.0
+        specifier: 3.0.0-beta.2
+        version: 3.0.0-beta.2
       '@crawlee/fs-storage':
         specifier: workspace:*
         version: link:../fs-storage
@@ -883,11 +888,11 @@ importers:
   packages/http-crawler:
     dependencies:
       '@apify/timeout':
-        specifier: ^0.4.4
-        version: 0.4.4
+        specifier: 1.0.0-beta.2
+        version: 1.0.0-beta.2
       '@apify/utilities':
-        specifier: ^2.15.5
-        version: 2.27.0
+        specifier: 3.0.0-beta.2
+        version: 3.0.0-beta.2
       '@crawlee/basic':
         specifier: workspace:*
         version: link:../basic-crawler
@@ -931,8 +936,8 @@ importers:
   packages/impit-client:
     dependencies:
       '@apify/datastructures':
-        specifier: ^2.0.3
-        version: 2.0.4
+        specifier: 3.0.0-beta.2
+        version: 3.0.0-beta.2
       '@crawlee/http-client':
         specifier: workspace:*
         version: link:../http-client
@@ -949,11 +954,11 @@ importers:
   packages/jsdom-crawler:
     dependencies:
       '@apify/timeout':
-        specifier: ^0.4.4
-        version: 0.4.4
+        specifier: 1.0.0-beta.2
+        version: 1.0.0-beta.2
       '@apify/utilities':
-        specifier: ^2.7.10
-        version: 2.27.0
+        specifier: 3.0.0-beta.2
+        version: 3.0.0-beta.2
       '@crawlee/http':
         specifier: workspace:*
         version: link:../http-crawler
@@ -982,11 +987,11 @@ importers:
   packages/linkedom-crawler:
     dependencies:
       '@apify/timeout':
-        specifier: ^0.4.4
-        version: 0.4.4
+        specifier: 1.0.0-beta.2
+        version: 1.0.0-beta.2
       '@apify/utilities':
-        specifier: ^2.15.5
-        version: 2.27.0
+        specifier: 3.0.0-beta.2
+        version: 3.0.0-beta.2
       '@crawlee/http':
         specifier: workspace:*
         version: link:../http-crawler
@@ -1028,11 +1033,11 @@ importers:
   packages/playwright-crawler:
     dependencies:
       '@apify/datastructures':
-        specifier: ^2.0.3
-        version: 2.0.4
+        specifier: 3.0.0-beta.2
+        version: 3.0.0-beta.2
       '@apify/timeout':
-        specifier: ^0.4.4
-        version: 0.4.4
+        specifier: 1.0.0-beta.2
+        version: 1.0.0-beta.2
       '@crawlee/basic':
         specifier: workspace:*
         version: link:../basic-crawler
@@ -1085,8 +1090,8 @@ importers:
   packages/puppeteer-crawler:
     dependencies:
       '@apify/datastructures':
-        specifier: ^2.0.3
-        version: 2.0.4
+        specifier: 3.0.0-beta.2
+        version: 3.0.0-beta.2
       '@crawlee/browser':
         specifier: workspace:*
         version: link:../browser-crawler
@@ -1124,8 +1129,8 @@ importers:
   packages/stagehand-crawler:
     dependencies:
       '@apify/timeout':
-        specifier: ^0.4.4
-        version: 0.4.4
+        specifier: 1.0.0-beta.2
+        version: 1.0.0-beta.2
       '@crawlee/browser':
         specifier: workspace:*
         version: link:../browser-crawler
@@ -1218,8 +1223,8 @@ importers:
         specifier: ^1.23.0
         version: 1.34.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@apify/utilities':
-        specifier: ^2.8.0
-        version: 2.27.0
+        specifier: 3.0.0-beta.2
+        version: 3.0.0-beta.2
       '@docusaurus/core':
         specifier: 3.10.2
         version: 3.10.2(patch_hash=7e95e0e59f770d24c0e51e1e2635b0a25edf33b38938162fa8c69ab42d38b1fb)(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.15.43)(esbuild@0.27.7)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(uglify-js@3.19.3))(esbuild@0.27.7)(uglify-js@3.19.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.43)(bufferutil@4.1.0)(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(esbuild@0.27.7)(lightningcss@1.33.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(supports-color@8.1.1)(typescript@6.0.3)(uglify-js@3.19.3)
@@ -1524,11 +1529,13 @@ packages:
   '@anthropic-ai/sdk@0.39.0':
     resolution: {integrity: sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==}
 
-  '@apify/consts@2.52.1':
-    resolution: {integrity: sha512-Nhal8FiIgAw5ylVL4U2DAeJJyKow0bFObAX/og5BJjB9xJ2csQcyVAx4ChnO7XOaeRU8HbRn9u0QUGzPt5NNqA==}
+  '@apify/consts@3.0.0-beta.2':
+    resolution: {integrity: sha512-kzxZZymdGTExboOUas4ie3+wWAKvS32WQwtA1QqEk0OoMfwbtUtDLBfT4l65lHKeF7p0JkFjWy+TxbxA/RkXyQ==}
+    engines: {node: '>=22'}
 
-  '@apify/datastructures@2.0.4':
-    resolution: {integrity: sha512-O/evwowHyN3HvP4oZxIzTFfrhOEynw9uvPk7qXquTU1yLB2WQxEWhoJdvGwVTXGuYm9Qd/0HOycPjk5m1NGDhQ==}
+  '@apify/datastructures@3.0.0-beta.2':
+    resolution: {integrity: sha512-IDeKHt0bfLdrNC7UcI7by3fOlHlQrGNu4OO5LeP/d+x/QqwAusVv4Er6h3SUZu5ZTAmhaLtXMoB7WguG816aAg==}
+    engines: {node: '>=22'}
 
   '@apify/docusaurus-plugin-typedoc-api@5.1.16':
     resolution: {integrity: sha512-zAKTwPpXq03lvNGfw3BE6SyyVUFyzkht15YUYki15Znm25h6Tpk2/n/tphgSPooYqMo8Sh0c7ljhCsDDpkT9NQ==}
@@ -1562,8 +1569,9 @@ packages:
   '@apify/input_secrets@1.2.30':
     resolution: {integrity: sha512-8sAHjOtLrjFm3DLKxKvpNQwzWTse7YyUQqHqNxpfZ2HDvYc6cJDB3o+0s/AlJTQrB+FdX+eki/4V0c4gcjXkUw==}
 
-  '@apify/log@2.5.35':
-    resolution: {integrity: sha512-dJM9RkA9yD7kew5oU3qxLaoB4hFHB7FF47TI0STJVmz0cUa8cXWer4DpJkvUA52lrVNQGsOurCo3kGQWzfg/9w==}
+  '@apify/log@3.0.0-beta.2':
+    resolution: {integrity: sha512-ZG0gl7e61obWrcUlR3Z8vs9O/fFNt/rVq/VJdqTKLreFg7UBo1RgMLoNy8fnNJeWlqm1JpmzphlEvLZ/ywDUjQ==}
+    engines: {node: '>=22'}
 
   '@apify/oxlint-config@0.2.5':
     resolution: {integrity: sha512-WTv3t49YBsAw/iIO3LauT7Gy/f9AEqMAqRwUtLBx1+gcBZSB0t2IHa4AqJA9DIo5115dnY6CWyqbqaf1IP0m0A==}
@@ -1575,8 +1583,9 @@ packages:
     engines: {node: '>= 0.10'}
     hasBin: true
 
-  '@apify/timeout@0.4.4':
-    resolution: {integrity: sha512-WOjdkuNRSo09ikse47t6jIW4R55FEmZdOaoUTbSmpwfmNNHVht+iTgoqeHIVr7vvI9s+mtTmvzPoesoZa0cjVA==}
+  '@apify/timeout@1.0.0-beta.2':
+    resolution: {integrity: sha512-xyNJvSdimm5MKooi/gawLT9uoscns6scgtbdWGl0+t8cWqSNNeTYCxeeWIxMVuzc5KW7ApAzVaq3ybz3ou5FXQ==}
+    engines: {node: '>=22'}
 
   '@apify/tsconfig@0.2.0':
     resolution: {integrity: sha512-0i6rF+hgXw6mQXhENYNTnP+Yo4WY38d698k/pk4rIpdCx/sSuEprR2N5WdtMaN628vCB+aZjff0jPN2EnQYtjQ==}
@@ -1587,8 +1596,9 @@ packages:
       react: 17.x || 18.x || 19.x
       react-dom: 17.x || 18.x || 19.x
 
-  '@apify/utilities@2.27.0':
-    resolution: {integrity: sha512-P3maAvUi5sUw4F4AKRyfczAQAl20YodEjSlFrjg6Bif8ThRAott7atEAfdy8FfyjI7Z0l+0MrbvtF4ZiGdJ8mw==}
+  '@apify/utilities@3.0.0-beta.2':
+    resolution: {integrity: sha512-/tQLog5MdAXyz/eLc+SLjJzY932K6xnVbSM4HbU44fkcpAbRdS50pWM6dRX4BNw8TLvC9m6nDZmcmFNEYCxpbQ==}
+    engines: {node: '>=22'}
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
@@ -13765,9 +13775,9 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@apify/consts@2.52.1': {}
+  '@apify/consts@3.0.0-beta.2': {}
 
-  '@apify/datastructures@2.0.4': {}
+  '@apify/datastructures@3.0.0-beta.2': {}
 
   '@apify/docusaurus-plugin-typedoc-api@5.1.16(7a9803b22b375410b54dc7fc5d3b5ce0)':
     dependencies:
@@ -13824,13 +13834,13 @@ snapshots:
 
   '@apify/input_secrets@1.2.30':
     dependencies:
-      '@apify/log': 2.5.35
-      '@apify/utilities': 2.27.0
+      '@apify/log': 3.0.0-beta.2
+      '@apify/utilities': 3.0.0-beta.2
       ow: 0.28.2
 
-  '@apify/log@2.5.35':
+  '@apify/log@3.0.0-beta.2':
     dependencies:
-      '@apify/consts': 2.52.1
+      '@apify/consts': 3.0.0-beta.2
       ansi-colors: 4.1.3
 
   '@apify/oxlint-config@0.2.5(oxlint@1.62.0(oxlint-tsgolint@7.0.2001))':
@@ -13841,7 +13851,7 @@ snapshots:
     dependencies:
       event-stream: 3.3.4
 
-  '@apify/timeout@0.4.4': {}
+  '@apify/timeout@1.0.0-beta.2': {}
 
   '@apify/tsconfig@0.2.0': {}
 
@@ -13851,10 +13861,10 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  '@apify/utilities@2.27.0':
+  '@apify/utilities@3.0.0-beta.2':
     dependencies:
-      '@apify/consts': 2.52.1
-      '@apify/log': 2.5.35
+      '@apify/consts': 3.0.0-beta.2
+      '@apify/log': 3.0.0-beta.2
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -19243,9 +19253,9 @@ snapshots:
 
   apify-client@2.23.4(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0):
     dependencies:
-      '@apify/consts': 2.52.1
-      '@apify/log': 2.5.35
-      '@apify/utilities': 2.27.0
+      '@apify/consts': 3.0.0-beta.2
+      '@apify/log': 3.0.0-beta.2
+      '@apify/utilities': 3.0.0-beta.2
       '@crawlee/types': 3.16.0
       ansi-colors: 4.1.3
       async-retry: 1.3.3
@@ -19261,9 +19271,9 @@ snapshots:
 
   apify-client@2.23.4(debug@4.4.3(supports-color@7.2.0))(supports-color@8.1.1):
     dependencies:
-      '@apify/consts': 2.52.1
-      '@apify/log': 2.5.35
-      '@apify/utilities': 2.27.0
+      '@apify/consts': 3.0.0-beta.2
+      '@apify/log': 3.0.0-beta.2
+      '@apify/utilities': 3.0.0-beta.2
       '@crawlee/types': 3.16.0
       ansi-colors: 4.1.3
       async-retry: 1.3.3
@@ -19281,12 +19291,12 @@ snapshots:
 
   apify@4.0.0-beta.24(bufferutil@4.1.0)(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0):
     dependencies:
-      '@apify/consts': 2.52.1
-      '@apify/datastructures': 2.0.4
+      '@apify/consts': 3.0.0-beta.2
+      '@apify/datastructures': 3.0.0-beta.2
       '@apify/input_secrets': 1.2.30
-      '@apify/log': 2.5.35
-      '@apify/timeout': 0.4.4
-      '@apify/utilities': 2.27.0
+      '@apify/log': 3.0.0-beta.2
+      '@apify/timeout': 1.0.0-beta.2
+      '@apify/utilities': 3.0.0-beta.2
       '@crawlee/core': link:packages/core
       '@crawlee/types': link:packages/types
       '@crawlee/utils': link:packages/utils
@@ -19303,12 +19313,12 @@ snapshots:
 
   apify@4.0.0-beta.24(bufferutil@4.1.0)(debug@4.4.3(supports-color@7.2.0))(supports-color@8.1.1):
     dependencies:
-      '@apify/consts': 2.52.1
-      '@apify/datastructures': 2.0.4
+      '@apify/consts': 3.0.0-beta.2
+      '@apify/datastructures': 3.0.0-beta.2
       '@apify/input_secrets': 1.2.30
-      '@apify/log': 2.5.35
-      '@apify/timeout': 0.4.4
-      '@apify/utilities': 2.27.0
+      '@apify/log': 3.0.0-beta.2
+      '@apify/timeout': 1.0.0-beta.2
+      '@apify/utilities': 3.0.0-beta.2
       '@crawlee/core': link:packages/core
       '@crawlee/types': link:packages/types
       '@crawlee/utils': link:packages/utils
@@ -28441,7 +28451,7 @@ snapshots:
       browserslist: 4.28.8
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.20.1
-      es-module-lexer: 2.0.0
+      es-module-lexer: 2.3.2
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,6 +16,12 @@ minimumReleaseAgeExclude:
   - "got-scraping"
 
 overrides:
+  # Test the apify-shared-js v3 betas (next dist-tag) across the workspace
+  "@apify/consts": "3.0.0-beta.2"
+  "@apify/datastructures": "3.0.0-beta.2"
+  "@apify/log": "3.0.0-beta.2"
+  "@apify/timeout": "1.0.0-beta.2"
+  "@apify/utilities": "3.0.0-beta.2"
   # Dedup minimatch to v9 everywhere except inside lerna — lerna 9.x's bundled
   # code (`__toESM(require('minimatch')).default(...)`) only works with v3,
   # whose CJS export *is* the function. Pinning v9 there caused the publish


### PR DESCRIPTION
Forces the `@apify/*` shared packages to the v3 betas from the `next` dist-tag (apify/apify-shared-js#683 and its stack: ESM-only, Node 22+) via pnpm overrides, to run this repo's checks against them before the majors graduate. Test branch, not meant to merge.
