### PR TITLE
fix(core): make skipNavigation request bookkeeping proxy-safe

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -1270,7 +1270,7 @@ export class BasicCrawler<
                                     crawlingContext,
                                     this.basicContextPipeline
                                         .chain(this.contextPipeline)
-                                        .call(crawlingContext, (ctx) => this.handleRequest(ctx, source, request)),
+                                        .call(crawlingContext, (ctx) => this.handleRequest(ctx, source)),
                                 ),
                         );
                     } catch (error) {
@@ -1279,7 +1279,7 @@ export class BasicCrawler<
                         if (error instanceof ContextPipelineInterruptedError) {
                             this.statistics.discardJob(request.id || request.uniqueKey);
                             await this.timeoutAndRetry(
-                                async () => this.requestManager?.markRequestAsHandled(request),
+                                async () => this.requestManager?.markRequestAsHandled(crawlingContext.request),
                                 this.internalTimeoutMillis,
                                 `Marking request ${crawlingContext.request.url} (${crawlingContext.request.id}) as handled timed out after ${
                                     this.internalTimeoutMillis / 1e3
@@ -1301,7 +1301,6 @@ export class BasicCrawler<
                             await this.requestFunctionErrorHandler(
                                 unwrappedError,
                                 crawlingContext as CrawlingContext,
-                                request,
                                 this.requestManager!,
                             );
                             // SessionError already retired the session in `requestFunctionErrorHandler`;
@@ -2639,13 +2638,15 @@ export class BasicCrawler<
     }
 
     /** Handles a single request - runs the request handler with retries, error handling, and lifecycle management. */
-    private async handleRequest(crawlingContext: ExtendedContext, requestSource: IRequestManager, request: Request) {
+    private async handleRequest(crawlingContext: ExtendedContext, requestSource: IRequestManager) {
         // An earlier phase we cannot cancel (e.g. a slow `extendContext`) may have run past the internal timeout,
         // which already failed the request in `runTaskFunction`. Bail before running the handler so it does not
         // execute (and re-report) on top of a request the crawler has already moved past.
         if ((crawlingContext as PendingCrawlingContext)[timeoutExpiredKey]?.()) {
             return;
         }
+
+        const { request } = crawlingContext;
 
         const statisticsId = request.id || request.uniqueKey;
 
@@ -2663,7 +2664,7 @@ export class BasicCrawler<
             await transaction?.commit();
 
             await this.timeoutAndRetry(
-                async () => requestSource.markRequestAsHandled(request!),
+                async () => requestSource.markRequestAsHandled(request),
                 this.internalTimeoutMillis,
                 `Marking request ${request.url} (${request.id}) as handled timed out after ${
                     this.internalTimeoutMillis / 1e3
@@ -2686,7 +2687,7 @@ export class BasicCrawler<
             try {
                 request.state = RequestState.ERROR_HANDLER;
                 await addTimeoutToPromise(
-                    async () => this.requestFunctionErrorHandler(err, crawlingContext, request, requestSource),
+                    async () => this.requestFunctionErrorHandler(err, crawlingContext, requestSource),
                     this.internalTimeoutMillis,
                     `Handling request failure of ${request.url} (${request.id}) timed out after ${
                         this.internalTimeoutMillis / 1e3
@@ -2844,15 +2845,14 @@ export class BasicCrawler<
 
     /**
      * Handles errors thrown by user provided requestHandler()
-     *
-     * @param request The request object, passed separately to circumvent potential dynamic logic in crawlingContext.request
      */
     private async requestFunctionErrorHandler(
         error: Error,
         crawlingContext: CrawlingContext,
-        request: Request,
         source: IRequestManager,
     ): Promise<void> {
+        const { request } = crawlingContext;
+
         if (error instanceof RequestThrottledError) {
             // The domain told us to come back later, so the request was never really attempted. Put it back
             // without recording a failure - it costs neither a retry nor session reputation.

--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -642,6 +642,14 @@ export abstract class BrowserCrawler<
                         }
                         return Reflect.get(target, propertyName, receiver);
                     },
+                    // Hide `loadedUrl` from enumeration so bookkeeping (spread/JSON/zod) skips it; direct reads still throw above.
+                    getOwnPropertyDescriptor(target, propertyName) {
+                        const descriptor = Reflect.getOwnPropertyDescriptor(target, propertyName);
+                        if (propertyName === 'loadedUrl' && descriptor) {
+                            return { ...descriptor, enumerable: false };
+                        }
+                        return descriptor;
+                    },
                 }) as LoadedRequest<Request>,
                 get response(): Response {
                     throw new NavigationSkippedError(

--- a/packages/http-crawler/src/internals/http-crawler.ts
+++ b/packages/http-crawler/src/internals/http-crawler.ts
@@ -509,6 +509,14 @@ export class HttpCrawler<
                         }
                         return Reflect.get(target, propertyName, receiver);
                     },
+                    // Hide `loadedUrl` from enumeration so bookkeeping (spread/JSON/zod) skips it; direct reads still throw above.
+                    getOwnPropertyDescriptor(target, propertyName) {
+                        const descriptor = Reflect.getOwnPropertyDescriptor(target, propertyName);
+                        if (propertyName === 'loadedUrl' && descriptor) {
+                            return { ...descriptor, enumerable: false };
+                        }
+                        return descriptor;
+                    },
                 }) as LoadedRequest<CrawleeRequest>,
                 get response(): InternalHttpCrawlingContext['response'] {
                     throw new NavigationSkippedError(

--- a/test/core/crawlers/browser_crawler.test.ts
+++ b/test/core/crawlers/browser_crawler.test.ts
@@ -18,7 +18,16 @@ import {
     SessionPool,
 } from '@crawlee/core';
 import type { PuppeteerGoToOptions } from '@crawlee/puppeteer';
-import { EnqueueStrategy, ProxyConfiguration, Request, RequestList, RequestState, Session } from '@crawlee/puppeteer';
+import {
+    EnqueueStrategy,
+    NavigationSkippedError,
+    ProxyConfiguration,
+    Request,
+    RequestList,
+    RequestQueue,
+    RequestState,
+    Session,
+} from '@crawlee/puppeteer';
 import { sleep } from '@crawlee/utils';
 // @ts-ignore This only throws when compiled against puppeteer 25+ (ESM only), we only import types, so its alllll gooooood
 import type { HTTPResponse } from 'puppeteer';
@@ -116,6 +125,47 @@ describe('BrowserCrawler', () => {
             expect(request.url).toEqual(sourcesCopy[id].url);
             expect(request.userData.title).toBe('Example Domain');
         });
+    });
+
+    test.concurrent('marks a skipNavigation request as handled via the proxied context', async () => {
+        const puppeteerPlugin = new PuppeteerPlugin(puppeteer);
+
+        const processed: Request[] = [];
+        const failed: Request[] = [];
+
+        // A RequestQueue (unlike RequestList) serializes the whole request during bookkeeping.
+        const requestQueue = await RequestQueue.open();
+        await requestQueue.addRequest({
+            url: `${serverAddress}/`,
+            userData: { foo: 'bar' },
+            skipNavigation: true,
+        });
+
+        const browserCrawler = new BrowserCrawlerTest({
+            browserPoolOptions: {
+                browserPlugins: [puppeteerPlugin],
+            },
+            requestQueue,
+            minConcurrency: 1,
+            maxConcurrency: 1,
+            requestHandler: async ({ request }) => {
+                expect(() => request.loadedUrl).toThrow(NavigationSkippedError);
+                processed.push(request);
+            },
+            failedRequestHandler: async ({ request }) => {
+                failed.push(request);
+            },
+        });
+
+        await browserCrawler.run();
+
+        expect(processed).toHaveLength(1);
+        expect(failed).toHaveLength(0);
+
+        const readBack = await requestQueue.getRequest(processed[0].uniqueKey);
+        expect(readBack).not.toBeNull();
+        expect(readBack!.handledAt).toBeDefined();
+        expect(readBack!.userData).toEqual({ foo: 'bar' });
     });
 
     test.concurrent('should teardown browser pool', async () => {

--- a/test/core/storages/request_queue.test.ts
+++ b/test/core/storages/request_queue.test.ts
@@ -1,6 +1,14 @@
 /* eslint-disable dot-notation */
 
-import { MemoryStorageBackend, ProxyConfiguration, Request, RequestQueue, serviceLocator } from '@crawlee/core';
+import type { LoadedRequest } from '@crawlee/core';
+import {
+    MemoryStorageBackend,
+    NavigationSkippedError,
+    ProxyConfiguration,
+    Request,
+    RequestQueue,
+    serviceLocator,
+} from '@crawlee/core';
 import { BaseHttpClient } from '@crawlee/http-client';
 import { sleep } from '@crawlee/utils';
 
@@ -702,4 +710,83 @@ describe('RequestQueue background batches', () => {
         await queue.markRequestAsHandled(req!);
         expect((await queue.checkReadiness()).status).toBe('finished');
     }, 10_000);
+});
+
+describe('RequestQueue bookkeeping with a skipNavigation request', () => {
+    beforeEach(async () => {
+        serviceLocator.setStorageBackend(new MemoryStorageBackend());
+        vitest.clearAllMocks();
+    });
+
+    // Mirror the crawlers' `skipNavigation` proxy: `loadedUrl` throws for user code but is non-enumerable
+    // so bookkeeping's spread/zod/JSON skips it.
+    const wrapSkipNavigation = (request: Request): LoadedRequest<Request> =>
+        new Proxy(request, {
+            get(target, propertyName, receiver) {
+                if (propertyName === 'loadedUrl') {
+                    throw new NavigationSkippedError(
+                        'The `request.loadedUrl` property is not available - `skipNavigation` was used',
+                    );
+                }
+                return Reflect.get(target, propertyName, receiver);
+            },
+            getOwnPropertyDescriptor(target, propertyName) {
+                const descriptor = Reflect.getOwnPropertyDescriptor(target, propertyName);
+                if (propertyName === 'loadedUrl' && descriptor) {
+                    return { ...descriptor, enumerable: false };
+                }
+                return descriptor;
+            },
+        }) as LoadedRequest<Request>;
+
+    test('markRequestAsHandled accepts the proxied request without NavigationSkippedError and keeps its fields', async () => {
+        const queue = await RequestQueue.open();
+        await queue.addRequest({
+            url: 'http://example.com/a',
+            userData: { foo: 'bar' },
+            skipNavigation: true,
+        });
+
+        const fetched = await queue.fetchNextRequest();
+        expect(fetched).not.toBeNull();
+        const proxied = wrapSkipNavigation(fetched!);
+
+        expect(() => proxied.loadedUrl).toThrow(NavigationSkippedError);
+
+        await expect(queue.markRequestAsHandled(proxied)).resolves.not.toBeNull();
+
+        // The guard still throws after bookkeeping — hiding `loadedUrl` from enumeration is internal only.
+        expect(() => proxied.loadedUrl).toThrow(NavigationSkippedError);
+
+        const readBack = await queue.getRequest(fetched!.uniqueKey);
+        expect(readBack).not.toBeNull();
+        expect(readBack!.url).toBe('http://example.com/a');
+        expect(readBack!.uniqueKey).toBe(fetched!.uniqueKey);
+        expect(readBack!.userData).toEqual({ foo: 'bar' });
+        expect(readBack!.handledAt).toBeDefined();
+    });
+
+    test('reclaimRequest accepts the proxied request without NavigationSkippedError and keeps its fields', async () => {
+        const queue = await RequestQueue.open();
+        await queue.addRequest({
+            url: 'http://example.com/b',
+            userData: { foo: 'baz' },
+            skipNavigation: true,
+        });
+
+        const fetched = await queue.fetchNextRequest();
+        expect(fetched).not.toBeNull();
+        const proxied = wrapSkipNavigation(fetched!);
+
+        await expect(queue.reclaimRequest(proxied)).resolves.not.toBeNull();
+
+        // The guard still throws after bookkeeping — hiding `loadedUrl` from enumeration is internal only.
+        expect(() => proxied.loadedUrl).toThrow(NavigationSkippedError);
+
+        const readBack = await queue.getRequest(fetched!.uniqueKey);
+        expect(readBack).not.toBeNull();
+        expect(readBack!.url).toBe('http://example.com/b');
+        expect(readBack!.uniqueKey).toBe(fetched!.uniqueKey);
+        expect(readBack!.userData).toEqual({ foo: 'baz' });
+    });
 });


### PR DESCRIPTION
With skipNavigation, the request is wrapped in a Proxy whose loadedUrl getter throws. Internal request-queue bookkeeping reads the whole request and tripped that, so BasicCrawler worked around it by passing the original unproxied request as a separate argument.

The proxy now marks loadedUrl non-enumerable, so bookkeeping skips it while direct access still throws. That lets the normal request flow through, and the extra argument is removed.

- closes #3526