### PR TITLE
fix(core): log background request-batch failures instead of swallowing them

### DIFF
--- a/packages/basic-crawler/src/internals/basic-crawler.ts
+++ b/packages/basic-crawler/src/internals/basic-crawler.ts
@@ -2228,6 +2228,10 @@ export class BasicCrawler<
         });
         // Keep callback failures observable to callers that await this promise without emitting an unhandled rejection
         // when callers intentionally leave background additions running, matching `drainRequestBatches` behavior.
+        // Silent by design, not an oversight: this `.then()` derives a new promise from `result
+        // .waitForAllRequestsToBeAdded` (the same `remainder` `drainRequestBatches` already attaches its own
+        // logging catch to), and Node tracks unhandled rejections per promise object - so this still needs a
+        // handler of its own to avoid a crash, but logging here too would double-report the same failure.
         void waitForAllRequestsToBeAdded.catch(() => {});
 
         return { ...result, waitForAllRequestsToBeAdded };

--- a/packages/core/src/storages/batched_adds.ts
+++ b/packages/core/src/storages/batched_adds.ts
@@ -2,6 +2,7 @@ import { setTimeout as sleep } from 'node:timers/promises';
 import type { ProcessedRequest } from '@crawlee/types';
 
 import { chunkedAsyncIterable, peekableAsyncIterable } from '../iterables.js';
+import type { CrawleeLogger } from '../log.js';
 import type { Source } from '../request.js';
 import type { AddRequestsBatchedResult } from './request_queue.js';
 import { activeStorageTransaction, withDirectStorageAccess } from './transaction.js';
@@ -17,6 +18,12 @@ export interface DrainRequestBatchesOptions<TItem extends Source> {
     waitBetweenBatchesMillis: number;
     waitForAllRequestsToBeAdded: boolean;
     maxNewRequests?: number;
+
+    /**
+     * Used to report a background batch failure that nothing else observes - see the `trackBackgroundBatches`
+     * catch below.
+     */
+    log: CrawleeLogger;
 
     /**
      * Adds a single chunk and reports what it processed.
@@ -52,6 +59,7 @@ export async function drainRequestBatches<TItem extends Source>(
         waitBetweenBatchesMillis,
         waitForAllRequestsToBeAdded,
         maxNewRequests,
+        log,
         processChunk,
         trackBackgroundBatches,
     } = options;
@@ -125,8 +133,15 @@ export async function drainRequestBatches<TItem extends Source>(
     const remainder = awaitsRemainder ? processRemainingChunks() : withDirectStorageAccess(processRemainingChunks);
 
     // The caller is not obliged to await `remainder`, so give it a handler of its own - an unhandled
-    // rejection here would otherwise take the process down.
-    trackBackgroundBatches?.(remainder.catch(() => {}));
+    // rejection here would otherwise take the process down. Logged rather than silently swallowed: without
+    // this, a background batch failure (and every request still queued behind it) previously vanished with
+    // no log, no `unprocessedRequests` entry, and no stats hit - on the default `crawler.run(urls)` path.
+    trackBackgroundBatches?.(
+        remainder.catch((error) => {
+            log.exception(error as Error, 'A batch of requests could not be added to the queue in the background');
+            return [];
+        }),
+    );
 
     if (awaitsRemainder) {
         addedRequests.push(...(await remainder));

--- a/packages/core/src/storages/request_queue.ts
+++ b/packages/core/src/storages/request_queue.ts
@@ -632,6 +632,7 @@ export class RequestQueue implements IStorage, IRequestManager {
             waitBetweenBatchesMillis,
             waitForAllRequestsToBeAdded,
             maxNewRequests,
+            log: this.log,
 
             /**
              * Requests the backend reports as unprocessed are warned about and skipped rather than retried:

--- a/packages/core/src/storages/throttling_request_manager.ts
+++ b/packages/core/src/storages/throttling_request_manager.ts
@@ -807,6 +807,7 @@ export class ThrottlingRequestManager<T extends IRequestManager = IRequestManage
             waitBetweenBatchesMillis: options.waitBetweenBatchesMillis ?? 1000,
             waitForAllRequestsToBeAdded: options.waitForAllRequestsToBeAdded ?? false,
             maxNewRequests: options.maxNewRequests,
+            log: this.log,
 
             // Routing is the only thing this manager adds; the targets do the batching, validation and
             // deduplication themselves.

--- a/test/core/storages/batched_adds.test.ts
+++ b/test/core/storages/batched_adds.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vitest } from 'vitest';
+
+import { drainRequestBatches } from '../../../packages/core/src/storages/batched_adds.js';
+
+describe('drainRequestBatches', () => {
+    // A failure in the background (non-initial) chunk previously vanished with no log, no
+    // `unprocessedRequests` entry, and no stats hit - the initial chunk's own success masked it entirely
+    // on the default `waitForAllRequestsToBeAdded: false` path used by `crawler.run(urls)`.
+    it('logs a background batch failure instead of swallowing it silently', async () => {
+        async function* items() {
+            yield { url: 'https://example.com/1' };
+            yield { url: 'https://example.com/2' };
+        }
+
+        const log = { exception: vitest.fn() } as any;
+        const backgroundError = new Error('backend unavailable');
+        // `trackBackgroundBatches` receives the exact `remainder.catch(...)` promise the fix attaches its
+        // logging to - awaiting *that* (rather than `result.waitForAllRequestsToBeAdded`, a separately
+        // derived `.catch()` chain off the same underlying `remainder`) is what actually guarantees the
+        // log call has already happened by the time the assertion below runs.
+        let trackedPromise: Promise<unknown> | undefined;
+
+        const result = await drainRequestBatches({
+            items: items(),
+            batchSize: 1,
+            waitBetweenBatchesMillis: 0,
+            waitForAllRequestsToBeAdded: false,
+            log,
+            processChunk: async (chunk, isInitial) => {
+                if (!isInitial) throw backgroundError;
+                return chunk.map(() => ({ wasAlreadyPresent: false, wasAlreadyHandled: false }) as any);
+            },
+            trackBackgroundBatches: (batches) => {
+                trackedPromise = batches;
+            },
+        });
+
+        // The call itself still returns as soon as the initial chunk lands, without waiting for
+        // (or throwing because of) the background chunk - that part of the contract is unchanged.
+        expect(result.addedRequests).toHaveLength(1);
+
+        await trackedPromise;
+
+        expect(log.exception).toHaveBeenCalledTimes(1);
+        expect(log.exception).toHaveBeenCalledWith(backgroundError, expect.stringContaining('background'));
+    });
+
+    // The original swallow (`.catch(() => {})`) existed specifically to stop an un-awaited background
+    // failure from crashing the process as an unhandled rejection - confirms that guarantee still holds
+    // now that the same catch also logs.
+    it('still hands trackBackgroundBatches a promise that settles instead of rejecting', async () => {
+        async function* items() {
+            yield { url: 'https://example.com/1' };
+            yield { url: 'https://example.com/2' };
+        }
+
+        const log = { exception: vitest.fn() } as any;
+        let trackedPromise: Promise<unknown> | undefined;
+
+        await drainRequestBatches({
+            items: items(),
+            batchSize: 1,
+            waitBetweenBatchesMillis: 0,
+            waitForAllRequestsToBeAdded: false,
+            log,
+            processChunk: async (chunk, isInitial) => {
+                if (!isInitial) throw new Error('backend unavailable');
+                return chunk.map(() => ({ wasAlreadyPresent: false, wasAlreadyHandled: false }) as any);
+            },
+            trackBackgroundBatches: (batches) => {
+                trackedPromise = batches;
+            },
+        });
+
+        await expect(trackedPromise).resolves.toEqual([]);
+    });
+
+    it('does not log anything when every batch succeeds', async () => {
+        async function* items() {
+            yield { url: 'https://example.com/1' };
+            yield { url: 'https://example.com/2' };
+        }
+
+        const log = { exception: vitest.fn() } as any;
+
+        const result = await drainRequestBatches({
+            items: items(),
+            batchSize: 1,
+            waitBetweenBatchesMillis: 0,
+            waitForAllRequestsToBeAdded: true,
+            log,
+            processChunk: async (chunk) =>
+                chunk.map(() => ({ wasAlreadyPresent: false, wasAlreadyHandled: false }) as any),
+        });
+
+        expect(result.addedRequests).toHaveLength(2);
+        expect(log.exception).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## What's the problem?

`drainRequestBatches()` (used by `RequestQueue.addRequestsBatched()` and `ThrottlingRequestManager.addRequestsBatched()`, and therefore by `crawler.addRequests()` / `crawler.run(urls)`) adds the first batch synchronously and lets the rest continue in the background.

If a background batch fails, the promise handed to `trackBackgroundBatches()` was caught with an empty `.catch(() => {})` - added purely to stop an un-awaited rejection from crashing the process, but it also throws away the error entirely. Every request still queued behind that failure is silently dropped: no log, no `unprocessedRequests` entry, no stats hit - and this sits on the *default* `crawler.run(urls)` path, not an edge case.

## What's the fix?

The catch in `batched_adds.ts` now logs the error via `log.exception(...)` before resolving to `[]`, so the failure is at least visible - the original crash-prevention behavior (never rejecting) is unchanged. `RequestQueue` and `ThrottlingRequestManager` now pass their own `log` through to the shared helper, matching how `processChunk` already logs `unprocessedRequests` via `this.log.warning(...)`.

`BasicCrawler.addRequests()` has a second, similar `.catch(() => {})` on a promise derived from the same underlying one via `.then()`. Left that one silent on purpose - it is a distinct promise object so it still needs its own handler to avoid an unhandled rejection, but logging there too would double-report the same failure `drainRequestBatches()` already logs once.

## Testing

- Added `test/core/storages/batched_adds.test.ts` - unit tests directly against `drainRequestBatches()` covering: a background failure gets logged, the tracked promise still resolves (never rejects, so nothing crashes downstream), and the success path stays silent.
- Ran the full existing suite for the affected area (`test/core/storages/`, `basic_crawler.test.ts`, `request_manager_tandem.test.ts`, `packages/core/test/request-queue/`) - all pass unchanged.
- Confirmed via `tsc` that the change introduces zero new type errors (diffed error-for-error against the unmodified baseline).
- `oxlint`/`oxfmt` clean.