### PR TITLE
fix(browser-pool): survive a page.close() that never settles

### DIFF
--- a/packages/browser-crawler/src/internals/browser-crawler.ts
+++ b/packages/browser-crawler/src/internals/browser-crawler.ts
@@ -49,8 +49,6 @@ import { addTimeoutToPromise, tryCancel } from '@apify/timeout';
 
 import type { BrowserLaunchContext } from './browser-launcher';
 
-const PAGE_CLOSE_TIMEOUT_MILLIS = 5000;
-
 export interface BrowserCrawlingContext<
     Crawler = unknown,
     Page extends CommonPage = CommonPage,
@@ -464,12 +462,8 @@ export abstract class BrowserCrawler<
 
         // Page creation may be aborted
         if (page) {
-            // Puppeteer 25+ can hang `page.close()` indefinitely when the page's navigation was aborted, don't let it block the crawler.
-            await addTimeoutToPromise(
-                async () => page.close(),
-                PAGE_CLOSE_TIMEOUT_MILLIS,
-                `page.close() timed out after ${PAGE_CLOSE_TIMEOUT_MILLIS / 1000} seconds`,
-            ).catch((error: Error) => this.log.debug('Error while closing page', { error }));
+            // `BrowserPool` bounds this and reconciles its own state if the close never settles.
+            await page.close().catch((error: Error) => this.log.debug('Error while closing page', { error }));
         }
     }
 

--- a/packages/browser-pool/src/abstract-classes/browser-controller.ts
+++ b/packages/browser-pool/src/abstract-classes/browser-controller.ts
@@ -184,7 +184,7 @@ export abstract class BrowserController<
      * Accounts for a page no longer being open. Callable from either side and safe to call twice:
      * the page's own `close` event, or the pool when it gives up on a close that never settles.
      * Tracked in a `WeakSet` rather than via `isClosed()`, because that reports the same event.
-     * @ignore
+     * @internal
      */
     registerPageClosed(page: NewPageResult): void {
         if (this.closedPages.has(page as object)) return;

--- a/packages/browser-pool/src/abstract-classes/browser-controller.ts
+++ b/packages/browser-pool/src/abstract-classes/browser-controller.ts
@@ -74,6 +74,8 @@ export abstract class BrowserController<
 
     private readonly closedPages = new WeakSet<object>();
 
+    private readonly pageTeardowns = new WeakMap<object, () => Promise<void>>();
+
     totalPages = 0;
 
     lastPageOpenedAt = Date.now();
@@ -189,6 +191,27 @@ export abstract class BrowserController<
 
         this.closedPages.add(page as object);
         this.activePages--;
+
+        const teardown = this.pageTeardowns.get(page as object);
+        if (!teardown) return;
+
+        this.pageTeardowns.delete(page as object);
+        teardown().catch((error: Error) => {
+            log.debug(`Could not clean up after a closed page.\nCause:${error.message}`, { id: this.id });
+        });
+    }
+
+    /**
+     * Registers cleanup belonging to a single page: an anonymizing proxy server, an incognito
+     * context. It runs from `registerPageClosed`, so it happens whether the page closed on its own
+     * or the pool gave up on a close that never settled, and it runs at most once.
+     *
+     * Hanging it off the page's `close` event instead leaks it in exactly the case this controller
+     * now handles, because that event does not arrive for a page the browser never destroyed.
+     * @ignore
+     */
+    protected registerPageTeardown(page: NewPageResult, teardown: () => Promise<void>): void {
+        this.pageTeardowns.set(page as object, teardown);
     }
 
     async setCookies(page: NewPageResult, cookies: Cookie[]): Promise<void> {

--- a/packages/browser-pool/src/abstract-classes/browser-controller.ts
+++ b/packages/browser-pool/src/abstract-classes/browser-controller.ts
@@ -72,6 +72,8 @@ export abstract class BrowserController<
 
     activePages = 0;
 
+    private readonly closedPages = new WeakSet<object>();
+
     totalPages = 0;
 
     lastPageOpenedAt = Date.now();
@@ -174,6 +176,19 @@ export abstract class BrowserController<
         this.lastPageOpenedAt = Date.now();
 
         return page;
+    }
+
+    /**
+     * Accounts for a page no longer being open. Callable from either side and safe to call twice:
+     * the page's own `close` event, or the pool when it gives up on a close that never settles.
+     * Tracked in a `WeakSet` rather than via `isClosed()`, because that reports the same event.
+     * @ignore
+     */
+    registerPageClosed(page: NewPageResult): void {
+        if (this.closedPages.has(page as object)) return;
+
+        this.closedPages.add(page as object);
+        this.activePages--;
     }
 
     async setCookies(page: NewPageResult, cookies: Cookie[]): Promise<void> {

--- a/packages/browser-pool/src/browser-pool.ts
+++ b/packages/browser-pool/src/browser-pool.ts
@@ -838,7 +838,7 @@ export class BrowserPool<
                 closing.then(
                     () => true,
                     (err: Error) => {
-                        log.warning(`Page close hook failed.\nCause:${err.message}`, {
+                        log.warning(`Closing a page failed, releasing it from the pool anyway.\nCause:${err.message}`, {
                             id: browserController.id,
                             pageId,
                         });

--- a/packages/browser-pool/src/browser-pool.ts
+++ b/packages/browser-pool/src/browser-pool.ts
@@ -26,6 +26,7 @@ import { log } from './logger';
 import type { InferBrowserPluginArray, UnwrapPromise } from './utils';
 
 const PAGE_CLOSE_KILL_TIMEOUT_MILLIS = 1000;
+const PAGE_CLOSE_TIMEOUT_MILLIS = 5000;
 const BROWSER_KILLER_INTERVAL_MILLIS = 10 * 1000;
 
 export interface BrowserPoolEvents<BC extends BrowserController, Page> {
@@ -809,13 +810,62 @@ export class BrowserPool<
         const pageId = this.getPageId(page)!;
 
         page.close = async (...args: unknown[]) => {
-            await this._executeHooks(this.prePageCloseHooks, page, browserController);
+            // A browser can acknowledge the close and then never destroy the target, in which case
+            // this never settles and the page's own `close` event never fires either (Chromium
+            // 536385539). Bound the whole sequence so nothing here can hang the caller, then
+            // reconcile the pool regardless of the outcome, so a page that refuses to close cannot
+            // leave the pool believing it is still open. `Promise.race` rather than
+            // `addTimeoutToPromise`: the latter inherits its AbortController from the calling frame,
+            // so a timeout here would cancel the task of whoever awaited `page.close()`.
+            let pageClosed = false;
 
-            await originalPageClose.apply(page, args).catch((err: Error) => {
-                log.debug(`Could not close page.\nCause:${err.message}`, { id: browserController.id });
-            });
+            const closing = (async () => {
+                await this._executeHooks(this.prePageCloseHooks, page, browserController);
 
-            await this._executeHooks(this.postPageCloseHooks, pageId, browserController);
+                await originalPageClose.apply(page, args).catch((err: Error) => {
+                    log.debug(`Could not close page.\nCause:${err.message}`, { id: browserController.id });
+                });
+
+                // Whether the page itself is gone. Tracked separately from the sequence finishing,
+                // so that a slow hook does not get the browser retired.
+                pageClosed = true;
+
+                await this._executeHooks(this.postPageCloseHooks, pageId, browserController);
+            })();
+
+            let timeout: NodeJS.Timeout | undefined;
+            const finished = await Promise.race([
+                closing.then(
+                    () => true,
+                    (err: Error) => {
+                        log.warning(`Page close hook failed.\nCause:${err.message}`, {
+                            id: browserController.id,
+                            pageId,
+                        });
+                        return true;
+                    },
+                ),
+                new Promise<boolean>((resolve) => {
+                    timeout = setTimeout(() => resolve(false), PAGE_CLOSE_TIMEOUT_MILLIS);
+                }),
+            ]);
+            clearTimeout(timeout);
+
+            if (!finished) {
+                log.warning(
+                    `Closing a page did not finish within ${PAGE_CLOSE_TIMEOUT_MILLIS / 1000} seconds, ` +
+                        'releasing it from the pool anyway.',
+                    { id: browserController.id, pageId },
+                );
+            }
+
+            if (!pageClosed) {
+                // The page is still attached, so this browser cannot be trusted with more work.
+                // Retiring it lets the reclamation below close the process once its pages drain.
+                this.retireBrowserController(browserController);
+            }
+
+            browserController.registerPageClosed(page);
 
             this.pages.delete(pageId);
             this._closeRetiredBrowserWithNoPages(browserController);

--- a/packages/browser-pool/src/playwright/playwright-controller.ts
+++ b/packages/browser-pool/src/playwright/playwright-controller.ts
@@ -77,10 +77,10 @@ export class PlaywrightController extends BrowserController<
         try {
             const page = await this.browser.newPage(contextOptions);
 
-            page.once('close', async () => {
-                this.registerPageClosed(page);
+            this.registerPageTeardown(page, close);
 
-                await close();
+            page.once('close', () => {
+                this.registerPageClosed(page);
             });
 
             if (this.launchContext.experimentalContainers) {

--- a/packages/browser-pool/src/playwright/playwright-controller.ts
+++ b/packages/browser-pool/src/playwright/playwright-controller.ts
@@ -78,7 +78,7 @@ export class PlaywrightController extends BrowserController<
             const page = await this.browser.newPage(contextOptions);
 
             page.once('close', async () => {
-                this.activePages--;
+                this.registerPageClosed(page);
 
                 await close();
             });

--- a/packages/browser-pool/src/puppeteer/puppeteer-controller.ts
+++ b/packages/browser-pool/src/puppeteer/puppeteer-controller.ts
@@ -88,7 +88,7 @@ export class PuppeteerController extends BrowserController<
                 */
 
                 page.once('close', async () => {
-                    this.activePages--;
+                    this.registerPageClosed(page);
 
                     try {
                         await context.close();
@@ -111,7 +111,7 @@ export class PuppeteerController extends BrowserController<
         tryCancel();
 
         page.once('close', () => {
-            this.activePages--;
+            this.registerPageClosed(page);
         });
 
         return page;

--- a/packages/browser-pool/src/puppeteer/puppeteer-controller.ts
+++ b/packages/browser-pool/src/puppeteer/puppeteer-controller.ts
@@ -87,16 +87,20 @@ export class PuppeteerController extends BrowserController<
                 }
                 */
 
-                page.once('close', async () => {
-                    this.registerPageClosed(page);
-
-                    try {
-                        await context.close();
-                    } catch (error: any) {
+                this.registerPageTeardown(page, async () => {
+                    // The proxy server is not chained behind the context close: that can hang on
+                    // the same target the page hung on, and the proxy runs in this process, so it
+                    // has to be reclaimed either way.
+                    const contextClosed = context.close().catch((error: any) => {
                         log.exception(error, 'Failed to close context.');
-                    } finally {
-                        await close();
-                    }
+                    });
+
+                    await close();
+                    await contextClosed;
+                });
+
+                page.once('close', () => {
+                    this.registerPageClosed(page);
                 });
 
                 return page;

--- a/packages/stagehand-crawler/src/internals/stagehand-controller.ts
+++ b/packages/stagehand-crawler/src/internals/stagehand-controller.ts
@@ -60,7 +60,7 @@ export class StagehandController extends BrowserController<BrowserType, LaunchOp
 
             // Track active pages
             page.once('close', () => {
-                this.activePages--;
+                this.registerPageClosed(page);
             });
 
             try {

--- a/test/browser-pool/browser-pool.test.ts
+++ b/test/browser-pool/browser-pool.test.ts
@@ -11,7 +11,7 @@ import type { Page } from 'puppeteer';
 // @ts-ignore This only throws when compiled against puppeteer 25+ (ESM only), vitest executes tests as ESM, so its alllll gooooood
 import puppeteer from 'puppeteer';
 
-import { addTimeoutToPromise } from '@apify/timeout';
+import { addTimeoutToPromise, tryCancel } from '@apify/timeout';
 
 import type { BrowserController } from '../../packages/browser-pool/src/abstract-classes/browser-controller';
 import { BrowserPool } from '../../packages/browser-pool/src/browser-pool';
@@ -226,10 +226,12 @@ describe.each([
             expect(controller.totalPages).toEqual(1);
         });
 
-        test('should release a page whose close never settles and retire its browser', async () => {
+        test("should do the pool's bookkeeping for a page whose close never settles", async () => {
             const page = await browserPool.newPage();
             const pageId = browserPool.getPageId(page)!;
             const controller = browserPool.getBrowserControllerByPage(page)!;
+            const pageClosed = vitest.fn();
+            browserPool.on(BROWSER_POOL_EVENTS.PAGE_CLOSED, pageClosed);
 
             expect(controller.activePages).toEqual(1);
 
@@ -240,8 +242,13 @@ describe.each([
 
             await page.close();
 
+            // None of this used to run: the override was parked on the un-timed close, so the
+            // browser kept a slot it could never get back.
             expect(controller.activePages).toEqual(0);
             expect(browserPool['pages'].has(pageId)).toBe(false);
+            expect(pageClosed).toHaveBeenCalled();
+
+            // The page is still attached, so the browser cannot be trusted with more work.
             expect(browserPool.activeBrowserControllers.has(controller)).toBe(false);
             expect(browserPool.retiredBrowserControllers.has(controller)).toBe(true);
         });
@@ -276,23 +283,29 @@ describe.each([
             expect(hookFinished).toBe(false);
             expect(controller.activePages).toEqual(0);
             expect(browserPool['pages'].has(pageId)).toBe(false);
-            // The page itself closed, so the browser is healthy and stays in rotation.
+            // Retirement is keyed on the page, not on the timeout, so a slow hook must not cost
+            // a browser that closed its page just fine.
             expect(browserPool.activeBrowserControllers.has(controller)).toBe(true);
             expect(browserPool.retiredBrowserControllers.has(controller)).toBe(false);
 
             releaseHook();
         });
 
-        test('should only count a page as closed once', async () => {
+        test('should not count the page twice when its close event arrives later', async () => {
             // `any` because the two-plugin matrix makes `page` a union, while the controller it
             // came from is a union too, so its parameter is the corresponding intersection.
             const page: any = await browserPool.newPage();
             const controller = browserPool.getBrowserControllerByPage(page)!;
 
-            expect(controller.activePages).toEqual(1);
+            page.close = () => new Promise<void>(() => {});
+            browserPool['_overridePageClose'](page);
 
-            controller.registerPageClosed(page);
-            controller.registerPageClosed(page);
+            await page.close();
+            expect(controller.activePages).toEqual(0);
+
+            // Closing the browser does eventually deliver the event the page never sent. Counting
+            // it again would push `activePages` negative and hand the browser work it cannot take.
+            page.emit('close');
 
             expect(controller.activePages).toEqual(0);
         });
@@ -301,9 +314,9 @@ describe.each([
             const page: any = await browserPool.newPage();
             const controller = browserPool.getBrowserControllerByPage(page)!;
 
-            // Stands in for the cleanup the controllers register per page: an anonymizing proxy
-            // server, an incognito context. It hangs off the page being gone rather than off the
-            // browser's `close` event, which does not arrive for a page that would not close.
+            // Stands in for what the controllers register per page: an anonymizing proxy server,
+            // an incognito context. Both used to hang off the `close` event, which does not
+            // arrive for a page the browser never destroyed.
             let tornDown = 0;
             (controller as any).registerPageTeardown(page, async () => {
                 tornDown++;
@@ -317,12 +330,33 @@ describe.each([
 
             expect(tornDown).toEqual(1);
 
-            // the browser closing delivers the `close` event late, which must not run it again
-            controller.registerPageClosed(page);
+            page.emit('close');
             await new Promise((resolve) => setImmediate(resolve));
 
             expect(tornDown).toEqual(1);
         });
+
+        test("should not cancel the caller's task when it gives up on a close", async () => {
+            const page = await browserPool.newPage();
+
+            // The bound on the close is a `Promise.race`, not `addTimeoutToPromise`: the latter
+            // takes its AbortController from the calling frame, so firing it here would cancel
+            // the request handler that closed the page.
+            (page as { close: () => Promise<void> }).close = () => new Promise<void>(() => {});
+            browserPool['_overridePageClose'](page);
+
+            await expect(
+                addTimeoutToPromise(
+                    async () => {
+                        await page.close();
+                        tryCancel();
+                        return 'caller survived';
+                    },
+                    30_000,
+                    'the caller was timed out',
+                ),
+            ).resolves.toEqual('caller survived');
+        }, 45_000);
 
         test('should retire browser after page count', async () => {
             browserPool.retireBrowserAfterPageCount = 2;

--- a/test/browser-pool/browser-pool.test.ts
+++ b/test/browser-pool/browser-pool.test.ts
@@ -226,6 +226,104 @@ describe.each([
             expect(controller.totalPages).toEqual(1);
         });
 
+        test('should release a page whose close never settles and retire its browser', async () => {
+            const page = await browserPool.newPage();
+            const pageId = browserPool.getPageId(page)!;
+            const controller = browserPool.getBrowserControllerByPage(page)!;
+
+            expect(controller.activePages).toEqual(1);
+
+            // A browser can acknowledge the close and then never destroy the target, so neither
+            // the promise nor the page's own `close` event ever arrives.
+            (page as { close: () => Promise<void> }).close = () => new Promise<void>(() => {});
+            browserPool['_overridePageClose'](page);
+
+            await page.close();
+
+            expect(controller.activePages).toEqual(0);
+            expect(browserPool['pages'].has(pageId)).toBe(false);
+            expect(browserPool.activeBrowserControllers.has(controller)).toBe(false);
+            expect(browserPool.retiredBrowserControllers.has(controller)).toBe(true);
+        });
+
+        test('should not retire the browser when only a post-close hook hangs', async () => {
+            // The page closes right away, so the unrelated idle-browser retirement would fire
+            // while we wait out the hook.
+            clearInterval(browserPool['browserRetireInterval']);
+
+            let hookStarted = false;
+            let hookFinished = false;
+            let releaseHook!: () => void;
+
+            browserPool.postPageCloseHooks = [
+                () =>
+                    new Promise<void>((resolve) => {
+                        hookStarted = true;
+                        releaseHook = () => {
+                            hookFinished = true;
+                            resolve();
+                        };
+                    }),
+            ];
+
+            const page = await browserPool.newPage();
+            const pageId = browserPool.getPageId(page)!;
+            const controller = browserPool.getBrowserControllerByPage(page)!;
+
+            await page.close();
+
+            expect(hookStarted).toBe(true);
+            expect(hookFinished).toBe(false);
+            expect(controller.activePages).toEqual(0);
+            expect(browserPool['pages'].has(pageId)).toBe(false);
+            // The page itself closed, so the browser is healthy and stays in rotation.
+            expect(browserPool.activeBrowserControllers.has(controller)).toBe(true);
+            expect(browserPool.retiredBrowserControllers.has(controller)).toBe(false);
+
+            releaseHook();
+        });
+
+        test('should only count a page as closed once', async () => {
+            // `any` because the two-plugin matrix makes `page` a union, while the controller it
+            // came from is a union too, so its parameter is the corresponding intersection.
+            const page: any = await browserPool.newPage();
+            const controller = browserPool.getBrowserControllerByPage(page)!;
+
+            expect(controller.activePages).toEqual(1);
+
+            controller.registerPageClosed(page);
+            controller.registerPageClosed(page);
+
+            expect(controller.activePages).toEqual(0);
+        });
+
+        test('should run a page teardown even when the close event never arrives', async () => {
+            const page: any = await browserPool.newPage();
+            const controller = browserPool.getBrowserControllerByPage(page)!;
+
+            // Stands in for the cleanup the controllers register per page: an anonymizing proxy
+            // server, an incognito context. It hangs off the page being gone rather than off the
+            // browser's `close` event, which does not arrive for a page that would not close.
+            let tornDown = 0;
+            (controller as any).registerPageTeardown(page, async () => {
+                tornDown++;
+            });
+
+            page.close = () => new Promise<void>(() => {});
+            browserPool['_overridePageClose'](page);
+
+            await page.close();
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(tornDown).toEqual(1);
+
+            // the browser closing delivers the `close` event late, which must not run it again
+            controller.registerPageClosed(page);
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(tornDown).toEqual(1);
+        });
+
         test('should retire browser after page count', async () => {
             browserPool.retireBrowserAfterPageCount = 2;
 


### PR DESCRIPTION
A browser can acknowledge a close and then never destroy the target, so `page.close()` never settles and the page's own `close` event never fires either. Today the pool's `_overridePageClose` is parked on that await, so `activePages` is never decremented, `pages.delete(pageId)` and `PAGE_CLOSED` never run, and the browser is held with a slot fewer than it thinks. At `maxOpenPagesPerBrowser` it stops being handed work, so it never reaches the retire threshold either.

- the 5s bound moves from `BrowserCrawler._cleanupContext` into the pool, where it now covers the whole close sequence, and the pool's bookkeeping runs regardless of the outcome
- `activePages` gets a single owner, `BrowserController.registerPageClosed()`, safe to call twice, so the pool can release a page whose `close` event will never arrive. All four decrement sites go through it
- if the page itself did not close, its browser is retired. Retiring only takes it out of rotation, so pages already open keep working, and it is closed once they drain

Retirement is keyed on the page, not on the overall timeout, so a slow post-close hook doesn't get a healthy browser retired.

This is for v3, v4 needs the same shape: the guard moved into `BrowserPool.closePage()`, which races the overridden `page.close` and abandons the same bookkeeping. I will open the pr after we make everything is right here and finalize the shape.

Closes #1829