### PR TITLE
fix(browser-pool): survive a page.close() that never settles

### DIFF
--- a/packages/browser-pool/src/abstract-classes/browser-controller.ts
+++ b/packages/browser-pool/src/abstract-classes/browser-controller.ts
@@ -140,6 +140,10 @@ export abstract class BrowserController<
 
     activePages = 0;
 
+    readonly #closedPages = new WeakSet<object>();
+
+    readonly #pageTeardowns = new WeakMap<object, () => Promise<void>>();
+
     totalPages = 0;
 
     lastPageOpenedAt = Date.now();
@@ -250,6 +254,40 @@ export abstract class BrowserController<
         this.lastPageOpenedAt = Date.now();
 
         return page;
+    }
+
+    /**
+     * Accounts for a page no longer being open. Callable from either side and safe to call twice:
+     * the page's own `close` event, or the pool when it gives up on a close that never settles.
+     * Tracked in a `WeakSet` rather than via `isClosed()`, because that reports the same event.
+     * @ignore
+     */
+    registerPageClosed(page: NewPageResult): void {
+        if (this.#closedPages.has(page as object)) return;
+
+        this.#closedPages.add(page as object);
+        this.activePages--;
+
+        const teardown = this.#pageTeardowns.get(page as object);
+        if (!teardown) return;
+
+        this.#pageTeardowns.delete(page as object);
+        teardown().catch((error: Error) => {
+            this.log.debug(`Could not clean up after a closed page.\nCause:${error.message}`, { id: this.id });
+        });
+    }
+
+    /**
+     * Registers cleanup belonging to a single page: an anonymizing proxy server, an incognito
+     * context. It runs from `registerPageClosed`, so it happens whether the page closed on its own
+     * or the pool gave up on a close that never settled, and it runs at most once.
+     *
+     * Hanging it off the page's `close` event instead leaks it in exactly the case this controller
+     * now handles, because that event does not arrive for a page the browser never destroyed.
+     * @ignore
+     */
+    protected registerPageTeardown(page: NewPageResult, teardown: () => Promise<void>): void {
+        this.#pageTeardowns.set(page as object, teardown);
     }
 
     async setCookies(page: NewPageResult, cookies: Cookie[]): Promise<void> {

--- a/packages/browser-pool/src/abstract-classes/browser-controller.ts
+++ b/packages/browser-pool/src/abstract-classes/browser-controller.ts
@@ -260,7 +260,7 @@ export abstract class BrowserController<
      * Accounts for a page no longer being open. Callable from either side and safe to call twice:
      * the page's own `close` event, or the pool when it gives up on a close that never settles.
      * Tracked in a `WeakSet` rather than via `isClosed()`, because that reports the same event.
-     * @ignore
+     * @internal
      */
     registerPageClosed(page: NewPageResult): void {
         if (this.#closedPages.has(page as object)) return;

--- a/packages/browser-pool/src/browser-pool.ts
+++ b/packages/browser-pool/src/browser-pool.ts
@@ -696,12 +696,10 @@ export class BrowserPool<
             this.retireBrowserByPage(page);
         }
 
-        // Puppeteer 25+ can hang `page.close()` indefinitely when the page's navigation was aborted, don't let it block the crawler.
-        await addTimeoutToPromise(
-            async () => page.close(),
-            PAGE_CLOSE_TIMEOUT_MILLIS,
-            `page.close() timed out after ${PAGE_CLOSE_TIMEOUT_MILLIS / 1000} seconds`,
-        );
+        // The bound on this lives in `overridePageClose`, where it covers the pool's own
+        // bookkeeping as well. Wrapping it here instead would time out the override and abandon
+        // that bookkeeping, leaving the browser holding a slot it can never get back.
+        await page.close();
     }
 
     /**
@@ -926,13 +924,62 @@ export class BrowserPool<
         const pageId = this.getPageId(page)!;
 
         page.close = async (...args: unknown[]) => {
-            await this.executeHooks(this.prePageCloseHooks, page, browserController);
+            // A browser can acknowledge the close and then never destroy the target, in which case
+            // this never settles and the page's own `close` event never fires either (Chromium
+            // 536385539). Bound the whole sequence so nothing here can hang the caller, then
+            // reconcile the pool regardless of the outcome, so a page that refuses to close cannot
+            // leave the pool believing it is still open. `Promise.race` rather than
+            // `addTimeoutToPromise`: the latter inherits its AbortController from the calling frame,
+            // so a timeout here would cancel the task of whoever awaited `page.close()`.
+            let pageClosed = false;
 
-            await originalPageClose.apply(page, args).catch((err: Error) => {
-                this.#log.debug(`Could not close page.\nCause:${err.message}`, { id: browserController.id });
-            });
+            const closing = (async () => {
+                await this.executeHooks(this.prePageCloseHooks, page, browserController);
 
-            await this.executeHooks(this.postPageCloseHooks, pageId, browserController);
+                await originalPageClose.apply(page, args).catch((err: Error) => {
+                    this.#log.debug(`Could not close page.\nCause:${err.message}`, { id: browserController.id });
+                });
+
+                // Whether the page itself is gone. Tracked separately from the sequence finishing,
+                // so that a slow hook does not get the browser retired.
+                pageClosed = true;
+
+                await this.executeHooks(this.postPageCloseHooks, pageId, browserController);
+            })();
+
+            let timeout: NodeJS.Timeout | undefined;
+            const finished = await Promise.race([
+                closing.then(
+                    () => true,
+                    (err: Error) => {
+                        this.#log.warning(
+                            `Closing a page failed, releasing it from the pool anyway.\nCause:${err.message}`,
+                            { id: browserController.id, pageId },
+                        );
+                        return true;
+                    },
+                ),
+                new Promise<boolean>((resolve) => {
+                    timeout = setTimeout(() => resolve(false), PAGE_CLOSE_TIMEOUT_MILLIS);
+                }),
+            ]);
+            clearTimeout(timeout);
+
+            if (!finished) {
+                this.#log.warning(
+                    `Closing a page did not finish within ${PAGE_CLOSE_TIMEOUT_MILLIS / 1000} seconds, ` +
+                        'releasing it from the pool anyway.',
+                    { id: browserController.id, pageId },
+                );
+            }
+
+            if (!pageClosed) {
+                // The page is still attached, so this browser cannot be trusted with more work.
+                // Retiring it lets the reclamation below close the process once its pages drain.
+                this.retireBrowserController(browserController);
+            }
+
+            browserController.registerPageClosed(page);
 
             this.pages.delete(pageId);
             this.closeRetiredBrowserWithNoPages(browserController);

--- a/packages/browser-pool/src/playwright/playwright-controller.ts
+++ b/packages/browser-pool/src/playwright/playwright-controller.ts
@@ -72,10 +72,10 @@ export class PlaywrightController extends BrowserController<
         try {
             const page = await this.browser.newPage(contextOptions);
 
-            page.once('close', async () => {
-                this.activePages--;
+            this.registerPageTeardown(page, close);
 
-                await close();
+            page.once('close', () => {
+                this.registerPageClosed(page);
             });
 
             tryCancel();

--- a/packages/browser-pool/src/puppeteer/puppeteer-controller.ts
+++ b/packages/browser-pool/src/puppeteer/puppeteer-controller.ts
@@ -84,16 +84,20 @@ export class PuppeteerController extends BrowserController<
                 }
                 */
 
-                page.once('close', async () => {
-                    this.activePages--;
-
-                    try {
-                        await context.close();
-                    } catch (error: any) {
+                this.registerPageTeardown(page, async () => {
+                    // The proxy server is not chained behind the context close: that can hang on
+                    // the same target the page hung on, and the proxy runs in this process, so it
+                    // has to be reclaimed either way.
+                    const contextClosed = context.close().catch((error: any) => {
                         this.log.exception(error, 'Failed to close context.');
-                    } finally {
-                        await close();
-                    }
+                    });
+
+                    await close();
+                    await contextClosed;
+                });
+
+                page.once('close', () => {
+                    this.registerPageClosed(page);
                 });
 
                 return page;
@@ -108,7 +112,7 @@ export class PuppeteerController extends BrowserController<
         tryCancel();
 
         page.once('close', () => {
-            this.activePages--;
+            this.registerPageClosed(page);
         });
 
         return page;

--- a/packages/stagehand-crawler/src/internals/stagehand-controller.ts
+++ b/packages/stagehand-crawler/src/internals/stagehand-controller.ts
@@ -59,7 +59,7 @@ export class StagehandController extends BrowserController<BrowserType, LaunchOp
 
             // Track active pages
             page.once('close', () => {
-                this.activePages--;
+                this.registerPageClosed(page);
             });
 
             try {

--- a/test/browser-pool/browser-pool.test.ts
+++ b/test/browser-pool/browser-pool.test.ts
@@ -11,7 +11,7 @@ import type { Page } from 'puppeteer';
 // @ts-ignore This only throws when compiled against puppeteer 25+ (ESM only), vitest executes tests as ESM, so its alllll gooooood
 import puppeteer from 'puppeteer';
 
-import { addTimeoutToPromise } from '@apify/timeout';
+import { addTimeoutToPromise, tryCancel } from '@apify/timeout';
 
 import type { BrowserController } from '../../packages/browser-pool/src/abstract-classes/browser-controller.js';
 import { BrowserPool } from '../../packages/browser-pool/src/browser-pool.js';
@@ -225,6 +225,164 @@ describe.each([
             expect(controller.activePages).toEqual(0);
             expect(controller.totalPages).toEqual(1);
         });
+
+        test("should do the pool's bookkeeping for a page whose close never settles", async () => {
+            const page = await browserPool.newPage();
+            const pageId = browserPool.getPageId(page)!;
+            const controller = browserPool.getBrowserControllerByPage(page)!;
+            const pageClosed = vitest.fn();
+            browserPool.on(BROWSER_POOL_EVENTS.PAGE_CLOSED, pageClosed);
+
+            expect(controller.activePages).toEqual(1);
+
+            // A browser can acknowledge the close and then never destroy the target, so neither
+            // the promise nor the page's own `close` event ever arrives.
+            (page as { close: () => Promise<void> }).close = () => new Promise<void>(() => {});
+            browserPool['overridePageClose'](page);
+
+            await page.close();
+
+            // None of this used to run: the override was parked on the un-timed close, so the
+            // browser kept a slot it could never get back.
+            expect(controller.activePages).toEqual(0);
+            expect(browserPool['pages'].has(pageId)).toBe(false);
+            expect(pageClosed).toHaveBeenCalled();
+
+            // The page is still attached, so the browser cannot be trusted with more work.
+            expect(browserPool.activeBrowserControllers.has(controller)).toBe(false);
+            expect(browserPool.retiredBrowserControllers.has(controller)).toBe(true);
+        });
+
+        test('should not retire the browser when only a post-close hook hangs', async () => {
+            let hookStarted = false;
+            let hookFinished = false;
+            let releaseHook!: () => void;
+
+            // Its own pool, because the page here closes for real and only the hook hangs, so
+            // `activePages` drops to 0 on the page's own `close` event. With the suite's
+            // `retireInactiveBrowserAfterSecs: 2` the unrelated idle-browser retirement would then
+            // fire while we wait the hook out, and this test would be measuring that instead.
+            const pool = new BrowserPool({
+                browserPlugins: [plugin],
+                retireInactiveBrowserAfterSecs: 600,
+                closeInactiveBrowserAfterSecs: 600,
+                postPageCloseHooks: [
+                    () =>
+                        new Promise<void>((resolve) => {
+                            hookStarted = true;
+                            releaseHook = () => {
+                                hookFinished = true;
+                                resolve();
+                            };
+                        }),
+                ],
+            });
+
+            try {
+                const page = await pool.newPage();
+                const pageId = pool.getPageId(page)!;
+                const controller = pool.getBrowserControllerByPage(page)!;
+
+                await page.close();
+
+                expect(hookStarted).toBe(true);
+                expect(hookFinished).toBe(false);
+                expect(controller.activePages).toEqual(0);
+                expect(pool['pages'].has(pageId)).toBe(false);
+                // Retirement is keyed on the page, not on the timeout, so a slow hook must not
+                // cost a browser that closed its page just fine.
+                expect(pool.activeBrowserControllers.has(controller)).toBe(true);
+                expect(pool.retiredBrowserControllers.has(controller)).toBe(false);
+            } finally {
+                releaseHook?.();
+                await pool.destroy();
+            }
+        }, 30_000);
+
+        test('should not count the page twice when its close event arrives later', async () => {
+            // `any` because the two-plugin matrix makes `page` a union, while the controller it
+            // came from is a union too, so its parameter is the corresponding intersection.
+            const page: any = await browserPool.newPage();
+            const controller = browserPool.getBrowserControllerByPage(page)!;
+
+            page.close = () => new Promise<void>(() => {});
+            browserPool['overridePageClose'](page);
+
+            await page.close();
+            expect(controller.activePages).toEqual(0);
+
+            // Closing the browser does eventually deliver the event the page never sent. Counting
+            // it again would push `activePages` negative and hand the browser work it cannot take.
+            page.emit('close');
+
+            expect(controller.activePages).toEqual(0);
+        });
+
+        test('should run a page teardown even when the close event never arrives', async () => {
+            const page: any = await browserPool.newPage();
+            const controller = browserPool.getBrowserControllerByPage(page)!;
+
+            // Stands in for what the controllers register per page: an anonymizing proxy server,
+            // an incognito context. Both used to hang off the `close` event, which does not
+            // arrive for a page the browser never destroyed.
+            let tornDown = 0;
+            (controller as any).registerPageTeardown(page, async () => {
+                tornDown++;
+            });
+
+            page.close = () => new Promise<void>(() => {});
+            browserPool['overridePageClose'](page);
+
+            await page.close();
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(tornDown).toEqual(1);
+
+            page.emit('close');
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(tornDown).toEqual(1);
+        });
+
+        test('should let closePage() return on a page whose close never settles', async () => {
+            const page = await browserPool.newPage();
+            const pageId = browserPool.getPageId(page)!;
+            const controller = browserPool.getBrowserControllerByPage(page)!;
+
+            (page as { close: () => Promise<void> }).close = () => new Promise<void>(() => {});
+            browserPool['overridePageClose'](page);
+
+            // `closePage` is the documented way a crawler returns a page, and the bound it needs
+            // lives in the override it calls. Bounding it here as well used to time that override
+            // out from the outside, which is what abandoned the bookkeeping below.
+            await expect(browserPool.closePage(page)).resolves.toBeUndefined();
+
+            expect(controller.activePages).toEqual(0);
+            expect(browserPool['pages'].has(pageId)).toBe(false);
+            expect(browserPool.retiredBrowserControllers.has(controller)).toBe(true);
+        }, 30_000);
+
+        test("should not cancel the caller's task when it gives up on a close", async () => {
+            const page = await browserPool.newPage();
+
+            // The bound on the close is a `Promise.race`, not `addTimeoutToPromise`: the latter
+            // takes its AbortController from the calling frame, so firing it here would cancel
+            // the request handler that closed the page.
+            (page as { close: () => Promise<void> }).close = () => new Promise<void>(() => {});
+            browserPool['overridePageClose'](page);
+
+            await expect(
+                addTimeoutToPromise(
+                    async () => {
+                        await page.close();
+                        tryCancel();
+                        return 'caller survived';
+                    },
+                    30_000,
+                    'the caller was timed out',
+                ),
+            ).resolves.toEqual('caller survived');
+        }, 45_000);
 
         test('should retire browser after page count', async () => {
             browserPool.retireBrowserAfterPageCount = 2;


### PR DESCRIPTION
porting https://github.com/apify/crawlee/pull/4108 to v4