### PR TITLE
perf(core): compile the per-request zod schemas

### DIFF
--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -9,7 +9,6 @@ import { z } from 'zod';
 import { cryptoRandomObjectId, normalizeUrl } from '@apify/utilities';
 
 import { serviceLocator } from './service_locator.js';
-import { keys } from './typedefs.js';
 import { parseArgument, schemas } from './validators.js';
 
 /** The `strategy` option accepted by {@apilink ExtractLinksOptions} and {@apilink EnqueueUrlsOptions}. */
@@ -39,37 +38,34 @@ export enum RequestState {
     SKIPPED,
 }
 
-const requestUrlSchema = z.object({ url: z.string() });
-
 // new properties on the Request object breaks serialization
-const requestOptionalSchemaShapes: Record<string, z.ZodType> = {
-    id: z.string().optional(),
-    loadedUrl: z.url().optional(),
-    uniqueKey: z.string().optional(),
-    method: z.string().optional(),
-    payload: z.union([z.string(), z.instanceof(Uint8Array)]).optional(),
-    noRetry: z.boolean().optional(),
-    retryCount: schemas.anyNumber.optional(),
-    sessionId: z.string().optional(),
-    maxRetries: schemas.anyNumber.optional(),
-    errorMessages: schemas.arrayOf(z.string(), 'strings').optional(),
-    headers: z.looseObject({}).optional(),
-    userData: z.looseObject({}).optional(),
-    label: z.string().optional(),
-    handledAt: z.union([dateString, z.date()]).optional(),
-    keepUrlFragment: z.boolean().optional(),
-    useExtendedUniqueKey: z.boolean().optional(),
-    alwaysEnqueue: z.boolean().optional(),
-    skipNavigation: z.boolean().optional(),
-    crawlDepth: schemas.anyNumber
-        .refine((value) => value >= 0, 'Expected a number greater than or equal to 0')
-        .optional(),
-    state: z.enum(RequestState).optional(),
-};
-
-// Each schema is wrapped in a single-key object so validation errors carry the property name.
-const requestOptionalSchemas: Partial<Record<string, z.ZodType>> = Object.fromEntries(
-    Object.entries(requestOptionalSchemaShapes).map(([key, schema]) => [key, z.object({ [key]: schema })]),
+// Compiled once: every `Request` runs it, and the generated fast path skips zod's interpreter.
+const requestOptionsSchema = z.compile(
+    z.looseObject({
+        url: z.string(),
+        id: z.string().optional(),
+        loadedUrl: z.url().optional(),
+        uniqueKey: z.string().optional(),
+        method: z.string().optional(),
+        payload: z.union([z.string(), z.instanceof(Uint8Array)]).optional(),
+        noRetry: z.boolean().optional(),
+        retryCount: schemas.anyNumber.optional(),
+        sessionId: z.string().optional(),
+        maxRetries: schemas.anyNumber.optional(),
+        errorMessages: schemas.arrayOf(z.string(), 'strings').optional(),
+        headers: z.looseObject({}).optional(),
+        userData: z.looseObject({}).optional(),
+        label: z.string().optional(),
+        handledAt: z.union([dateString, z.date()]).optional(),
+        keepUrlFragment: z.boolean().optional(),
+        useExtendedUniqueKey: z.boolean().optional(),
+        alwaysEnqueue: z.boolean().optional(),
+        skipNavigation: z.boolean().optional(),
+        crawlDepth: schemas.anyNumber
+            .refine((value) => value >= 0, 'Expected a number greater than or equal to 0')
+            .optional(),
+        state: z.enum(RequestState).optional(),
+    }),
 );
 
 /**
@@ -174,23 +170,7 @@ class CrawleeRequest<UserData extends Dictionary = Dictionary> {
         }
 
         parseArgument(options, schemas.anyObject, 'RequestOptions');
-        parseArgument(options, requestUrlSchema, 'RequestOptions');
-        // Full-shape validation is slow, because it checks all predicates
-        // even if the validated object has only 1 property.
-        // This custom validation loop iterates only over existing
-        // properties and speeds up the validation cca 3-fold.
-        keys(options).forEach((prop) => {
-            // skip url, because it is validated above
-            if (prop === 'url') {
-                return;
-            }
-
-            const schema = requestOptionalSchemas[prop as string];
-            const value = options[prop];
-            if (schema) {
-                parseArgument({ [prop]: value }, schema, 'RequestOptions');
-            }
-        });
+        parseArgument(options, requestOptionsSchema, 'RequestOptions');
 
         const {
             id,

--- a/packages/core/src/storages/request_queue.ts
+++ b/packages/core/src/storages/request_queue.ts
@@ -64,19 +64,26 @@ const addRequestsBatchedOptionsSchema = z.strictObject({
     waitBetweenBatchesMillis: schemas.anyNumber.default(1000),
     maxNewRequests: schemas.anyNumber.optional(),
 });
-const newRequestLikeSchema = z.looseObject({
-    url: z.string(),
-    id: z.undefined().optional(),
-});
-const handledRequestSchema = z.looseObject({
-    id: z.string(),
-    uniqueKey: z.string(),
-    handledAt: z.string().optional(),
-});
-const reclaimedRequestSchema = z.looseObject({
-    id: z.string(),
-    uniqueKey: z.string(),
-});
+// Compiled: these run once per request.
+const newRequestLikeSchema = z.compile(
+    z.looseObject({
+        url: z.string(),
+        id: z.undefined().optional(),
+    }),
+);
+const handledRequestSchema = z.compile(
+    z.looseObject({
+        id: z.string(),
+        uniqueKey: z.string(),
+        handledAt: z.string().optional(),
+    }),
+);
+const reclaimedRequestSchema = z.compile(
+    z.looseObject({
+        id: z.string(),
+        uniqueKey: z.string(),
+    }),
+);
 const uniqueKeySchema = z.string();
 const openOptionsSchema = z.strictObject({
     configuration: z.instanceof(Configuration).optional(),

--- a/packages/utils/src/internals/schemas.ts
+++ b/packages/utils/src/internals/schemas.ts
@@ -82,11 +82,7 @@ export const plainObject = z.custom<Record<string, unknown>>(
     { message: 'Invalid input: expected an object' },
 );
 
-/**
- * Shape of a request stored in a request queue.
- * @internal
- */
-export const storageRequest = z.looseObject({
+const storageRequestShape = z.looseObject({
     id: z.string(),
     url: z.url({ protocol: /^https?$/ }),
     uniqueKey: z.string(),
@@ -96,10 +92,16 @@ export const storageRequest = z.looseObject({
 });
 
 /**
+ * Shape of a request stored in a request queue. Compiled: storage clients validate every request with it.
+ * @internal
+ */
+export const storageRequest = z.compile(storageRequestShape);
+
+/**
  * {@link storageRequest} before an id is assigned.
  * @internal
  */
-export const storageRequestWithoutId = storageRequest.omit({ id: true });
+export const storageRequestWithoutId = storageRequestShape.omit({ id: true });
 
 /**
  * `z.array(item)` whose top-level type error names the element type — ``expected an array of numbers`` —
@@ -118,7 +120,7 @@ export function arrayOf<TItem extends z.ZodType>(item: TItem, elements: string):
  * Batch of {@link storageRequestWithoutId}.
  * @internal
  */
-export const storageRequestBatch = arrayOf(storageRequestWithoutId, 'requests');
+export const storageRequestBatch = z.compile(arrayOf(storageRequestWithoutId, 'requests'));
 
 /**
  * Options of request queue add/update operations.

--- a/scripts/benchmarks/request-validation.mjs
+++ b/scripts/benchmarks/request-validation.mjs
@@ -1,0 +1,50 @@
+// Throughput of the per-request validation paths. Run against a build: `pnpm build && node scripts/benchmarks/request-validation.mjs`.
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+
+const req = createRequire(new URL('../../packages/crawlee/package.json', import.meta.url));
+const load = (specifier) => import(pathToFileURL(req.resolve(specifier)).href);
+const { Request } = await load('@crawlee/core');
+const { schemas } = await load('@crawlee/utils/internal');
+const { z } = await load('zod');
+
+const options = {
+    url: 'https://example.com/products/123?page=2',
+    uniqueKey: 'https://example.com/products/123?page=2',
+    method: 'GET',
+    userData: { label: 'DETAIL', depth: 3 },
+    headers: { accept: 'text/html' },
+};
+const stored = { id: 'abc123', ...options, retryCount: 0 };
+const batch = Array.from({ length: 100 }, (_, i) => ({
+    ...options,
+    url: `${options.url}&i=${i}`,
+    uniqueKey: `${options.uniqueKey}&i=${i}`,
+}));
+
+function opsPerSecond(fn, minMs = 500) {
+    for (let i = 0; i < 2000; i++) fn();
+    let n = 0;
+    const t0 = performance.now();
+    let t;
+    do {
+        for (let i = 0; i < 1000; i++) fn();
+        n += 1000;
+        t = performance.now();
+    } while (t - t0 < minMs);
+    return n / ((t - t0) / 1000);
+}
+const best = (fn) => Math.round(Math.max(opsPerSecond(fn), opsPerSecond(fn), opsPerSecond(fn)));
+
+console.table([
+    { case: 'new Request(options)', 'ops/s': best(() => new Request(options)) },
+    { case: 'storageRequest parse', 'ops/s': best(() => z.parse(schemas.storageRequest, stored)) },
+    {
+        case: 'storageRequestBatch parse (100 requests)',
+        'ops/s': best(() => z.parse(schemas.storageRequestBatch, batch)),
+    },
+    {
+        case: 'requestQueueOperationOptions parse',
+        'ops/s': best(() => z.parse(schemas.requestQueueOperationOptions, { forefront: true })),
+    },
+]);


### PR DESCRIPTION
Compiles the zod schemas that run once per request with `z.compile()`: the `Request` constructor options, `storageRequest` / `storageRequestBatch` in `@crawlee/utils`, and the request-like schemas in `RequestQueue`. The `Request` constructor also validates the whole options object with one compiled schema instead of one single-key schema per present property; the per-key loop was a workaround for the interpreter's cost that the compiled fast path removes. Error messages are unchanged: the fast path only takes the success case and falls back to the interpreter for failures.

Measured on an M-series Mac with `scripts/benchmarks/request-validation.mjs`:

| | before | after |
|---|---|---|
| `new Request(options)` | 467k ops/s | 797k ops/s |
| `storageRequest` parse | 1.57M ops/s | 2.40M ops/s |
| `storageRequestBatch` parse (100 requests) | 18.2k ops/s | 24.3k ops/s |

Compiling costs 0.1–1.4 ms per schema at import, so only the per-request schemas are compiled; options validated once per crawler are not worth it.

What was also tried and dropped: moving everything to `zod/mini` saves 4–5 ms of a 264 ms `import 'crawlee'` locally and nothing measurable on the platform, and it breaks the apify SDK (`coerceNumber.default()` on our exported schemas). Zod's eager loading of 62 locale files costs ~12 ms of import time, which only an upstream change to zod can remove.

[🤖] Claude Code using Fable 5.1
